### PR TITLE
Fix title and description of EmptyContent in CollectiveNotFound

### DIFF
--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -296,13 +296,13 @@ describe('Page', function() {
 			cy.log('Show outline in view mode')
 			cy.contains('button', 'Show outline')
 				.click()
-			cy.get('.editor--toc .editor--toc__item')
+			cy.get('#text-container .editor--toc .editor--toc__item')
 				.should('contain', 'Second-Level Heading')
 
 			// Switch to edit mode
 			cy.switchPageMode(1)
 
-			cy.get('.editor--toc .editor--toc__item')
+			cy.get('.text-editor .editor--toc .editor--toc__item')
 				.should('contain', 'Second-Level Heading')
 
 			cy.log('Close outline in edit mode')

--- a/src/components/CollectiveNotFound.vue
+++ b/src/components/CollectiveNotFound.vue
@@ -1,17 +1,8 @@
 <template>
-	<NcEmptyContent>
-		{{ t('collectives', 'Collective not found:') }}
-		{{ collectiveParam }}
+	<NcEmptyContent :title="t('collectives', 'Collective not found: {collective}', { collective: collectiveParam })"
+		:description="t('collectives', 'You\'re not part of a collective with that name.')">
 		<template #icon>
 			<CollectivesIcon />
-		</template>
-		<template #desc>
-			<div>
-				{{ t('collectives', 'You\'re not part of a collective with that name.') }}
-			</div>
-			<div>
-				{{ t('collectives', 'Select a collective or create a new one on the left.') }}
-			</div>
 		</template>
 	</NcEmptyContent>
 </template>


### PR DESCRIPTION
Signed-off-by: Jonas <jonas@freesources.org>

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
