### PR TITLE
fix:collective name gets added in printview

### DIFF
--- a/src/components/CollectivePrint.vue
+++ b/src/components/CollectivePrint.vue
@@ -70,6 +70,7 @@ export default {
 
 	computed: {
 		...mapGetters([
+			'currentCollective',
 			'pagesTreeWalk',
 			'shareTokenParam',
 		]),
@@ -86,6 +87,16 @@ export default {
 			return this.loadingTotal
 				? this.loadingCount / this.loadingTotal * 100
 				: 0
+		},
+
+		documentTitle() {
+			const parts = [
+				this.currentCollective.name,
+				t('collectives', 'Collectives'),
+				'Nextcloud',
+			]
+
+			return parts.join(' - ')
 		},
 	},
 
@@ -162,6 +173,8 @@ export default {
 			this.$nextTick(() => {
 				// Scroll back to the beginning of the document
 				document.getElementById('content-vue').scrollIntoView()
+				document.title = this.documentTitle
+
 				window.print()
 			})
 		},


### PR DESCRIPTION
### 📝 Summary

added collective name to the document title before printing.

* Resolves: #474 

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots
![printview](https://user-images.githubusercontent.com/121554887/213187769-94836547-9633-4cd8-b508-46dbf31b400e.PNG)





### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) is not needed.
