### PR TITLE
ci: Use apcu and speed up basic auth for cypress/integration tests

### DIFF
--- a/.github/workflows/behat-sqlite.yml
+++ b/.github/workflows/behat-sqlite.yml
@@ -74,7 +74,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite
+          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite, apcu
+          ini-values:
+            apc.enable_cli=on
           coverage: none
 
       - name: Install composer dependencies
@@ -86,6 +88,7 @@ jobs:
           DB_PORT: 4444
         run: |
           mkdir data
+          echo '<?php $CONFIG=["memcache.local"=>"\OC\Memcache\APCu","hashing_default_password"=>true];' > config/config.php
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
           ./occ app:enable --force circles
           ./occ app:enable --force ${{ env.APP_NAME }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -92,7 +92,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite, gd
+          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite, gd, apcu
+          ini-values:
+            apc.enable_cli=on
           coverage: none
 
       - name: Install composer dependencies
@@ -133,6 +135,7 @@ jobs:
           DB_PORT: 4444
         run: |
           mkdir data
+          echo '<?php $CONFIG=["memcache.local"=>"\OC\Memcache\APCu","hashing_default_password"=>true];' > config/config.php
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
           ./occ app:enable --force contacts
           ./occ app:enable --force ${{ env.APP_NAME }}


### PR DESCRIPTION
### 📝 Summary

Speed up CI a bit. Let's see how the numbers are since collectives has quite a good coverage :)

![Screenshot 2023-01-02 at 18 20 12](https://user-images.githubusercontent.com/3404133/210262558-c204921b-c13e-43dd-87ae-759569331079.png)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
