### PR TITLE
Build parent path without queries

### DIFF
--- a/lib/Model/PageInfo.php
+++ b/lib/Model/PageInfo.php
@@ -87,16 +87,18 @@ class PageInfo extends Entity implements JsonSerializable {
 	public function fromFile(File $file, int $parentId, ?string $lastUserId = null, ?string $lastUserDisplayName = null, ?string $emoji = null, ?string $subpageOrder = null): void {
 		$this->setId($file->getId());
 		// Set folder name as title for all index pages except the collective landing page
+		$dirName = dirname($file->getInternalPath());
+		$dirName = $dirName === '.' ? '' : $dirName;
 		if ($parentId !== 0 && 0 === strcmp($file->getName(), self::INDEX_PAGE_TITLE . self::SUFFIX)) {
-			$this->setTitle($file->getParent()->getName());
+			$this->setTitle(basename($dirName));
 		} else {
 			$this->setTitle(basename($file->getName(), self::SUFFIX));
 		}
+		$this->setFilePath($dirName);
 		$this->setTimestamp($file->getMTime());
 		$this->setSize($file->getSize());
 		$this->setFileName($file->getName());
 		$this->setCollectivePath(rtrim(explode('/', $file->getMountPoint()->getMountPoint(), 4)[3], '/'));
-		$this->setFilePath($file->getParent()->getInternalPath());
 		if (null !== $lastUserId) {
 			$this->setLastUserId($lastUserId);
 		}

--- a/lib/Mount/CollectiveFolderManager.php
+++ b/lib/Mount/CollectiveFolderManager.php
@@ -32,6 +32,9 @@ class CollectiveFolderManager {
 	private IRequest $request;
 	private ?string $rootPath = null;
 
+	/** @var int|null */
+	private $rootFolderStorageId = null;
+
 	/**
 	 * CollectiveFolderManager constructor.
 	 *
@@ -185,14 +188,18 @@ class CollectiveFolderManager {
 	 * @throws NotFoundException
 	 */
 	private function getRootFolderStorageId(): int {
-		$qb = $this->connection->getQueryBuilder();
+		if ($this->rootFolderStorageId === null) {
+			$qb = $this->connection->getQueryBuilder();
 
-		$qb->select('fileid')
-			->from('filecache')
-			->where($qb->expr()->eq('storage', $qb->createNamedParameter($this->getRootFolder()->getStorage()->getCache()->getNumericStorageId())))
-			->andWhere($qb->expr()->eq('path_hash', $qb->createNamedParameter(md5($this->getRootPath()))));
+			$qb->select('fileid')
+				->from('filecache')
+				->where($qb->expr()->eq('storage', $qb->createNamedParameter($this->getRootFolder()->getStorage()->getCache()->getNumericStorageId())))
+				->andWhere($qb->expr()->eq('path_hash', $qb->createNamedParameter(md5($this->getRootPath()))));
 
-		return (int)$qb->execute()->fetchColumn();
+			$this->rootFolderStorageId = (int)$qb->execute()->fetchColumn();
+		}
+
+		return $this->rootFolderStorageId;
 	}
 
 	/**

--- a/tests/Unit/Model/PageInfoTest.php
+++ b/tests/Unit/Model/PageInfoTest.php
@@ -18,6 +18,7 @@ class PageInfoTest extends TestCase {
 		$fileMountPoint = '/files/user/Collectives/collective/';
 		$fileCollectivePath = 'Collectives/collective';
 		$parentInternalPath = 'path/to/file';
+		$internalPath = $parentInternalPath . '/' . $fileName;
 		$userId = 'jane';
 
 		$mountPoint = $this->getMockBuilder(MountPoint::class)
@@ -39,6 +40,7 @@ class PageInfoTest extends TestCase {
 		$file->method('getName')->willReturn($fileName);
 		$file->method('getMountPoint')->willReturn($mountPoint);
 		$file->method('getParent')->willReturn($parent);
+		$file->method('getInternalPath')->willReturn($internalPath);
 
 		$pageInfo = new PageInfo();
 		$pageInfo->fromFile($file, 1, $userId);

--- a/tests/Unit/Service/PageServiceTest.php
+++ b/tests/Unit/Service/PageServiceTest.php
@@ -242,6 +242,8 @@ class PageServiceTest extends TestCase {
 			->willReturn($folder);
 		$indexFile->method('getMountPoint')
 			->willReturn($mountPoint);
+		$indexFile->method('getInternalPath')
+			->willReturn('Collectives/testfolder/Readme.md');
 		$indexPage = new Page();
 		$this->pageMapper->method('findByFileId')
 			->willReturn($indexPage);
@@ -268,6 +270,9 @@ class PageServiceTest extends TestCase {
 				->willReturn($folder);
 			$file->method('getMountPoint')
 				->willReturn($mountPoint);
+			$file->method('getInternalPath')
+				->willReturn('Collectives/testfolder/Readme.md');
+
 			$filesNotJustMd[] = $file;
 
 			// Only add markdown files to $filesJustMd


### PR DESCRIPTION
In GitLab by @juliushaertl on Aug 18, 2022, 13:28

- Build parent node name from path without getting the parent node 
- Pass parent node where available to avoid extra db queries
- Cache root storage id per request to avoid duplicate queries

Cuts down the queries in half on our perftesting instance for the handbook example collective: 948 -> 541

Related upstream fix in server, but is not fully applicable here due to the recursive directory iteration https://github.com/nextcloud/server/pull/33602

Fixes #377