### PR TITLE
Draft: create and open a talk room for the current collective

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ In your Nextcloud instance, simply navigate to **»Apps«**, find the
 **»Circles«** and **»Collectives«** apps and enable them.
 
 	]]></description>
-	<version>0.11.22</version>
+	<version>0.12.22-beta1</version>
 	<licence>agpl</licence>
 	<author>CollectiveCloud Team</author>
 	<namespace>Collectives</namespace>

--- a/lib/Controller/CollectiveController.php
+++ b/lib/Controller/CollectiveController.php
@@ -111,15 +111,17 @@ class CollectiveController extends Controller {
 	 *
 	 * @param int         $id
 	 * @param string|null $emoji
+	 * @param string|null $conversationToken
 	 *
 	 * @return DataResponse
 	 */
-	public function update(int $id, string $emoji = null): DataResponse {
-		return $this->prepareResponse(function () use ($id, $emoji) {
+	public function update(int $id, string $emoji = null, string $conversationToken = null): DataResponse {
+		return $this->prepareResponse(function () use ($id, $emoji, $conversationToken) {
 			$collective = $this->service->updateCollective(
 				$this->getUserId(),
 				$id,
-				$emoji
+				$emoji,
+				$conversationToken
 			);
 			return [
 				"data" => $collective,

--- a/lib/Db/Collective.php
+++ b/lib/Db/Collective.php
@@ -14,6 +14,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setEmoji(string $value)
  * @method string getCircleUniqueId()
  * @method void setCircleUniqueId(string $value)
+ * @method string getConversationToken()
+ * @method void setConversationToken(string $value)
  * @method int|null getTrashTimestamp()
  * @method void setTrashTimestamp(?int $value)
  */
@@ -23,6 +25,9 @@ class Collective extends Entity implements JsonSerializable {
 
 	/** @var string */
 	protected $emoji;
+
+	/** @var string */
+	protected $conversationToken;
 
 	/** @var int|null */
 	protected $trashTimestamp;
@@ -53,6 +58,7 @@ class Collective extends Entity implements JsonSerializable {
 			'id' => $this->id,
 			'emoji' => $this->emoji,
 			'circleId' => $this->circleUniqueId,
+			'conversationToken' => $this->conversationToken,
 			'trashTimestamp' => $this->trashTimestamp
 		];
 	}

--- a/lib/Migration/Version001000Date20210809000000.php
+++ b/lib/Migration/Version001000Date20210809000000.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Collectives\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version001000Date20210809000000 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array   $options
+	 *
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('collectives');
+		if (!$table->hasColumn('conversation_token')) {
+			$table->addColumn('conversation_token', Types::STRING, [
+				'notnull' => false,
+				'length' => 8,
+			]);
+		}
+		return $schema;
+	}
+}

--- a/lib/Model/CollectiveInfo.php
+++ b/lib/Model/CollectiveInfo.php
@@ -22,6 +22,7 @@ class CollectiveInfo extends Collective {
 	public function __construct(Collective $collective, string $name, int $level = Member::LEVEL_MEMBER) {
 		$this->id = $collective->getId();
 		$this->circleUniqueId = $collective->getCircleId();
+		$this->conversationToken = $collective->getConversationToken();
 		$this->emoji = $collective->getEmoji();
 		$this->trashTimestamp = $collective->getTrashTimestamp();
 		$this->name = $name;
@@ -32,6 +33,7 @@ class CollectiveInfo extends Collective {
 		return [
 			'id' => $this->id,
 			'circleId' => $this->circleUniqueId,
+			'conversationToken' => $this->conversationToken,
 			'emoji' => $this->emoji,
 			'trashTimestamp' => $this->trashTimestamp,
 			'name' => $this->name,

--- a/lib/Service/CollectiveService.php
+++ b/lib/Service/CollectiveService.php
@@ -166,13 +166,14 @@ class CollectiveService {
 	 * @param string      $userId
 	 * @param int         $id
 	 * @param string|null $emoji
+	 * @param string|null $conversationToken
 	 *
 	 * @return CollectiveInfo
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 * @throws MissingDependencyException
 	 */
-	public function updateCollective(string $userId, int $id, string $emoji = null): CollectiveInfo {
+	public function updateCollective(string $userId, int $id, string $emoji = null, string $conversationToken = null): CollectiveInfo {
 		if (null === $collective = $this->collectiveMapper->findById($id, $userId)) {
 			throw new NotFoundException('Collective not found: ' . $id);
 		}
@@ -184,6 +185,10 @@ class CollectiveService {
 
 		if ($emoji) {
 			$collective->setEmoji($emoji);
+		}
+
+		if ($conversationToken) {
+			$collective->setConversationToken($conversationToken);
 		}
 
 		return new CollectiveInfo($this->collectiveMapper->update($collective),

--- a/tests/Integration/features/collective.feature
+++ b/tests/Integration/features/collective.feature
@@ -9,6 +9,14 @@ Feature: collective
     And user "alice" sees pagePath "Readme.md" in "mycollective"
     And user "john" doesn't see collective "mycollective"
 
+  Scenario: Update a collectives emoji
+    When user "jane" sets "emoji" to "🌊" for collective "mycollective"
+    Then user "alice" sees collective "mycollective" with "emoji" set to "🌊"
+
+  Scenario: Update a collectives conversation token
+    When user "jane" sets "conversationToken" to "12345678" for collective "mycollective"
+    Then user "alice" sees collective "mycollective" with "conversationToken" set to "12345678"
+
   Scenario: Fail to trash a collective as simple member
     And user "alice" fails to trash collective "mycollective"
 

--- a/tests/Unit/Service/CollectiveServiceTest.php
+++ b/tests/Unit/Service/CollectiveServiceTest.php
@@ -148,6 +148,7 @@ class CollectiveServiceTest extends TestCase {
 			'id' => 123,
 			'emoji' => null,
 			'circleId' => null,
+			'conversationToken' => null,
 			'trashTimestamp' => null,
 			'name' => 'free',
 			'level' => Member::LEVEL_OWNER


### PR DESCRIPTION
In GitLab by @azul on Aug 9, 2021, 11:01

It looks like we need to keep track of the room ourselves as there's no way to create and later identify a room for a circle other than going through the participants list of every room.

See #139.