### PR TITLE
Add API to register extra collective action for other apps

### DIFF
--- a/lib/Controller/StartController.php
+++ b/lib/Controller/StartController.php
@@ -2,6 +2,7 @@
 
 namespace OCA\Collectives\Controller;
 
+use OCA\Collectives\Events\CollectivesLoadAdditionalScriptsEvent;
 use OCA\Viewer\Event\LoadViewer;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
@@ -41,7 +42,8 @@ class StartController extends Controller {
 		if ($appsMissing = $this->checkDependencies()) {
 			return new TemplateResponse('collectives', 'error', ['appsMissing' => $appsMissing]);  // templates/error.php
 		}
-		$this->eventDispatcher->dispatch(LoadViewer::class, new LoadViewer());
+		$this->eventDispatcher->dispatchTyped(new LoadViewer());
+		$this->eventDispatcher->dispatchTyped(new CollectivesLoadAdditionalScriptsEvent());
 		return new TemplateResponse('collectives', 'main', [ // templates/main.php
 			'id-app-content' => '#app-content-vue',
 			'id-app-navigation' => '#app-navigation-vue',

--- a/lib/Events/CollectivesLoadAdditionalScriptsEvent.php
+++ b/lib/Events/CollectivesLoadAdditionalScriptsEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OCA\Collectives\Events;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * This event is triggered when the Collectives app is rendered.
+ * It can be used to add additional scripts to the Collectives app.
+ */
+class CollectivesLoadAdditionalScriptsEvent extends Event {
+}

--- a/src/components/Collective/CollectiveActions.vue
+++ b/src/components/Collective/CollectiveActions.vue
@@ -41,6 +41,14 @@
 			{{ t('collectives', 'Unshare') }}
 		</NcActionButton>
 		<NcActionSeparator v-if="collectiveCanShare(collective) && !isPublic" />
+		<NcActionButton v-if="collectiveExtraAction"
+			:close-after-click="true"
+			@click="collectiveExtraAction.click()">
+			{{ collectiveExtraAction.title }}
+			<template #icon>
+				<OpenInNewIcon :size="16" />
+			</template>
+		</NcActionButton>
 		<NcActionLink :close-after-click="true"
 			:href="printLink"
 			target="_blank">
@@ -65,6 +73,7 @@ import { generateUrl } from '@nextcloud/router'
 import ContentPasteIcon from 'vue-material-design-icons/ContentPaste.vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import DownloadIcon from 'vue-material-design-icons/Download.vue'
+import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import { SHARE_COLLECTIVE, UPDATE_SHARE_COLLECTIVE, UNSHARE_COLLECTIVE } from '../../store/actions.js'
 import displayError from '../../util/displayError.js'
 import CopyToClipboardMixin from '../../mixins/CopyToClipboardMixin.js'
@@ -83,6 +92,7 @@ export default {
 		ContentPasteIcon,
 		CheckIcon,
 		DownloadIcon,
+		OpenInNewIcon,
 	},
 
 	mixins: [
@@ -111,6 +121,7 @@ export default {
 			'isCollectiveAdmin',
 			'isPublic',
 			'loading',
+			'pagesTreeWalk',
 		]),
 
 		isContactsInstalled() {
@@ -150,6 +161,23 @@ export default {
 			return this.isPublic
 				? generateUrl(`/apps/collectives/p/${this.shareTokenParam}/print/${this.collective.name}`)
 				: generateUrl(`/apps/collectives/_/print/${this.collective.name}`)
+		},
+
+		/**
+		 * Other apps can register an extra collective action via
+		 * OCA.Collectives.CollectiveExtraAction
+		 */
+		collectiveExtraAction() {
+			const collectiveExtraAction = this.OCA.Collectives?.CollectiveExtraAction
+			if (!collectiveExtraAction) {
+				return null
+			}
+
+			const pageIds = this.pagesTreeWalk().map(p => p.id)
+			return {
+				title: collectiveExtraAction.title ?? t('collectives', 'Extra action'),
+				click: () => collectiveExtraAction.click(pageIds) ?? function() {},
+			}
 		},
 	},
 


### PR DESCRIPTION
Other apps can listen to CollectivesLoadAdditionalScriptsEvent to load additional JS scripts when the Collectives app is rendered.

If they define an object OCA.Collectives.CollectiveExtraAction with string `title` and callback function `click`.

Signed-off-by: Jonas <jonas@freesources.org>

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
