### PR TITLE
Only display collective extra action in landing page actions

### DIFF
--- a/src/components/Collective/CollectiveActions.vue
+++ b/src/components/Collective/CollectiveActions.vue
@@ -41,14 +41,6 @@
 			{{ t('collectives', 'Unshare') }}
 		</NcActionButton>
 		<NcActionSeparator v-if="collectiveCanShare(collective) && !isPublic" />
-		<NcActionButton v-if="collectiveExtraAction"
-			:close-after-click="true"
-			@click="collectiveExtraAction.click()">
-			{{ collectiveExtraAction.title }}
-			<template #icon>
-				<OpenInNewIcon :size="16" />
-			</template>
-		</NcActionButton>
 		<NcActionLink :close-after-click="true"
 			:href="printLink"
 			target="_blank">
@@ -73,7 +65,6 @@ import { generateUrl } from '@nextcloud/router'
 import ContentPasteIcon from 'vue-material-design-icons/ContentPaste.vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import DownloadIcon from 'vue-material-design-icons/Download.vue'
-import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import { SHARE_COLLECTIVE, UPDATE_SHARE_COLLECTIVE, UNSHARE_COLLECTIVE } from '../../store/actions.js'
 import displayError from '../../util/displayError.js'
 import CopyToClipboardMixin from '../../mixins/CopyToClipboardMixin.js'
@@ -92,7 +83,6 @@ export default {
 		ContentPasteIcon,
 		CheckIcon,
 		DownloadIcon,
-		OpenInNewIcon,
 	},
 
 	mixins: [
@@ -121,7 +111,6 @@ export default {
 			'isCollectiveAdmin',
 			'isPublic',
 			'loading',
-			'pagesTreeWalk',
 		]),
 
 		isContactsInstalled() {
@@ -161,23 +150,6 @@ export default {
 			return this.isPublic
 				? generateUrl(`/apps/collectives/p/${this.shareTokenParam}/print/${this.collective.name}`)
 				: generateUrl(`/apps/collectives/_/print/${this.collective.name}`)
-		},
-
-		/**
-		 * Other apps can register an extra collective action via
-		 * OCA.Collectives.CollectiveExtraAction
-		 */
-		collectiveExtraAction() {
-			const collectiveExtraAction = this.OCA.Collectives?.CollectiveExtraAction
-			if (!collectiveExtraAction) {
-				return null
-			}
-
-			const pageIds = this.pagesTreeWalk().map(p => p.id)
-			return {
-				title: collectiveExtraAction.title ?? t('collectives', 'Extra action'),
-				click: () => collectiveExtraAction.click(pageIds) ?? function() {},
-			}
 		},
 	},
 

--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -10,6 +10,14 @@
 		</NcActionButton>
 		<CollectiveActions v-if="inPageList && isLandingPage"
 			:collective="currentCollective" />
+		<NcActionButton v-if="collectiveExtraAction"
+			:close-after-click="true"
+			@click="collectiveExtraAction.click()">
+			{{ collectiveExtraAction.title }}
+			<template #icon>
+				<OpenInNewIcon :size="16" />
+			</template>
+		</NcActionButton>
 		<NcActionButton v-if="!inPageList"
 			:close-after-click="true"
 			@click.native="toggle('outline')">
@@ -69,6 +77,7 @@ import DeleteIcon from 'vue-material-design-icons/Delete.vue'
 import DeleteOffIcon from 'vue-material-design-icons/DeleteOff.vue'
 import EmoticonOutlineIcon from 'vue-material-design-icons/EmoticonOutline.vue'
 import FormatListBulletedIcon from 'vue-material-design-icons/FormatListBulleted.vue'
+import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import PagesTemplateIcon from '../Icon/PagesTemplateIcon.vue'
 import PageActionLastUser from './PageActionLastUser.vue'
 import pageMixin from '../../mixins/pageMixin.js'
@@ -88,6 +97,7 @@ export default {
 		FormatListBulletedIcon,
 		PagesTemplateIcon,
 		PageActionLastUser,
+		OpenInNewIcon,
 	},
 
 	mixins: [
@@ -142,6 +152,7 @@ export default {
 		...mapGetters([
 			'currentCollective',
 			'loading',
+			'pagesTreeWalk',
 			'showing',
 			'showTemplates',
 			'visibleSubpages',
@@ -181,6 +192,23 @@ export default {
 
 		hasSubpages() {
 			return !!this.visibleSubpages(this.pageId).length || !!this.hasTemplate
+		},
+
+		/**
+		 * Other apps can register an extra collective action via
+		 * OCA.Collectives.CollectiveExtraAction
+		 */
+		collectiveExtraAction() {
+			const collectiveExtraAction = this.OCA.Collectives?.CollectiveExtraAction
+			if (!collectiveExtraAction) {
+				return null
+			}
+
+			const pageIds = this.pagesTreeWalk().map(p => p.id)
+			return {
+				title: collectiveExtraAction.title ?? t('collectives', 'Extra action'),
+				click: () => collectiveExtraAction.click(pageIds) ?? function() {},
+			}
 		},
 	},
 


### PR DESCRIPTION
The actions depend on currentCollective, which is only available in PageAction context, not in the collectives list.

Fixes: #475

Signed-off-by: Jonas <jonas@freesources.org>