### PR TITLE
Add modal to move pages inside the collective

### DIFF
--- a/.github/workflows/app-upgrade-mysql.yml
+++ b/.github/workflows/app-upgrade-mysql.yml
@@ -3,16 +3,16 @@ name: app upgrade
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
-      - 'appinfo/**'
-      - 'lib/**'
-      - 'templates/**'
-      - 'tests/**'
-      - 'vendor/**'
-      - 'vendor-bin/**'
-      - '.php-cs-fixer.dist.php'
-      - 'composer.json'
-      - 'composer.lock'
+      #- '.github/workflows/**'
+      #- 'appinfo/**'
+      #- 'lib/**'
+      #- 'templates/**'
+      #- 'tests/**'
+      #- 'vendor/**'
+      #- 'vendor-bin/**'
+      #- '.php-cs-fixer.dist.php'
+      #- 'composer.json'
+      #- 'composer.lock'
 
   push:
     branches:

--- a/.github/workflows/behat-sqlite.yml
+++ b/.github/workflows/behat-sqlite.yml
@@ -3,16 +3,16 @@ name: Behat
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
-      - 'appinfo/**'
-      - 'lib/**'
-      - 'templates/**'
-      - 'tests/**'
-      - 'vendor/**'
-      - 'vendor-bin/**'
-      - '.php-cs-fixer.dist.php'
-      - 'composer.json'
-      - 'composer.lock'
+      #- '.github/workflows/**'
+      #- 'appinfo/**'
+      #- 'lib/**'
+      #- 'templates/**'
+      #- 'tests/**'
+      #- 'vendor/**'
+      #- 'vendor-bin/**'
+      #- '.php-cs-fixer.dist.php'
+      #- 'composer.json'
+      #- 'composer.lock'
 
   push:
     branches:

--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -8,15 +8,15 @@ name: Lint
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
-      - 'src/**'
-      - 'appinfo/info.xml'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'tsconfig.json'
-      - '**.js'
-      - '**.ts'
-      - '**.vue'
+      #- '.github/workflows/**'
+      #- 'src/**'
+      #- 'appinfo/info.xml'
+      #- 'package.json'
+      #- 'package-lock.json'
+      #- 'tsconfig.json'
+      #- '**.js'
+      #- '**.ts'
+      #- '**.vue'
 
 permissions:
   contents: read

--- a/.github/workflows/occ-cli-mysql.yml
+++ b/.github/workflows/occ-cli-mysql.yml
@@ -3,16 +3,16 @@ name: occ cli
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
-      - 'appinfo/**'
-      - 'lib/**'
-      - 'templates/**'
-      - 'tests/**'
-      - 'vendor/**'
-      - 'vendor-bin/**'
-      - '.php-cs-fixer.dist.php'
-      - 'composer.json'
-      - 'composer.lock'
+      #- '.github/workflows/**'
+      #- 'appinfo/**'
+      #- 'lib/**'
+      #- 'templates/**'
+      #- 'tests/**'
+      #- 'vendor/**'
+      #- 'vendor-bin/**'
+      #- '.php-cs-fixer.dist.php'
+      #- 'composer.json'
+      #- 'composer.lock'
 
   push:
     branches:

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -8,16 +8,16 @@ name: PHPUnit
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
-      - 'appinfo/**'
-      - 'lib/**'
-      - 'templates/**'
-      - 'tests/**'
-      - 'vendor/**'
-      - 'vendor-bin/**'
-      - '.php-cs-fixer.dist.php'
-      - 'composer.json'
-      - 'composer.lock'
+      #- '.github/workflows/**'
+      #- 'appinfo/**'
+      #- 'lib/**'
+      #- 'templates/**'
+      #- 'tests/**'
+      #- 'vendor/**'
+      #- 'vendor-bin/**'
+      #- '.php-cs-fixer.dist.php'
+      #- 'composer.json'
+      #- 'composer.lock'
 
   push:
     branches:

--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -91,7 +91,7 @@ describe('Page', function() {
 		})
 	})
 
