### PR TITLE
WIP: Periodically update page content for read mode from editor session

### DIFF
--- a/src/components/Page.vue
+++ b/src/components/Page.vue
@@ -189,6 +189,12 @@ export default {
 		document.title = this.documentTitle
 		this.initTitleEntry()
 		this.getPageContent()
+		setInterval(() => {
+			if (this.sessionContent() && this.pageContent !== this.sessionContent()) {
+				this.pageContent = this.sessionContent()
+			}
+			//
+		}, 2000)
 	},
 
 	methods: {
@@ -200,6 +206,11 @@ export default {
 			dispatchGetPages: GET_PAGES,
 			dispatchGetVersions: GET_VERSIONS,
 		}),
+
+		// this is a method so it does not get cached
+		sessionContent() {
+			return this.syncService()?._getContent()
+		},
 
 		// this is a method so it does not get cached
 		syncService() {
@@ -254,7 +265,7 @@ export default {
 		readyEditor() {
 			// Set pageContent if it's been empty before
 			if (!this.pageContent) {
-				this.pageContent = this.syncService()._getContent()
+				this.pageContent = this.sessionContent()
 			}
 			this.readMode = false
 			if (this.loading('newPage')) {
@@ -298,7 +309,7 @@ export default {
 
 			this.scrollTop = document.getElementById('editor')?.scrollTop || 0
 
-			const pageContent = this.syncService()._getContent()
+			const pageContent = this.sessionContent()
 			const changed = this.pageContent !== pageContent
 
 			// if there is still no page content we remind the user


### PR DESCRIPTION
In GitLab by @mejo- on May 30, 2022, 14:00

If we have an editor with an open session, periodically (every two
seconds) update the page content from that session.

That way, users can stay in read mode when they merely want to follow
what others type.