### PR TITLE
Improve error message when leaving a collective fails

### DIFF
--- a/src/components/Collective/CollectiveActions.vue
+++ b/src/components/Collective/CollectiveActions.vue
@@ -229,8 +229,13 @@ export default {
 			this.dispatchMarkCollectiveDeleted(collective)
 
 			this.leaveTimeout = setTimeout(() => {
-				this.dispatchLeaveCircle(collective).catch(() => {
-					showError(t('collectives', 'Could not leave the collective'))
+				this.dispatchLeaveCircle(collective).catch((e) => {
+					console.error('Failed to leave collective', e)
+					let errorMessage = ''
+					if (e.response?.data?.ocs?.meta?.message) {
+						errorMessage = e.response.data.ocs.meta.message
+					}
+					showError(t('collectives', 'Could not leave the collective. {errorMessage}', { errorMessage }))
 					this.dispatchUnmarkCollectiveDeleted(collective)
 				})
 			}, 10000)


### PR DESCRIPTION
With https://github.com/nextcloud/circles/pull/1236 leaving will fail if the user is not a direct member. This change will make sure the explanation is shown to the user.

Signed-off-by: Jonas <jonas@freesources.org>
