### PR TITLE
Display info with a link to Collectives in Files app

### DIFF
--- a/cypress/e2e/collective.spec.js
+++ b/cypress/e2e/collective.spec.js
@@ -54,6 +54,8 @@ describe('Collective', function() {
 			cy.get(`${fileListSelector} a`).contains('Preexisting Collective').click()
 			cy.get(`${controlsSelector} .breadcrumb`).should('contain', 'Preexisting Collective')
 			cy.get(fileListSelector).should('contain', 'Readme.md')
+			cy.get('.filelist-collectives-wrapper')
+				.should('contain', 'The content of this folder is best viewed in the Collectives app.')
 		})
 	})
 

--- a/lib/Listeners/BeforeTemplateRenderedListener.php
+++ b/lib/Listeners/BeforeTemplateRenderedListener.php
@@ -6,21 +6,45 @@ declare(strict_types=1);
 namespace OCA\Collectives\Listeners;
 
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\IConfig;
+use OCP\IUserSession;
 use OCP\Util;
 
 /** @template-implements IEventListener<Event|BeforeTemplateRenderedEvent> */
 class BeforeTemplateRenderedListener implements IEventListener {
+	private IUserSession $userSession;
+	private IConfig $config;
+	private IInitialState $initialState;
+
+	public function __construct(IUserSession $userSession,
+								IConfig $config,
+								IInitialState $initialState) {
+		$this->userSession = $userSession;
+		$this->config = $config;
+		$this->initialState = $initialState;
+	}
+
 	public function handle(Event $event): void {
 		if (!($event instanceof BeforeTemplateRenderedEvent)) {
 			return;
 		}
 
+		$userFolder = '';
 		if ($event->isLoggedIn()) {
 			Util::addStyle('collectives', 'collectives');
+
+			// Get Collectives user folder for users
+			$userId = $this->userSession->getUser()
+				? $this->userSession->getUser()->getUID()
+				: null;
+			$userFolder = $this->config->getUserValue($userId, 'collectives', 'user_folder', '');
 		}
 
 		Util::addScript('collectives', 'collectives-files');
+		// Provide Collectives user folder as initial state
+		$this->initialState->provideInitialState('user_folder', $userFolder);
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nextcloud/dialogs": "^3.2.0",
         "@nextcloud/event-bus": "^3.0.2",
         "@nextcloud/files": "^2.1.0",
+        "@nextcloud/initial-state": "^2.0.0",
         "@nextcloud/moment": "^1.2.1",
         "@nextcloud/notify_push": "^1.1.3",
         "@nextcloud/paths": "^2.1.0",
@@ -2948,6 +2949,14 @@
         "core-js": "^3.6.4"
       }
     },
+    "node_modules/@nextcloud/capabilities/node_modules/@nextcloud/initial-state": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-1.2.1.tgz",
+      "integrity": "sha512-2TH2DzJBolYHWfbSovTWkByAIg0gdsyuVfZpf5APnJu/9PixXKbnrVFnaEdxjeP262Gok7ARMFFQeSiuzKRQeQ==",
+      "dependencies": {
+        "core-js": "^3.6.4"
+      }
+    },
     "node_modules/@nextcloud/dialogs": {
       "version": "3.2.0",
       "license": "GPL-3.0-or-later",
@@ -3032,11 +3041,9 @@
       }
     },
     "node_modules/@nextcloud/initial-state": {
-      "version": "1.2.1",
-      "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "core-js": "^3.6.4"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.0.0.tgz",
+      "integrity": "sha512-xmNP30v/RnkJ2z1HcuEo7YfcLJJa+FdWTwgNldXHOlMeMbl/ESpsGkWL2sULrhYurz64L0JpfwEdi/cHcmyuZQ=="
     },
     "node_modules/@nextcloud/l10n": {
       "version": "1.6.0",
@@ -3270,11 +3277,6 @@
         "npm": "^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@nextcloud/text/node_modules/@nextcloud/initial-state": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.0.0.tgz",
-      "integrity": "sha512-xmNP30v/RnkJ2z1HcuEo7YfcLJJa+FdWTwgNldXHOlMeMbl/ESpsGkWL2sULrhYurz64L0JpfwEdi/cHcmyuZQ=="
-    },
     "node_modules/@nextcloud/typings": {
       "version": "1.4.3",
       "license": "GPL-3.0-or-later",
@@ -3353,10 +3355,6 @@
         "ical.js": "^1.5.0",
         "uuid": "^8.3.2"
       }
