### PR TITLE
Import nc-vue component separately in FileListInfo component

### DIFF
--- a/src/views/FileListInfo.vue
+++ b/src/views/FileListInfo.vue
@@ -20,7 +20,8 @@
 
 <script>
 import { generateUrl } from '@nextcloud/router'
-import { NcButton } from '@nextcloud/vue'
+// As it's the only nextcloud-vue component used in collectives-files.js, import it separately to keep asset small
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import InformationIcon from 'vue-material-design-icons/Information.vue'
 
 export default {


### PR DESCRIPTION
This shrinks the collectives-files.js asset from 4MB to ~100KB.

Signed-off-by: Jonas <jonas@freesources.org>
