### PR TITLE
Mention required php extensions in DEVELOPING

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -8,6 +8,7 @@ The following tools are required for app development:
 * g++: to compile some NodeJS dependencies
 * gettext: to generate pot/translation files
 * rsync and openssl: for generating release tarballs
+* php `dom` and `sqlite` extension
 * composer for installing php dependencies
 * nextcloud server: for running php tests
 * circles app: for passing some php tests that depend on it.


### PR DESCRIPTION
Installed collectives today in a fresh ubuntu 20.04 and it was missing these.