-    },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/initial-state": {
-      "version": "2.0.0",
-      "license": "GPL-3.0-or-later"
     },
     "node_modules/@nextcloud/vue/node_modules/uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nextcloud/dialogs": "^3.2.0",
     "@nextcloud/event-bus": "^3.0.2",
     "@nextcloud/files": "^2.1.0",
+    "@nextcloud/initial-state": "^2.0.0",
     "@nextcloud/moment": "^1.2.1",
     "@nextcloud/notify_push": "^1.1.3",
     "@nextcloud/paths": "^2.1.0",

--- a/src/files.js
+++ b/src/files.js
@@ -1,4 +1,5 @@
 import { generateUrl, imagePath } from '@nextcloud/router'
+import { FilesCollectivesPlugin } from './helpers/files.js'
 
 __webpack_nonce__ = btoa(OC.requestToken) // eslint-disable-line
 __webpack_public_path__ = OC.linkTo('collectives', 'js/') // eslint-disable-line
@@ -10,3 +11,5 @@ window.addEventListener('DOMContentLoaded', () => {
 		OC.MimeType._mimeTypeIcons['dir-collective'] = imagePath('collectives', 'folder-collective')
 	}
 })
+
+OC.Plugins.register('OCA.Files.FileList', FilesCollectivesPlugin)

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -1,0 +1,56 @@
+import Vue from 'vue'
+import FileListInfo from '../views/FileListInfo.vue'
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+
+const FilesCollectivesPlugin = {
+	el: null,
+
+	async getCollectivesFolder() {
+		const response = await axios.get(generateOcsUrl('apps/collectives/api/v1.0/settings/user/user_folder'))
+		return response.data.ocs.data
+	},
+
+	attach(fileList) {
+		if (fileList.id !== 'files' && fileList.id !== 'files.public') {
+			return
+		}
+
+		this.el = document.createElement('div')
+		this.el.id = 'files-collectives-info-wrapper'
+		fileList.registerHeader({
+			id: 'collectives',
+			el: this.el,
+			render: this.render.bind(this),
+			// Higher order than Text rich workspaces
+			order: -1,
+		})
+	},
+
+	async render(fileList) {
+		const collectivesFolder = await this.getCollectivesFolder()
+		const View = Vue.extend(FileListInfo)
+		Vue.prototype.t = window.t
+		Vue.prototype.n = window.n
+		const vm = new View({
+			propsData: {
+				collectivesFolder,
+				path: fileList.getCurrentDirectory(),
+			},
+		}).$mount(this.el)
+
+		fileList.$el.on('urlChanged', data => {
+			vm.path = data.dir.toString()
+		})
+
+		fileList.$el.on('changeDirectory', data => {
+			vm.path = data.dir.toString()
+		})
+
+		return this.el
+	},
+}
+
+export {
+	FilesCollectivesPlugin,
+}

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -1,15 +1,9 @@
 import Vue from 'vue'
 import FileListInfo from '../views/FileListInfo.vue'
