### PR TITLE
Cypress: wait one second after switching page mode in TOC test

### DIFF
--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -302,6 +302,9 @@ describe('Page', function() {
 			// Switch to edit mode
 			cy.switchPageMode(1)
 
+			// Wait one second and see whether it fixes the flaky test
+			cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
+
 			cy.get('.text-editor .editor--toc .editor--toc__item')
 				.should('contain', 'Second-Level Heading')
 


### PR DESCRIPTION
Let's see whether it fixes the flaky test.

Signed-off-by: Jonas <jonas@freesources.org>