-	describe('set page emoji', function() {
+	describe('Set page emoji', function() {
 		it('Allows setting a page emoji from title bar', function() {
 			cy.visit('/apps/collectives/Our%20Garden/Day%201')
 			cy.get('#titleform .page-title-icon')
@@ -121,7 +121,40 @@ describe('Page', function() {
 		})
 	})
 
-	describe('with special chars', function() {
+	describe('Move a page using the modal', function() {
+		it('Moves page to a subpage', function() {
+			cy.seedPage('Move me', '', 'Readme.md')
+			cy.seedPage('Target', '', 'Readme.md')
+			cy.seedPage('Target Subpage', '', 'Target.md')
+			cy.visit('/apps/collectives/Our%20Garden')
+			cy.contains('.app-content-list-item', 'Move me')
+				.find('.action-item__menutoggle')
+				.click({ force: true })
+			cy.get('button.action-button')
+				.contains('Move page')
+				.click()
+			cy.get('.picker-page-list li')
+				.contains('Target')
+				.click()
+			cy.get('.picker-move-buttons button .arrow-down-icon')
+				.click()
+			cy.get('.picker-buttons button')
+				.contains('Move page here')
+				.click()
+
+			cy.visit('/apps/collectives/Our%20Garden/Target')
+			cy.contains('.page-list-drag-item', 'Target')
+				.get('.page-list-indent .app-content-list-item')
+				.first()
+				.contains('Target Subpage')
+			cy.contains('.page-list-drag-item', 'Target')
+				.get('.page-list-indent .app-content-list-item')
+				.last()
+				.contains('Move me')
+		})
+	})
+
+	describe('With special chars', function() {
 		it('loads well', function() {
 			cy.contains('.app-content-list-item a', '#% special chars').click()
 			cy.get('.app-content-list-item').should('contain', '#% special chars')

--- a/src/components/Page/MoveModal.vue
+++ b/src/components/Page/MoveModal.vue
@@ -1,0 +1,71 @@
+<template>
+	<PagePicker :page-id="pageId"
+		:parent-id="parentId"
+		:loading="moving"
+		@select="onMove"
+		@close="onClose" />
+</template>
+
+<script>
+import PagePicker from './PagePicker.vue'
+import pageMixin from '../../mixins/pageMixin.js'
+
+export default {
+	name: 'MoveModal',
+
+	components: {
+		PagePicker,
+	},
+
+	mixins: [
+		pageMixin,
+	],
+
+	props: {
+		pageId: {
+			type: Number,
+			required: true,
+		},
+		parentId: {
+			type: Number,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			moving: false,
+		}
+	},
+
+	methods: {
+		onClose() {
+			this.$emit('close')
+		},
+
+		/**
+		 *
+		 * @param {object} object Parameter object
+		 * @param {number} object.parentId new parent page for page
+		 * @param {number} object.newIndex new order index of page
+		 */
+		async onMove({ parentId, newIndex }) {
+			this.moving = true
+
+			if (parentId !== this.parentId) {
+				// Move page to new parent
+				this.movePage(this.parentId, parentId, this.pageId, newIndex)
+			} else {
+				// Change subpage order of current parent
+				this.subpageOrderUpdate(this.parentId, this.pageId, newIndex)
+			}
+
+			this.moving = false
+			this.$emit('close')
+		},
+	},
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -1,70 +1,83 @@
 <template>
-	<NcActions :force-menu="true" @click.native.stop>
-		<NcActionButton v-if="!inPageList && !showing('sidebar') && isMobile"
-			icon="icon-menu-sidebar"
-			:aria-label="t('collectives', 'Open page sidebar')"
-			aria-controls="app-sidebar-vue"
-			:close-after-click="true"
-			@click="toggle('sidebar')">
-			{{ t('collectives', 'Open page sidebar') }}
-		</NcActionButton>
-		<CollectiveActions v-if="inPageList && isLandingPage"
-			:collective="currentCollective" />
-		<NcActionButton v-if="collectiveExtraAction"
-			:close-after-click="true"
-			@click="collectiveExtraAction.click()">
-			{{ collectiveExtraAction.title }}
-			<template #icon>
-				<OpenInNewIcon :size="16" />
-			</template>
-		</NcActionButton>
-		<NcActionButton v-if="!inPageList"
-			:close-after-click="true"
-			@click.native="toggle('outline')">
-			<template #icon>
-				<FormatListBulletedIcon :size="20" />
-			</template>
-			{{ toggleOutlineString }}
-		</NcActionButton>
-		<NcActionLink v-if="showFilesLink"
-			:href="filesUrl"
-			icon="icon-files-dark"
-			:close-after-click="true">
-			{{ t('collectives', 'Show in Files') }}
-		</NcActionLink>
-		<NcActionButton v-if="!isTemplate && !isLandingPage"
-			:close-after-click="true"
-			@click.native="show('details')"
-			@click="gotoPageEmojiPicker">
-			<template #icon>
-				<EmoticonOutlineIcon :size="20" />
-			</template>
-			{{ setEmojiString }}
-		</NcActionButton>
-		<NcActionButton v-if="!isTemplate"
-			:close-after-click="true"
-			class="action-button-template"
-			@click.native="show('details')"
-			@click="editTemplate(pageId)">
-			<template #icon>
-				<PagesTemplateIcon :size="14" />
-			</template>
-			{{ editTemplateString }}
-		</NcActionButton>
-		<NcActionButton v-if="!isLandingPage"
-			:close-after-click="true"
-			:disabled="hasSubpages"
-			@click.native="show('details')"
-			@click="deletePage(parentId, pageId)">
-			<template #icon>
-				<DeleteOffIcon v-if="hasSubpages" :size="20" />
-				<DeleteIcon v-else :size="20" />
-			</template>
-			{{ deletePageString }}
-		</NcActionButton>
-		<NcActionSeparator v-if="lastUserId && lastUserDisplayName" />
-		<PageActionLastUser :last-user-id="lastUserId" :last-user-display-name="lastUserDisplayName" :timestamp="timestamp" />
-	</NcActions>
+	<div>
+		<NcActions :force-menu="true" @click.native.stop>
+			<NcActionButton v-if="!inPageList && !showing('sidebar') && isMobile"
+				icon="icon-menu-sidebar"
+				:aria-label="t('collectives', 'Open page sidebar')"
+				aria-controls="app-sidebar-vue"
+				:close-after-click="true"
+				@click="toggle('sidebar')">
+				{{ t('collectives', 'Open page sidebar') }}
+			</NcActionButton>
+			<CollectiveActions v-if="inPageList && isLandingPage"
+				:collective="currentCollective" />
+			<NcActionButton v-if="collectiveExtraAction"
+				:close-after-click="true"
+				@click="collectiveExtraAction.click()">
+				{{ collectiveExtraAction.title }}
+				<template #icon>
+					<OpenInNewIcon :size="16" />
+				</template>
+			</NcActionButton>
+			<NcActionButton v-if="!inPageList"
+				:close-after-click="true"
+				@click.native="toggle('outline')">
+				<template #icon>
+					<FormatListBulletedIcon :size="20" />
+				</template>
+				{{ toggleOutlineString }}
+			</NcActionButton>
+			<NcActionLink v-if="showFilesLink"
+				:href="filesUrl"
+				icon="icon-files-dark"
+				:close-after-click="true">
+				{{ t('collectives', 'Show in Files') }}
+			</NcActionLink>
+			<NcActionButton v-if="!isTemplate && !isLandingPage"
+				:close-after-click="true"
+				@click.native="show('details')"
+				@click="gotoPageEmojiPicker">
+				<template #icon>
+					<EmoticonOutlineIcon :size="20" />
+				</template>
+				{{ setEmojiString }}
+			</NcActionButton>
+			<NcActionButton v-if="!isTemplate"
+				:close-after-click="true"
+				class="action-button-template"
+				@click.native="show('details')"
+				@click="editTemplate(pageId)">
+				<template #icon>
+					<PagesTemplateIcon :size="14" />
+				</template>
+				{{ editTemplateString }}
+			</NcActionButton>
+			<NcActionButton v-if="!isLandingPage"
+				:close-after-click="true"
+				@click="onOpenMoveModal">
+				<template #icon>
+					<OpenInNewIcon :size="20" />
+				</template>
+				{{ t('collectives', 'Move page') }}
+			</NcActionButton>
+			<NcActionButton v-if="!isLandingPage"
+				:close-after-click="true"
+				:disabled="hasSubpages"
+				@click="deletePage(parentId, pageId)">
+				<template #icon>
+					<DeleteOffIcon v-if="hasSubpages" :size="20" />
+					<DeleteIcon v-else :size="20" />
+				</template>
+				{{ deletePageString }}
+			</NcActionButton>
+			<NcActionSeparator v-if="lastUserId && lastUserDisplayName" />
+			<PageActionLastUser :last-user-id="lastUserId" :last-user-display-name="lastUserDisplayName" :timestamp="timestamp" />
+		</NcActions>
+		<MoveModal v-if="showMoveModal"
+			:page-id="pageId"
+			:parent-id="parentId"
+			@close="onCloseMoveModal" />
+	</div>
 </template>
 
 <script>
@@ -78,6 +91,7 @@ import DeleteOffIcon from 'vue-material-design-icons/DeleteOff.vue'
 import EmoticonOutlineIcon from 'vue-material-design-icons/EmoticonOutline.vue'
 import FormatListBulletedIcon from 'vue-material-design-icons/FormatListBulleted.vue'
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
+import MoveModal from './MoveModal.vue'
 import PagesTemplateIcon from '../Icon/PagesTemplateIcon.vue'
 import PageActionLastUser from './PageActionLastUser.vue'
 import pageMixin from '../../mixins/pageMixin.js'
@@ -87,6 +101,7 @@ export default {
 
 	components: {
 		CollectiveActions,
+		MoveModal,
 		NcActions,
 		NcActionButton,
 		NcActionLink,
@@ -146,6 +161,12 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+	},
+
+	data() {
+		return {
+			showMoveModal: false,
+		}
 	},
 
 	computed: {
@@ -222,6 +243,14 @@ export default {
 			this.$nextTick(() => {
 				this.show('pageEmojiPicker')
 			})
+		},
+
+		onOpenMoveModal() {
+			this.showMoveModal = true
+		},
+
+		onCloseMoveModal() {
+			this.showMoveModal = false
 		},
 	},
 }

--- a/src/components/Page/PagePicker.vue
+++ b/src/components/Page/PagePicker.vue
@@ -2,19 +2,32 @@
 	<NcModal @close="onClose">
 		<div class="modal-content">
 			<h2 class="oc-dialog-title">
-				{{ t('collectives', 'Choose target') }}
+				{{ t('collectives', 'Move page') }}
 			</h2>
 			<span class="crumbs">
-				<a @click="onClickHome">
-					<HomeIcon :size="20" />
-				</a>
-				<a v-for="page in pageCrumbs"
+				<div class="crumbs-home">
+					<NcButton type="tertiary"
+						:aria-label="t('collectives', 'Breadcrumb for Home')"
+						:disabled="pageCrumbs.length === 0"
+						class="crumb-button"
+						@click="onClickHome">
+						<template #icon>
+							<HomeIcon :size="20" />
+						</template>
+					</NcButton>
+				</div>
+				<div v-for="(page, index) in pageCrumbs"
 					:key="page.id"
-					class="level"
-					@click="onClickPage(page)">
+					:aria-label="t('collectives', 'Breadcrumb for {page}', { page: page.title })"
+					class="crumbs-level">
 					<ChevronRightIcon :size="20" />
-					{{ page.title }}
-				</a>
+					<NcButton type="tertiary"
+						:disabled="(index + 1) === pageCrumbs.length"
+						class="crumb-button"
+						@click="onClickPage(page)">
+						{{ page.title }}
+					</NcButton>
+				</div>
 			</span>
 			<div class="picker-page-list">
 				<ul v-if="subpages.length > 0">
@@ -22,12 +35,16 @@
 						:id="`picker-page-${page.id}`"
 						:key="page.id">
 						<a :class="{'self': page.id === pageId}"
+							:href="page.id === pageId ? false : '#'"
 							class="picker-page-item"
 							@click="onClickPage(page)">
 							<div v-if="page.emoji" class="picker-page-icon">
 								{{ page.emoji }}
 							</div>
-							<PageIcon v-else class="picker-page-icon" :size="20" />
+							<PageIcon v-else
+								class="picker-page-icon"
+								:size="20"
+								fill-color="var(--color-background-darker)" />
 							<div class="picker-page-title">
 								{{ page.title }}
 							</div>
@@ -239,31 +256,42 @@ export default {
 }
 
 .crumbs {
+	color: var(--color-text-maxcontrast);
 	display: inline-flex;
 	padding-right: 0;
-	flex-wrap: wrap;
 
-	a {
+	div {
 		display: flex;
-		align-items: center;
-		opacity: 0.7;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
 		flex: 0 0 auto;
-		min-width: 0;
 		max-width: 200px;
+
+		.crumb-button {
+			color: var(--color-text-maxcontrast);
+		}
 
 		&:hover {
 			opacity: 1;
 		}
 
-		.level {
+		&.crumbs-home {
+			flex-shrink: 0;
+		}
+
+		&.crumbs-level {
 			display: inline-flex;
 			min-width: 0;
-			flex: 0 0 auto;
-			order: 1;
-			padding-right: 7px;
+			flex-shrink: 1;
+		}
+
+		&:last-child {
+			flex-shrink: 0;
+
+			.crumb-button {
+				color: var(--color-main-text);
+			}
 		}
 	}
 }
@@ -304,8 +332,7 @@ export default {
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		width: 20px;
-		margin-right: 6px;
+		width: 44px;
 	}
 
 	.picker-page-title {

--- a/src/components/Page/PagePicker.vue
+++ b/src/components/Page/PagePicker.vue
@@ -1,0 +1,314 @@
+<template>
+	<NcModal @close="onClose">
+		<div class="modal-content">
+			<h2 class="oc-dialog-title">
+				{{ t('collectives', 'Choose target') }}
+			</h2>
+			<span class="crumbs">
+				<a @click="onClickHome">
+					<HomeIcon :size="20" />
+				</a>
+				<a v-for="page in pageCrumbs"
+					:key="page.id"
+					class="level"
+					@click="onClickPage(page)">
+					<ChevronRightIcon :size="20" />
+					{{ page.title }}
+				</a>
+			</span>
+			<div class="picker-page-list">
+				<ul v-if="subpages.length > 0">
+					<li v-for="(page, index) in subpages"
+						:id="`picker-page-${page.id}`"
+						:key="page.id">
+						<a :class="{'self': page.id === pageId}"
+							class="picker-page-item"
+							@click="onClickPage(page)">
+							<div v-if="page.emoji" class="picker-page-icon">
+								{{ page.emoji }}
+							</div>
+							<PageIcon v-else class="picker-page-icon" :size="20" />
+							<div class="picker-page-title">
+								{{ page.title }}
+							</div>
+							<div v-if="page.id === pageId" class="picker-move-buttons">
+								<NcButton :disabled="index === 0"
+									type="tertiary"
+									@click="onClickUp">
+									<template #icon>
+										<ArrowUpIcon :size="20" />
+									</template>
+								</NcButton>
+								<NcButton :disabled="index === (subpages.length - 1)"
+									type="tertiary"
+									@click="onClickDown">
+									<template #icon>
+										<ArrowDownIcon :size="20" />
+									</template>
+								</NcButton>
+							</div>
+						</a>
+					</li>
+				</ul>
+			</div>
+			<div class="picker-buttons">
+				<NcButton type="primary" :disabled="loading" @click="onSelect">
+					<template #icon>
+						<NcLoadingIcon v-if="loading" :size="20" />
+					</template>
+					{{ t('collectives', 'Move page here') }}
+				</NcButton>
+			</div>
+		</div>
+	</NcModal>
+</template>
+
+<script>
+import { mapGetters, mapState } from 'vuex'
+import { NcButton, NcLoadingIcon, NcModal } from '@nextcloud/vue'
+import ArrowDownIcon from 'vue-material-design-icons/ArrowDown.vue'
+import ArrowUpIcon from 'vue-material-design-icons/ArrowUp.vue'
+import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
+import HomeIcon from 'vue-material-design-icons/Home.vue'
+import PageIcon from '../Icon/PageIcon.vue'
+
+export default {
+	name: 'PagePicker',
+
+	components: {
+		ArrowDownIcon,
+		ArrowUpIcon,
+		ChevronRightIcon,
+		HomeIcon,
+		NcButton,
+		NcLoadingIcon,
+		NcModal,
+		PageIcon,
+	},
+
+	props: {
+		loading: {
+			type: Boolean,
+			default: false,
+		},
+		pageId: {
+			type: Number,
+			required: true,
+		},
+		parentId: {
+			type: Number,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			subpages: [],
+			selectedPageId: undefined,
+		}
+	},
+
+	computed: {
+		...mapGetters([
+			'collectivePage',
+			'pageParents',
+			'visibleSubpages',
+		]),
+
+		...mapState({
+			pages: (state) => state.pages.pages,
+		}),
+
+		pageCrumbs() {
+			return this.pageParents(this.selectedPageId)
+		},
+	},
+
+	watch: {
+		'selectedPageId'() {
+			this.updateSubpages()
+		},
+	},
+
+	mounted() {
+		this.selectedPageId = this.parentId
+		this.updateSubpages()
+	},
+
+	methods: {
+		updateSubpages() {
+			this.subpages = this.visibleSubpages(this.selectedPageId)
+
+			// Add current page to top of subpages if not part of it yet
+			if (!this.subpages.find(p => (p.id === this.pageId))) {
+				this.subpages.unshift(this.pages.find(p => (p.id === this.pageId)))
+			}
+
+			// Scroll current page into view (important when listing parent page)
+			this.$nextTick(() => {
+				document.getElementById(`picker-page-${this.pageId}`).scrollIntoView({ block: 'center' })
+			})
+		},
+
+		/**
+		 *
+		 * @param {number} from old index
+		 * @param {number} to new index
+		 */
+		swapSubpages(from, to) {
+			const length = this.subpages.length - 1
+			if (from >= 0 && from <= length && to >= 0 && to <= length) {
+				this.subpages.splice(from, 1, this.subpages.splice(to, 1, this.subpages[from])[0])
+			}
+
+			// Scroll current page into view
+			this.$nextTick(() => {
+				document.getElementById(`picker-page-${this.pageId}`).scrollIntoView({ block: 'center' })
+			})
+		},
+
+		onClickHome() {
+			this.selectedPageId = this.collectivePage.id
+		},
+
+		/**
+		 *
+		 * @param {object} page page object
+		 */
+		onClickPage(page) {
+			if (page.id === this.pageId) {
+				// Don't allow to move pages below themselves
+				return
+			}
+			this.selectedPageId = page.id
+		},
+
+		onClickDown() {
+			const pageIndex = this.subpages.findIndex(p => (p.id === this.pageId))
+			this.swapSubpages(pageIndex, pageIndex + 1)
+		},
+
+		onClickUp() {
+			const pageIndex = this.subpages.findIndex(p => (p.id === this.pageId))
+			this.swapSubpages(pageIndex, pageIndex - 1)
+		},
+
+		onClose() {
+			this.$emit('close')
+		},
+
+		onSelect() {
+			this.$emit('select', { parentId: this.selectedPageId, newIndex: this.subpages.findIndex(p => p.id === this.pageId) })
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+:deep(.modal-container) {
+	width: calc(100vw - 120px) !important;
+	height: calc(100vw - 120px) !important;
+	max-width: 600px !important;
+	max-height: 500px !important;
+}
+
+.modal-content {
+	display: flex;
+	box-sizing: border-box;
+	width: 100%;
+	height: 100%;
+	flex-direction: column;
+	padding: 15px;
+}
+
+.crumbs {
+	display: inline-flex;
+	padding-right: 0;
+	flex-wrap: wrap;
+
+	a {
+		display: flex;
+		align-items: center;
+		opacity: 0.7;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
+		flex: 0 0 auto;
+		min-width: 0;
+		max-width: 200px;
+
+		&:hover {
+			opacity: 1;
+		}
+
+		.level {
+			display: inline-flex;
+			min-width: 0;
+			flex: 0 0 auto;
+			order: 1;
+			padding-right: 7px;
+		}
+	}
+}
+
+.picker-page-list {
+	display: inline-block;
+	width: 100%;
+	height: 100%;
+	overflow-y: auto;
+	flex: 1;
+
+	li a {
+		display: flex;
+
+		&:not(:last-child) {
+			border-bottom: 1px solid var(--color-border);
+		}
+
+		&:hover, &:focus, &:active {
+			background-color: var(--color-background-hover);
+		}
+
+		// Element of the page that is to be moved
+		&.self {
+			background-color: var(--color-primary-light);
+		}
+	}
+
+	li a.self {
+		cursor: default;
+
+		.picker-page-icon, .picker-page-title {
+			cursor: default;
+		}
+	}
+
+	.picker-page-icon {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		width: 20px;
+		margin-right: 6px;
+	}
+
+	.picker-page-title {
+		padding: 14px 14px 14px 0;
+		flex: 1;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+	}
+
+	.picker-move-buttons {
+		display: flex;
+		align-items: center;
+		padding: 0 12px;
+	}
+}
+
+.picker-buttons {
+	display: flex;
+	justify-content: flex-end;
+	padding-top: 10px;
+}
+</style>

--- a/src/components/Page/PagePicker.vue
+++ b/src/components/Page/PagePicker.vue
@@ -133,6 +133,12 @@ export default {
 	mounted() {
 		this.selectedPageId = this.parentId
 		this.updateSubpages()
+
+		window.addEventListener('keydown', this.handleKeyDown, true)
+	},
+
+	beforeDestroy() {
+		window.removeEventListener('keydown', this.handleKeyDown, true)
 	},
 
 	methods: {
@@ -199,6 +205,17 @@ export default {
 
 		onSelect() {
 			this.$emit('select', { parentId: this.selectedPageId, newIndex: this.subpages.findIndex(p => p.id === this.pageId) })
+		},
+
+		handleKeyDown(event) {
+			if (event.key === 'ArrowDown') {
+				event.preventDefault()
+				this.onClickDown()
+			}
+			if (event.key === 'ArrowUp') {
+				event.preventDefault()
+				this.onClickUp()
+			}
 		},
 	},
 }

--- a/src/mixins/pageMixin.js
+++ b/src/mixins/pageMixin.js
@@ -129,8 +129,8 @@ export default {
 		 * @param {number} newIndex New index for pageId
 		 */
 		async movePage(oldParentId, newParentId, pageId, newIndex) {
-			// Add page to subpageOrder of old parent first to ensure correct sorting
-			// Don't await response in order to prevent jumping around
+			// Add page to subpageOrder of new parent first to ensure correct sorting
+			// Don't await response to prevent jumping around
 			this.subpageOrderAdd(newParentId, pageId, newIndex)
 
 			// Move subpage to new parent

--- a/src/store/pages.js
+++ b/src/store/pages.js
@@ -177,6 +177,19 @@ export default {
 			return pages
 		},
 
+		pageParents: (state, getters) => (pageId) => {
+			const pages = []
+			while (pageId !== getters.collectivePage.id) {
+				const page = state.pages.find(p => (p.id === pageId))
+				if (!page) {
+					break
+				}
+				pages.unshift(page)
+				pageId = page.parentId
+			}
+			return pages
+		},
+
 		visibleSubpages: (state, getters) => (parentId) => {
 			return getters.sortedSubpages(parentId)
 		},


### PR DESCRIPTION
### 📝 Summary

Allows to move pages between subpages and in sort order inside

Fixes: #462

#### 🖼️ Screenshots

Action | Modal
---|---
![2023-01-01T22:35:26,492573140+01:00](https://user-images.githubusercontent.com/3582805/210185349-ad3eb43e-0d43-422a-b20a-5a234c195862.png) | ![2023-01-01T22:35:12,193365414+01:00](https://user-images.githubusercontent.com/3582805/210185354-5ed1fb5a-03f9-4671-9492-21efdadc0fd7.png) |

#### Screencast

[recording.webm](https://user-images.githubusercontent.com/3582805/210185543-c6491c9b-2f42-4976-9eca-842829edab7f.webm)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