-import axios from '@nextcloud/axios'
-import { generateOcsUrl } from '@nextcloud/router'
+import { loadState } from '@nextcloud/initial-state'
 
 const FilesCollectivesPlugin = {
 	el: null,
-
-	async getCollectivesFolder() {
-		const response = await axios.get(generateOcsUrl('apps/collectives/api/v1.0/settings/user/user_folder'))
-		return response.data.ocs.data
-	},
 
 	attach(fileList) {
 		if (fileList.id !== 'files' && fileList.id !== 'files.public') {
@@ -27,8 +21,8 @@ const FilesCollectivesPlugin = {
 		})
 	},
 
-	async render(fileList) {
-		const collectivesFolder = await this.getCollectivesFolder()
+	render(fileList) {
+		const collectivesFolder = loadState('collectives', 'user_folder', null)
 		const View = Vue.extend(FileListInfo)
 		Vue.prototype.t = window.t
 		Vue.prototype.n = window.n

--- a/src/views/FileListInfo.vue
+++ b/src/views/FileListInfo.vue
@@ -69,7 +69,7 @@ export default {
 
 	methods: {
 		setActive() {
-			this.active = this.path.startsWith(this.collectivesFolder)
+			this.active = this.collectivesFolder && this.path.startsWith(this.collectivesFolder)
 		},
 	},
 }

--- a/src/views/FileListInfo.vue
+++ b/src/views/FileListInfo.vue
@@ -1,0 +1,115 @@
+<template>
+	<div v-if="active" class="filelist-collectives-wrapper">
+		<div class="infobox">
+			<InformationIcon fill-color="var(--color-primary-element)" />
+
+			<div class="content">
+				{{ t('collectives', 'The content of this folder is best viewed in the Collectives app.') }}
+
+				<a :href="collectivesLink">
+					<NcButton :aria-label="t('collectives', 'Open in Collectives')"
+						type="primary"
+						class="button">
+						{{ t('collectives', 'Open in Collectives') }}
+					</NcButton>
+				</a>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { generateUrl } from '@nextcloud/router'
+import { NcButton } from '@nextcloud/vue'
+import InformationIcon from 'vue-material-design-icons/Information.vue'
+
+export default {
+	name: 'FileListInfo',
+
+	components: {
+		InformationIcon,
+		NcButton,
+	},
+
+	props: {
+		collectivesFolder: {
+			type: String,
+			required: true,
+		},
+		path: {
+			type: String,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			active: false,
+		}
+	},
+
+	computed: {
+		collectivesLink() {
+			const collectivesPath = this.path.startsWith(this.collectivesFolder)
+				? this.path.slice(this.collectivesFolder.length)
+				: ''
+			return generateUrl('/apps/collectives' + collectivesPath)
+		},
+	},
+
+	watch: {
+		'path'() {
+			this.setActive()
+		},
+	},
+
+	mounted() {
+		this.setActive()
+	},
+
+	methods: {
+		setActive() {
+			this.active = this.path.startsWith(this.collectivesFolder)
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.filelist-collectives-wrapper {
+	padding: 28px 30px 0 50px;
+	margin-bottom: 20px;
+	display: flex;
+	overflow: hidden;
+	flex-wrap: wrap;
+	min-width: 0;
+
+	.infobox {
+		display: flex;
+		align-items: center;
+		justify-content: flex-start;
+
+		background-color: var(--color-background-hover);
+		border-left-color: var(--color-primary-element);
+		border-radius: var(--border-radius);
+		padding: 1em;
+		padding-left: 0.5em;
+		border-left-width: 0.3em;
+		border-left-style: solid;
+		margin-bottom: 0.5em;
+
+		.content {
+			display: flex;
+			align-items: center;
+			justify-content: flex-start;
+
+			margin-left: 1em;
+			margin-bottom: 0;
+
+			.button {
+				margin-left: 12px;
+			}
+		}
+	}
+}
+</style>


### PR DESCRIPTION
Inside collectives folders in the Files app, display an info box and a button to navigate to the Collectives app instead.

Fixes: #138

Signed-off-by: Jonas <jonas@freesources.org>

### 📝 Summary

* Resolves: #138

#### 🖼️ Screenshots

![2022-12-21T15:23:32,786517496+01:00](https://user-images.githubusercontent.com/3582805/208927668-e38434a6-4ef3-45df-aa22-dd048a61362d.png)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
