### PR TITLE
Add reference provider and basic reference widget

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -174,6 +174,7 @@ jobs:
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           COMMIT_INFO_SHA:  ${{ github.event.pull_request.head.sha }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_ncVersion: ${{ matrix.server-versions }}
 
       - name: Upload test failure screenshots
         uses: actions/upload-artifact@v3

--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -1,0 +1,41 @@
+FROM nextcloud:latest as source
+
+WORKDIR /tmp
+
+RUN set -ex; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends git;
+
+RUN set -ex; \
+    git clone --depth 1 https://github.com/nextcloud/server.git; \
+    git clone --depth 1 https://github.com/nextcloud/circles.git server/apps/circles; \
+    git clone --depth 1 https://github.com/nextcloud/text.git server/apps/text; \
+    git clone --depth 1 https://github.com/nextcloud/viewer.git server/apps/viewer;
+
+RUN set -ex; \
+    cd server; \
+    git submodule update --init;
+
+RUN set -ex; \
+	cp -r -v /usr/src/nextcloud/config /tmp/server;
+
+FROM nextcloud:latest
+
+RUN set -ex; \
+	rm -rf /usr/src/nextcloud;
+
+COPY --from=source --chown=www-data:www-data /tmp/server /usr/src/nextcloud
+
+RUN set -ex; \
+	cd /usr/src/nextcloud; \
+	mkdir data; \
+    mkdir custom_apps; \
+    chown -R www-data:www-data config data apps custom_apps;
+
+ENV NEXTCLOUD_ADMIN_PASSWORD=admin
+ENV NEXTCLOUD_ADMIN_USER=admin
+ENV SQLITE_DATABASE=sqlite_db
+
+RUN mv /entrypoint.sh /original_entrypoint.sh
+
+COPY --chown=www-data:www-data --chmod=0755 ./entrypoint.sh /entrypoint.sh

--- a/cypress/docker-compose.yml
+++ b/cypress/docker-compose.yml
@@ -1,14 +1,18 @@
 version: '3'
 
 services:
-  nextcloud-cypress:
-    image: registry.gitlab.com/collectivecloud/docker-builds:php8.1-ncmaster
-    entrypoint:
-      - /usr/local/bin/run.sh
+  nextcloud_cypress:
+    build:
+      context: .
+      network: host
     restart: always
     ports:
       - 8081:80
     environment:
-      APP_SOURCE:
+      - CYPRESS_baseUrl
+      - APP_SOURCE
     volumes:
-      - ${APP_SOURCE}:/var/www/html/apps/collectives
+      - type: bind
+        read_only: true
+        source: ${APP_SOURCE}
+        target: /var/www/html/custom_apps/collectives

--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -251,6 +251,34 @@ describe('Page', function() {
 		})
 	})
 
+	// Reference picker autocompletion is only available on Nextcloud 26+
+	if (Cypress.env('ncVersion') !== 'stable25') {
+		describe('Using the reference picker', function() {
+			it('Supports selecting a page from a collective', function() {
+				cy.visit('/apps/collectives/Our%20Garden/Page%20Title')
+
+				cy.getEditor()
+					.should('be.visible')
+					.type('/Coll')
+				cy.get('.tippy-content .link-picker__item')
+					.contains('Collective pages')
+					.click()
+				cy.get('.reference-picker input[type="text"]')
+					.type('Day 2')
+				cy.get('.search-result')
+					.contains('Day 2')
+					.click()
+
+				/*
+				 * Disable for now - in CI Nextcloud is on http (no TLS) and link previews don't get rendered
+				cy.getEditor()
+					.get('.widgets--list .collective-page--info .line')
+					.should('contain', 'Day 2')
+				 */
+			})
+		})
+	}
+
 	describe('Using the page list filter', function() {
 		it('Shows only landing page and (sub)pages matching the filter string', function() {
 			cy.get('input[name="pageFilter"]')

--- a/cypress/entrypoint.sh
+++ b/cypress/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Ensure correct permissions, as the bind-mount might currupt them (and prevent the installation)
+[ -e /var/www/html/custom_apps ] && chown -R www-data:www-data /var/www/html/custom_apps > /dev/null 2>&1
+
+NEXTCLOUD_UPDATE=1
+export NEXTCLOUD_UPDATE
+OUTPUT=$(/original_entrypoint.sh true)
+
+echo "$OUTPUT"
+
+# Check if new installed
+G=$(echo "$OUTPUT" | grep "New nextcloud instance")
+if [ $? -eq 0 ]; then
+    echo "Nextcloud installed, fill demo data"
+    su -s /bin/bash www-data -c "
+        php /var/www/html/occ config:system:set debug --value='true' --type=boolean
+        export OC_PASS=1234561
+        php /var/www/html/occ user:add --password-from-env user1
+        php /var/www/html/occ user:add --password-from-env user2
+        php /var/www/html/occ app:enable circles
+        php /var/www/html/occ app:enable viewer
+        php /var/www/html/occ app:enable text
+        php /var/www/html/occ app:enable --force collectives
+        php /var/www/html/occ app:list
+        for user in alice bob jane john; do \
+            OC_PASS="\$user" php /var/www/html/occ user:add --password-from-env "\$user"; \
+        done
+        php /var/www/html/occ group:add "Bobs Group"
+        for user in bob jane; do \
+            php /var/www/html/occ group:adduser "Bobs Group" "\$user"; \
+        done
+        php /var/www/html/occ collectives:create SearchTest --owner=bob
+        php /var/www/html/occ collectives:index
+    "
+fi
+
+exec $@

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -15,6 +15,7 @@ use OCA\Collectives\Listeners\ShareDeletedListener;
 use OCA\Collectives\Mount\CollectiveFolderManager;
 use OCA\Collectives\Mount\MountProvider;
 use OCA\Collectives\Reference\PageReferenceProvider;
+use OCA\Collectives\Reference\SearchablePageReferenceProvider;
 use OCA\Collectives\Search\CollectiveProvider;
 use OCA\Collectives\Search\PageProvider;
 use OCA\Collectives\Search\PageContentProvider;
@@ -30,6 +31,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\IMimeTypeLoader;
+use OCP\IConfig;
 use OCP\Share\Events\ShareDeletedEvent;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -76,7 +78,15 @@ class Application extends App implements IBootstrap {
 		$context->registerSearchProvider(CollectiveProvider::class);
 		$context->registerSearchProvider(PageProvider::class);
 		$context->registerSearchProvider(PageContentProvider::class);
-		$context->registerReferenceProvider(PageReferenceProvider::class);
+
+		$container = $this->getContainer();
+		/** @var IConfig $config */
+		$config = $container->get(IConfig::class);
+		if (version_compare($config->getSystemValueString('version', '0.0.0'), '26.0.0', '<')) {
+			$context->registerReferenceProvider(PageReferenceProvider::class);
+		} else {
+			$context->registerReferenceProvider(SearchablePageReferenceProvider::class);
+		}
 
 		$cacheListener = $this->getContainer()->get(CacheListener::class);
 		$cacheListener->listen();

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -8,11 +8,13 @@ use Closure;
 use OCA\Circles\Events\CircleDestroyedEvent;
 use OCA\Collectives\CacheListener;
 use OCA\Collectives\Fs\UserFolderHelper;
+use OCA\Collectives\Listeners\CollectivesReferenceListener;
 use OCA\Collectives\Listeners\CircleDestroyedListener;
 use OCA\Collectives\Listeners\BeforeTemplateRenderedListener;
 use OCA\Collectives\Listeners\ShareDeletedListener;
 use OCA\Collectives\Mount\CollectiveFolderManager;
 use OCA\Collectives\Mount\MountProvider;
+use OCA\Collectives\Reference\PageReferenceProvider;
 use OCA\Collectives\Search\CollectiveProvider;
 use OCA\Collectives\Search\PageProvider;
 use OCA\Collectives\Search\PageContentProvider;
@@ -25,6 +27,7 @@ use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Share\Events\ShareDeletedEvent;
@@ -46,6 +49,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
 		$context->registerEventListener(CircleDestroyedEvent::class, CircleDestroyedListener::class);
 		$context->registerEventListener(ShareDeletedEvent::class, ShareDeletedListener::class);
+		$context->registerEventListener(RenderReferenceEvent::class, CollectivesReferenceListener::class);
 
 		$context->registerService(MountProvider::class, function (ContainerInterface $c) {
 			return new MountProvider(
@@ -72,6 +76,7 @@ class Application extends App implements IBootstrap {
 		$context->registerSearchProvider(CollectiveProvider::class);
 		$context->registerSearchProvider(PageProvider::class);
 		$context->registerSearchProvider(PageContentProvider::class);
+		$context->registerReferenceProvider(PageReferenceProvider::class);
 
 		$cacheListener = $this->getContainer()->get(CacheListener::class);
 		$cacheListener->listen();

--- a/lib/Listeners/CollectivesReferenceListener.php
+++ b/lib/Listeners/CollectivesReferenceListener.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace OCA\Collectives\Listeners;
+
+use OCA\Collectives\AppInfo\Application;
+use OCP\Collaboration\Reference\RenderReferenceEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Util;
+
+class CollectivesReferenceListener implements IEventListener {
+	public function __construct() {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof RenderReferenceEvent) {
+			return;
+		}
+
+		Util::addScript(Application::APP_NAME, Application::APP_NAME . '-reference');
+	}
+}

--- a/lib/Reference/PageReferenceProvider.php
+++ b/lib/Reference/PageReferenceProvider.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace OCA\Collectives\Reference;
+
+use DateTime;
+use OC\Collaboration\Reference\LinkReferenceProvider;
+use OCA\Collectives\Model\CollectiveInfo;
+use OCA\Collectives\Service\CollectiveService;
+use OCA\Collectives\Service\PageService;
+use OCP\Collaboration\Reference\ADiscoverableReferenceProvider;
+use OCP\Collaboration\Reference\ISearchableReferenceProvider;
+use OCP\Collaboration\Reference\Reference;
+use OC\Collaboration\Reference\ReferenceManager;
+use OCA\Collectives\AppInfo\Application;
+use OCP\Collaboration\Reference\IReference;
+use OCP\Files\File;
+use OCP\IConfig;
+use OCP\IDateTimeFormatter;
+use OCP\IL10N;
+
+use OCP\IURLGenerator;
+
+class PageReferenceProvider extends ADiscoverableReferenceProvider implements ISearchableReferenceProvider {
+	private const RICH_OBJECT_TYPE = Application::APP_NAME . '_page';
+
+	private ?string $userId;
+	private IConfig $config;
+	private ReferenceManager $referenceManager;
+	private IL10N $l10n;
+	private IURLGenerator $urlGenerator;
+	private LinkReferenceProvider $linkReferenceProvider;
+	private PageService $pageService;
+	private CollectiveService $collectiveService;
+	private IDateTimeFormatter $dateTimeFormatter;
+
+	public function __construct(IConfig $config,
+								CollectiveService $collectiveService,
+								PageService $pageService,
+								IL10N $l10n,
+								IURLGenerator $urlGenerator,
+								IDateTimeFormatter $dateTimeFormatter,
+								ReferenceManager $referenceManager,
+								LinkReferenceProvider $linkReferenceProvider,
+								?string $userId) {
+		$this->userId = $userId;
+		$this->config = $config;
+		$this->referenceManager = $referenceManager;
+		$this->l10n = $l10n;
+		$this->urlGenerator = $urlGenerator;
+		$this->linkReferenceProvider = $linkReferenceProvider;
+		$this->pageService = $pageService;
+		$this->collectiveService = $collectiveService;
+		$this->dateTimeFormatter = $dateTimeFormatter;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getId(): string {
+		return Application::APP_NAME . '-ref-pages';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getTitle(): string {
+		return $this->l10n->t('Collective pages');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getOrder(): int {
+		return 10;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getIconUrl(): string {
+		return $this->urlGenerator->getAbsoluteURL(
+			$this->urlGenerator->imagePath(Application::APP_NAME, 'collectives-dark.svg')
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getSupportedSearchProviderIds(): array {
+		return ['collectives-pages'];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function matchReference(string $referenceText): bool {
+		if ($this->userId === null) {
+			return false;
+		}
+		$start = $this->urlGenerator->getAbsoluteURL('/apps/' . Application::APP_NAME);
+		$startIndex = $this->urlGenerator->getAbsoluteURL('/index.php/apps/' . Application::APP_NAME);
+
+		// link example:
+		// https://nextcloud.local/apps/collectives/supacollective/Tutos/Hacking/Spectre?fileId=14457
+		// https://nextcloud.local/apps/collectives/supacollective/Tutos/Hacking/Spectre
+		$noIndexMatch = preg_match('/^' . preg_quote($start, '/') . '\/[^\/]+\//i', $referenceText) === 1;
+		$indexMatch = preg_match('/^' . preg_quote($startIndex, '/') . '\/[^\/]+\//i', $referenceText) === 1;
+
+		return $noIndexMatch || $indexMatch;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function resolveReference(string $referenceText): ?IReference {
+		if ($this->matchReference($referenceText)) {
+			$pageInfo = $this->getPagePathFromDirectLink($referenceText);
+			if ($pageInfo !== null) {
+				// TODO should it work if the fileId GET param is not there?
+				if (isset($pageInfo['fileId'])) {
+					$pageFileId = $pageInfo['fileId'];
+					$collectiveName = $pageInfo['collectiveName'];
+					$collectives = $this->collectiveService->getCollectives($this->userId);
+					$collectives = array_filter($collectives, static function (CollectiveInfo $c) use ($collectiveName) {
+						return $c->getName() === $collectiveName;
+					});
+					if (!empty($collectives)) {
+						$collective = end($collectives);
+						$pageInfo['collective'] = $collective;
+						$collectiveFolder = $this->pageService->getCollectiveFolder($collective->getId(), $this->userId);
+						$pageFile = $collectiveFolder->getById($pageFileId);
+						if (!empty($pageFile) && isset($pageFile[0]) && $pageFile[0] instanceof File) {
+							$pageFile = $pageFile[0];
+							$pageInfo['page'] = $this->pageService->findByFile($collective->getId(), $pageFile, $this->userId);
+
+							$reference = new Reference($referenceText);
+
+							$reference->setTitle($pageInfo['page']->getEmoji() . ' ' . $pageInfo['page']->getTitle());
+
+							$description = $this->l10n->t('In collective %1$s %2$s', [$collective->getEmoji(), $collective->getName()])
+								. ' - ' . $pageInfo['page']->getFilePath();
+							$reference->setDescription($description);
+							$pageInfo['description'] = $description;
+
+							$date = new DateTime();
+							$date->setTimestamp($pageInfo['page']->getTimestamp());
+							$formattedRelativeDate = $this->dateTimeFormatter->formatTimeSpan($date);
+							$pageInfo['lastEdited'] = $this->l10n->t('Last edition %1$s', [$formattedRelativeDate]);
+
+							$imageUrl = $this->urlGenerator->getAbsoluteURL(
+								$this->urlGenerator->imagePath(Application::APP_NAME, 'page.svg')
+							);
+							$reference->setImageUrl($imageUrl);
+
+							$pageInfo['link'] = $referenceText;
+							$reference->setUrl($referenceText);
+
+							$reference->setRichObject(
+								self::RICH_OBJECT_TYPE,
+								$pageInfo,
+							);
+							return $reference;
+						}
+					}
+				}
+			}
+			// fallback to opengraph if it matches but somehow we can't resolve
+			return $this->linkReferenceProvider->resolveReference($referenceText);
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param string $url
+	 * @return array|null
+	 */
+	public function getPagePathFromDirectLink(string $url): ?array {
+		$start = $this->urlGenerator->getAbsoluteURL('/apps/' . Application::APP_NAME);
+		$startIndex = $this->urlGenerator->getAbsoluteURL('/index.php/apps/' . Application::APP_NAME);
+
+		preg_match('/^' . preg_quote($start, '/') . '\/([^\/]+)\/([^?]+)/i', $url, $matches);
+		if (!$matches || count($matches) < 3) {
+			preg_match('/^' . preg_quote($startIndex, '/') . '\/([^\/]+)\/([^?]+)/i', $url, $matches);
+		}
+		if ($matches && count($matches) > 2) {
+			$pagePath = [
+				'collectiveName' => $matches[1],
+				'pagePath' => $matches[2],
+			];
+			preg_match('/\?fileId=(\d+)$/i', $url, $matches);
+			if ($matches && count($matches) > 1) {
+				$pagePath['fileId'] = (int) $matches[1];
+			}
+			return $pagePath;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCachePrefix(string $referenceId): string {
+		return $this->userId ?? '';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCacheKey(string $referenceId): ?string {
+		return $referenceId;
+	}
+
+	/**
+	 * @param string $userId
+	 * @return void
+	 */
+	public function invalidateUserCache(string $userId): void {
+		$this->referenceManager->invalidateCache($userId);
+	}
+}

--- a/lib/Reference/PageReferenceProvider.php
+++ b/lib/Reference/PageReferenceProvider.php
@@ -138,8 +138,8 @@ class PageReferenceProvider implements IReferenceProvider {
 		}
 		if ($matches && count($matches) > 2) {
 			$pagePath = [
-				'collectiveName' => $matches[1],
-				'pagePath' => $matches[2],
+				'collectiveName' => urldecode($matches[1]),
+				'pagePath' => urldecode($matches[2]),
 			];
 			preg_match('/\?fileId=(\d+)$/i', $url, $matches);
 			if ($matches && count($matches) > 1) {

--- a/lib/Reference/PageReferenceProvider.php
+++ b/lib/Reference/PageReferenceProvider.php
@@ -3,8 +3,8 @@
 namespace OCA\Collectives\Reference;
 
 use DateTime;
+use Exception;
 use OC\Collaboration\Reference\LinkReferenceProvider;
-use OCA\Collectives\Model\CollectiveInfo;
 use OCA\Collectives\Service\CollectiveService;
 use OCA\Collectives\Service\PageService;
 use OCP\Collaboration\Reference\IReferenceProvider;
@@ -12,11 +12,11 @@ use OCP\Collaboration\Reference\Reference;
 use OC\Collaboration\Reference\ReferenceManager;
 use OCA\Collectives\AppInfo\Application;
 use OCP\Collaboration\Reference\IReference;
-use OCP\Files\File;
 use OCP\IDateTimeFormatter;
 use OCP\IL10N;
 
 use OCP\IURLGenerator;
+use Throwable;
 
 class PageReferenceProvider implements IReferenceProvider {
 	private const RICH_OBJECT_TYPE = Application::APP_NAME . '_page';
@@ -72,58 +72,53 @@ class PageReferenceProvider implements IReferenceProvider {
 	 */
 	public function resolveReference(string $referenceText): ?IReference {
 		if ($this->matchReference($referenceText)) {
-			$pageInfo = $this->getPagePathFromDirectLink($referenceText);
-			if ($pageInfo !== null) {
-				// TODO should it work if the fileId GET param is not there?
-				if (isset($pageInfo['fileId'])) {
-					$pageFileId = $pageInfo['fileId'];
-					$collectiveName = $pageInfo['collectiveName'];
-					$collectives = $this->collectiveService->getCollectives($this->userId);
-					$collectives = array_filter($collectives, static function (CollectiveInfo $c) use ($collectiveName) {
-						return $c->getName() === $collectiveName;
-					});
-					if (!empty($collectives)) {
-						$collective = end($collectives);
-						$pageInfo['collective'] = $collective;
-						$collectiveFolder = $this->pageService->getCollectiveFolder($collective->getId(), $this->userId);
-						$pageFile = $collectiveFolder->getById($pageFileId);
-						if (!empty($pageFile) && isset($pageFile[0]) && $pageFile[0] instanceof File) {
-							$pageFile = $pageFile[0];
-							$pageInfo['page'] = $this->pageService->findByFile($collective->getId(), $pageFile, $this->userId);
-
-							$reference = new Reference($referenceText);
-
-							$reference->setTitle($pageInfo['page']->getEmoji() . ' ' . $pageInfo['page']->getTitle());
-
-							$description = $this->l10n->t('In collective %1$s %2$s', [$collective->getEmoji(), $collective->getName()])
-								. ' - ' . $pageInfo['page']->getFilePath();
-							$reference->setDescription($description);
-							$pageInfo['description'] = $description;
-
-							$date = new DateTime();
-							$date->setTimestamp($pageInfo['page']->getTimestamp());
-							$formattedRelativeDate = $this->dateTimeFormatter->formatTimeSpan($date);
-							$pageInfo['lastEdited'] = $this->l10n->t('Last edition %1$s', [$formattedRelativeDate]);
-
-							$imageUrl = $this->urlGenerator->getAbsoluteURL(
-								$this->urlGenerator->imagePath(Application::APP_NAME, 'page.svg')
-							);
-							$reference->setImageUrl($imageUrl);
-
-							$pageInfo['link'] = $referenceText;
-							$reference->setUrl($referenceText);
-
-							$reference->setRichObject(
-								self::RICH_OBJECT_TYPE,
-								$pageInfo,
-							);
-							return $reference;
-						}
-					}
-				}
+			$pageReferenceInfo = $this->getPagePathFromDirectLink($referenceText);
+			// TODO should it work if the fileId GET param is not there?
+			if (!$pageReferenceInfo || !isset($pageReferenceInfo['fileId'])) {
+				// fallback to opengraph if it matches but somehow we can't resolve
+				return $this->linkReferenceProvider->resolveReference($referenceText);
 			}
-			// fallback to opengraph if it matches but somehow we can't resolve
-			return $this->linkReferenceProvider->resolveReference($referenceText);
+
+			$pageFileId = $pageReferenceInfo['fileId'];
+			$collectiveName = $pageReferenceInfo['collectiveName'];
+			try {
+				$collective = $this->collectiveService->findCollectiveByName($this->userId, $collectiveName);
+				$page = $this->pageService->findByFileId($collective->getId(), $pageFileId, $this->userId);
+			} catch (Exception | Throwable $e) {
+				// fallback to opengraph if it matches but somehow we can't resolve
+				return $this->linkReferenceProvider->resolveReference($referenceText);
+			}
+			$pageReferenceInfo['collective'] = $collective;
+			$pageReferenceInfo['page'] = $page;
+
+			$reference = new Reference($referenceText);
+			$pageEmoji = $page->getEmoji();
+			$refTitle = $pageEmoji ? $pageEmoji . ' ' . $page->getTitle() : $page->getTitle();
+			$reference->setTitle($refTitle);
+
+			$description = $this->l10n->t('In collective %1$s', [$this->collectiveService->getCollectiveNameWithEmoji($collective)])
+				. ' - ' . $page->getFilePath();
+			$reference->setDescription($description);
+			$pageReferenceInfo['description'] = $description;
+
+			$date = new DateTime();
+			$date->setTimestamp($page->getTimestamp());
+			$formattedRelativeDate = $this->dateTimeFormatter->formatTimeSpan($date);
+			$pageReferenceInfo['lastEdited'] = $this->l10n->t('Last edition %1$s', [$formattedRelativeDate]);
+
+			$imageUrl = $this->urlGenerator->getAbsoluteURL(
+				$this->urlGenerator->imagePath(Application::APP_NAME, 'page.svg')
+			);
+			$reference->setImageUrl($imageUrl);
+
+			$pageReferenceInfo['link'] = $referenceText;
+			$reference->setUrl($referenceText);
+
+			$reference->setRichObject(
+				self::RICH_OBJECT_TYPE,
+				$pageReferenceInfo,
+			);
+			return $reference;
 		}
 
 		return null;

--- a/lib/Reference/SearchablePageReferenceProvider.php
+++ b/lib/Reference/SearchablePageReferenceProvider.php
@@ -176,8 +176,8 @@ class SearchablePageReferenceProvider extends ADiscoverableReferenceProvider imp
 		}
 		if ($matches && count($matches) > 2) {
 			$pagePath = [
-				'collectiveName' => $matches[1],
-				'pagePath' => $matches[2],
+				'collectiveName' => urldecode($matches[1]),
+				'pagePath' => urldecode($matches[2]),
 			];
 			preg_match('/\?fileId=(\d+)$/i', $url, $matches);
 			if ($matches && count($matches) > 1) {

--- a/lib/Reference/SearchablePageReferenceProvider.php
+++ b/lib/Reference/SearchablePageReferenceProvider.php
@@ -7,7 +7,8 @@ use OC\Collaboration\Reference\LinkReferenceProvider;
 use OCA\Collectives\Model\CollectiveInfo;
 use OCA\Collectives\Service\CollectiveService;
 use OCA\Collectives\Service\PageService;
-use OCP\Collaboration\Reference\IReferenceProvider;
+use OCP\Collaboration\Reference\ADiscoverableReferenceProvider;
+use OCP\Collaboration\Reference\ISearchableReferenceProvider;
 use OCP\Collaboration\Reference\Reference;
 use OC\Collaboration\Reference\ReferenceManager;
 use OCA\Collectives\AppInfo\Application;
@@ -18,7 +19,7 @@ use OCP\IL10N;
 
 use OCP\IURLGenerator;
 
-class PageReferenceProvider implements IReferenceProvider {
+class SearchablePageReferenceProvider extends ADiscoverableReferenceProvider implements ISearchableReferenceProvider {
 	private const RICH_OBJECT_TYPE = Application::APP_NAME . '_page';
 
 	private ?string $userId;
@@ -46,6 +47,43 @@ class PageReferenceProvider implements IReferenceProvider {
 		$this->pageService = $pageService;
 		$this->collectiveService = $collectiveService;
 		$this->dateTimeFormatter = $dateTimeFormatter;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getId(): string {
+		return Application::APP_NAME . '-ref-pages';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getTitle(): string {
+		return $this->l10n->t('Collective pages');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getOrder(): int {
+		return 10;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getIconUrl(): string {
+		return $this->urlGenerator->getAbsoluteURL(
+			$this->urlGenerator->imagePath(Application::APP_NAME, 'collectives-dark.svg')
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getSupportedSearchProviderIds(): array {
+		return ['collectives-pages'];
 	}
 
 	/**

--- a/lib/Search/CollectiveProvider.php
+++ b/lib/Search/CollectiveProvider.php
@@ -3,6 +3,7 @@
 namespace OCA\Collectives\Search;
 
 use OCA\Collectives\Service\CollectiveHelper;
+use OCA\Collectives\Service\CollectiveService;
 use OCA\Collectives\Service\MissingDependencyException;
 use OCA\Collectives\Service\NotFoundException;
 use OCA\Collectives\Service\NotPermittedException;
@@ -20,6 +21,7 @@ class CollectiveProvider implements IProvider {
 	private IURLGenerator $urlGenerator;
 	private CollectiveHelper $collectiveHelper;
 	private IAppManager $appManager;
+	private CollectiveService $collectiveService;
 
 	/**
 	 * CollectiveProvider constructor.
@@ -32,11 +34,13 @@ class CollectiveProvider implements IProvider {
 	public function __construct(IL10N $l10n,
 								IURLGenerator $urlGenerator,
 								CollectiveHelper $collectiveHelper,
+								CollectiveService $collectiveService,
 								IAppManager $appManager) {
 		$this->l10n = $l10n;
 		$this->urlGenerator = $urlGenerator;
 		$this->collectiveHelper = $collectiveHelper;
 		$this->appManager = $appManager;
+		$this->collectiveService = $collectiveService;
 	}
 
 	/**
@@ -90,7 +94,7 @@ class CollectiveProvider implements IProvider {
 			}
 			$collectiveSearchResults[] = new SearchResultEntry(
 				'',
-				$collective->getName(),
+				$this->collectiveService->getCollectiveNameWithEmoji($collective),
 				'',
 				$this->urlGenerator->linkToRoute('collectives.start.index') . '/' . rawurlencode($collective->getName()),
 				'icon-collectives'

--- a/lib/Search/PageProvider.php
+++ b/lib/Search/PageProvider.php
@@ -2,6 +2,9 @@
 
 namespace OCA\Collectives\Search;
 
+use OCA\Collectives\AppInfo\Application;
+use OCA\Collectives\Model\CollectiveInfo;
+use OCA\Collectives\Model\PageInfo;
 use OCA\Collectives\Service\CollectiveHelper;
 use OCA\Collectives\Service\MissingDependencyException;
 use OCA\Collectives\Service\NotFoundException;
@@ -93,11 +96,13 @@ class PageProvider implements IProvider {
 			$pageInfos = $this->pageService->findByString($collective->getId(), $query->getTerm(), $user->getUID());
 			foreach ($pageInfos as $pageInfo) {
 				$pageSearchResults[] = new SearchResultEntry(
-					'',
-					$pageInfo->getTitle(),
-					str_replace('{collective}', $collective->getName(), $this->l10n->t('in Collective {collective}')),
+					$this->urlGenerator->getAbsoluteURL(
+						$this->urlGenerator->imagePath(Application::APP_NAME, 'page.svg')
+					),
+					$this->getPageTitle($pageInfo),
+					$this->l10n->t('in Collective %1$s', [$this->getCollectiveName($collective)]),
 					implode('/', array_filter([
-						$this->urlGenerator->linkToRoute('collectives.start.index'),
+						$this->urlGenerator->linkToRouteAbsolute('collectives.start.index'),
 						$this->pageService->getPageLink($collective->getName(), $pageInfo)
 					])),
 					'icon-collectives-page'
@@ -109,5 +114,29 @@ class PageProvider implements IProvider {
 			$this->getName(),
 			$pageSearchResults
 		);
+	}
+
+	/**
+	 * @param PageInfo $pageInfo
+	 * @return string
+	 */
+	private function getPageTitle(PageInfo $pageInfo): string {
+		$emoji = $pageInfo->getEmoji();
+		if ($emoji) {
+			return $emoji . ' ' . $pageInfo->getTitle();
+		}
+		return $pageInfo->getTitle();
+	}
+
+	/**
+	 * @param CollectiveInfo $collectiveInfo
+	 * @return string
+	 */
+	private function getCollectiveName(CollectiveInfo $collectiveInfo): string {
+		$emoji = $collectiveInfo->getEmoji();
+		if ($emoji) {
+			return $emoji . ' ' . $collectiveInfo->getName();
+		}
+		return $collectiveInfo->getTitle();
 	}
 }

--- a/lib/Search/PageProvider.php
+++ b/lib/Search/PageProvider.php
@@ -103,7 +103,7 @@ class PageProvider implements IProvider {
 						$this->urlGenerator->imagePath(Application::APP_NAME, 'page.svg')
 					),
 					$this->getPageTitle($pageInfo),
-					$this->l10n->t('in Collective %1$s', [$this->collectiveService->getCollectiveNameWithEmoji($collective)]),
+					$this->l10n->t('In collective %1$s', [$this->collectiveService->getCollectiveNameWithEmoji($collective)]),
 					implode('/', array_filter([
 						$this->urlGenerator->linkToRouteAbsolute('collectives.start.index'),
 						$this->pageService->getPageLink($collective->getName(), $pageInfo)

--- a/lib/Search/PageProvider.php
+++ b/lib/Search/PageProvider.php
@@ -3,9 +3,9 @@
 namespace OCA\Collectives\Search;
 
 use OCA\Collectives\AppInfo\Application;
-use OCA\Collectives\Model\CollectiveInfo;
 use OCA\Collectives\Model\PageInfo;
 use OCA\Collectives\Service\CollectiveHelper;
+use OCA\Collectives\Service\CollectiveService;
 use OCA\Collectives\Service\MissingDependencyException;
 use OCA\Collectives\Service\NotFoundException;
 use OCA\Collectives\Service\NotPermittedException;
@@ -25,6 +25,7 @@ class PageProvider implements IProvider {
 	private CollectiveHelper $collectiveHelper;
 	private PageService $pageService;
 	private IAppManager $appManager;
+	private CollectiveService $collectiveService;
 
 	/**
 	 * CollectiveProvider constructor.
@@ -38,6 +39,7 @@ class PageProvider implements IProvider {
 	public function __construct(IL10N $l10n,
 								IURLGenerator $urlGenerator,
 								CollectiveHelper $collectiveHelper,
+								CollectiveService $collectiveService,
 								PageService $pageService,
 								IAppManager $appManager) {
 		$this->l10n = $l10n;
@@ -45,6 +47,7 @@ class PageProvider implements IProvider {
 		$this->collectiveHelper = $collectiveHelper;
 		$this->pageService = $pageService;
 		$this->appManager = $appManager;
+		$this->collectiveService = $collectiveService;
 	}
 
 	/**
@@ -100,7 +103,7 @@ class PageProvider implements IProvider {
 						$this->urlGenerator->imagePath(Application::APP_NAME, 'page.svg')
 					),
 					$this->getPageTitle($pageInfo),
-					$this->l10n->t('in Collective %1$s', [$this->getCollectiveName($collective)]),
+					$this->l10n->t('in Collective %1$s', [$this->collectiveService->getCollectiveNameWithEmoji($collective)]),
 					implode('/', array_filter([
 						$this->urlGenerator->linkToRouteAbsolute('collectives.start.index'),
 						$this->pageService->getPageLink($collective->getName(), $pageInfo)
@@ -122,21 +125,8 @@ class PageProvider implements IProvider {
 	 */
 	private function getPageTitle(PageInfo $pageInfo): string {
 		$emoji = $pageInfo->getEmoji();
-		if ($emoji) {
-			return $emoji . ' ' . $pageInfo->getTitle();
-		}
-		return $pageInfo->getTitle();
-	}
-
-	/**
-	 * @param CollectiveInfo $collectiveInfo
-	 * @return string
-	 */
-	private function getCollectiveName(CollectiveInfo $collectiveInfo): string {
-		$emoji = $collectiveInfo->getEmoji();
-		if ($emoji) {
-			return $emoji . ' ' . $collectiveInfo->getName();
-		}
-		return $collectiveInfo->getTitle();
+		return $emoji
+			? $emoji . ' ' . $pageInfo->getTitle()
+			: $pageInfo->getTitle();
 	}
 }

--- a/lib/Service/CollectiveService.php
+++ b/lib/Service/CollectiveService.php
@@ -123,6 +123,36 @@ class CollectiveService extends CollectiveServiceBase {
 	}
 
 	/**
+	 * @param string $userId
+	 * @param string $name
+	 * @return CollectiveInfo
+	 * @throws MissingDependencyException
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 */
+	public function findCollectiveByName(string $userId, string $name): CollectiveInfo {
+		$collectives = $this->getCollectives($userId);
+		$collectives = array_filter($collectives, static function (CollectiveInfo $c) use ($name) {
+			return $c->getName() === $name;
+		});
+		if (empty($collectives)) {
+			throw new NotFoundException('Unable to find a collective from its name');
+		}
+		return end($collectives);
+	}
+
+	/**
+	 * @param CollectiveInfo $collectiveInfo
+	 * @return string
+	 */
+	public function getCollectiveNameWithEmoji(CollectiveInfo $collectiveInfo): string {
+		$emoji = $collectiveInfo->getEmoji();
+		return $emoji
+			? $emoji . ' ' . $collectiveInfo->getName()
+			: $collectiveInfo->getName();
+	}
+
+	/**
 	 * @param string      $userId
 	 * @param string      $userLang
 	 * @param string      $safeName

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -555,7 +555,7 @@ class PageService {
 			$pageFile = $pageFile[0];
 			return $this->findByFile($collectiveId, $pageFile, $userId);
 		}
-		throw new NotFoundException('Error getting page by file ID ' . $fileId . ' in collective ' . $collectiveId);
+		throw new NotFoundException('Failed to get page by file ID ' . $fileId . ' in collective ' . $collectiveId);
 	}
 
 	/**

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -538,6 +538,27 @@ class PageService {
 	}
 
 	/**
+	 * @param int $collectiveId
+	 * @param int $fileId
+	 * @param string $userId
+	 * @return PageInfo
+	 * @throws FilesNotFoundException
+	 * @throws InvalidPathException
+	 * @throws MissingDependencyException
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 */
+	public function findByFileId(int $collectiveId, int $fileId, string $userId): PageInfo {
+		$collectiveFolder = $this->getCollectiveFolder($collectiveId, $userId);
+		$pageFile = $collectiveFolder->getById($fileId);
+		if (!empty($pageFile) && isset($pageFile[0]) && $pageFile[0] instanceof File) {
+			$pageFile = $pageFile[0];
+			return $this->findByFile($collectiveId, $pageFile, $userId);
+		}
+		throw new NotFoundException('Error getting page by file ID ' . $fileId . ' in collective ' . $collectiveId);
+	}
+
+	/**
 	 * @param int    $collectiveId
 	 * @param int    $parentId
 	 * @param int    $id

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@nextcloud/router": "^2.0.1",
         "@nextcloud/text": "^26.0.0-alpha.6",
         "@nextcloud/vue": "^7.6.1",
+        "@nextcloud/vue-richtext": "^2.0.4",
         "debounce": "^1.2.1",
         "escape-html": "^1.0.3",
         "sortablejs": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@nextcloud/router": "^2.0.1",
     "@nextcloud/text": "^26.0.0-alpha.6",
     "@nextcloud/vue": "^7.6.1",
+    "@nextcloud/vue-richtext": "^2.0.4",
     "debounce": "^1.2.1",
     "escape-html": "^1.0.3",
     "sortablejs": "^1.15.0",

--- a/src/reference.js
+++ b/src/reference.js
@@ -1,0 +1,40 @@
+/**
+ * @copyright Copyright (c) 2023 Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { registerWidget } from '@nextcloud/vue-richtext'
+import Vue from 'vue'
+import PageReferenceWidget from './views/PageReferenceWidget.vue'
+
+Vue.prototype.t = t
+Vue.prototype.n = n
+Vue.prototype.OC = OC
+Vue.prototype.OCA = OCA
+
+registerWidget('collectives_page', (el, { richObjectType, richObject, accessible }) => {
+	const Widget = Vue.extend(PageReferenceWidget)
+	new Widget({
+		propsData: {
+			richObjectType,
+			richObject,
+			accessible,
+		},
+	}).$mount(el)
+})

--- a/src/views/PageReferenceWidget.vue
+++ b/src/views/PageReferenceWidget.vue
@@ -1,0 +1,117 @@
+<!--
+  - @copyright Copyright (c) 2022 Julien Veyssier <eneiluj@posteo.net>
+  -
+  - @author 2022 Julien Veyssier <eneiluj@posteo.net>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+	<div v-if="richObject" class="collective-page">
+		<div class="collective-page--image">
+			<span v-if="emoji"
+				class="page-emoji">
+				{{ emoji }}
+			</span>
+			<CollectivesIcon v-else
+				:size="50" />
+		</div>
+		<div class="collective-page--info">
+			<div class="line">
+				<strong>
+					<a :href="richObject.link" target="_blank">
+						{{ richObject.page.title }}
+					</a>
+				</strong>
+			</div>
+			<div class="description">
+				{{ richObject.description }}
+			</div>
+			<div class="last-edited">
+				{{ richObject.lastEdited }}
+				<NcUserBubble :user="richObject.page.lastUserId"
+					:display-name="richObject.page.lastUserDisplayName" />
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import CollectivesIcon from '../components/Icon/CollectivesIcon.vue'
+import NcUserBubble from '@nextcloud/vue/dist/Components/NcUserBubble.js'
+
+export default {
+	name: 'PageReferenceWidget',
+
+	components: {
+		CollectivesIcon,
+		NcUserBubble,
+	},
+
+	props: {
+		richObjectType: {
+			type: String,
+			default: '',
+		},
+		richObject: {
+			type: Object,
+			default: null,
+		},
+		accessible: {
+			type: Boolean,
+			default: true,
+		},
+	},
+
+	computed: {
+		emoji() {
+			return this.richObject.page.emoji ?? this.richObject.collective.emoji ?? null
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.collective-page {
+	width: 100%;
+	white-space: normal;
+	padding: 12px;
+	display: flex;
+
+	a {
+		padding: 0 !important;
+		&:not(:hover) {
+			text-decoration: unset !important;
+		}
+	}
+
+	&--image {
+		margin-right: 12px;
+		display: flex;
+		align-items: center;
+		.page-emoji {
+			display: flex;
+			align-items: center;
+			height: 50px;
+			font-size: 50px;
+		}
+	}
+
+	.spacer {
+		flex-grow: 1;
+	}
+}
+</style>

--- a/src/views/PageReferenceWidget.vue
+++ b/src/views/PageReferenceWidget.vue
@@ -26,7 +26,7 @@
 				class="page-emoji">
 				{{ emoji }}
 			</span>
-			<CollectivesIcon v-else
+			<PageIcon v-else
 				:size="50" />
 		</div>
 		<div class="collective-page--info">
@@ -50,14 +50,14 @@
 </template>
 
 <script>
-import CollectivesIcon from '../components/Icon/CollectivesIcon.vue'
+import PageIcon from '../components/Icon/PageIcon.vue'
 import NcUserBubble from '@nextcloud/vue/dist/Components/NcUserBubble.js'
 
 export default {
 	name: 'PageReferenceWidget',
 
 	components: {
-		CollectivesIcon,
+		PageIcon,
 		NcUserBubble,
 	},
 
@@ -78,7 +78,7 @@ export default {
 
 	computed: {
 		emoji() {
-			return this.richObject.page.emoji ?? this.richObject.collective.emoji ?? null
+			return this.richObject.page.emoji
 		},
 	},
 }

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,42 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master@">
+<files psalm-version="5.6.0@e784128902dfe01d489c4123d69918a9f3c1eac5">
+  <file src="lib/AppInfo/Application.php">
+    <MissingDependency>
+      <code>PageReferenceProvider</code>
+      <code>SearchablePageReferenceProvider</code>
+    </MissingDependency>
+    <UndefinedClass>
+      <code>RenderReferenceEvent</code>
+    </UndefinedClass>
+    <UndefinedInterfaceMethod>
+      <code>registerReferenceProvider</code>
+      <code>registerReferenceProvider</code>
+    </UndefinedInterfaceMethod>
+  </file>
   <file src="lib/Fs/UserFolderHelper.php">
-    <UndefinedClass occurrences="2">
+    <UndefinedClass>
       <code>$e</code>
       <code>NoUserException</code>
     </UndefinedClass>
   </file>
+  <file src="lib/Listeners/CollectivesReferenceListener.php">
+    <MissingTemplateParam>
+      <code>IEventListener</code>
+    </MissingTemplateParam>
+    <UndefinedClass>
+      <code>RenderReferenceEvent</code>
+    </UndefinedClass>
+  </file>
   <file src="lib/Mount/CollectiveFolderManager.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$maskedStorage</code>
     </InvalidArgument>
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>LazyFolder</code>
     </UndefinedClass>
   </file>
   <file src="lib/Mount/CollectiveStorage.php">
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$storage</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="lib/Mount/NoExcludePropagatorStorageWrapper.php">
-    <ConstructorSignatureMismatch occurrences="1">
+    <ConstructorSignatureMismatch>
       <code>NoExcludePropagatorStorageWrapper</code>
     </ConstructorSignatureMismatch>
   </file>
+  <file src="lib/Reference/PageReferenceProvider.php">
+    <UndefinedClass>
+      <code>IReferenceProvider</code>
+    </UndefinedClass>
+  </file>
+  <file src="lib/Reference/SearchablePageReferenceProvider.php">
+    <UndefinedClass>
+      <code>ADiscoverableReferenceProvider</code>
+      <code>ISearchableReferenceProvider</code>
+    </UndefinedClass>
+  </file>
   <file src="lib/Service/CircleHelper.php">
-    <UndefinedClass occurrences="2">
+    <UndefinedClass>
       <code>$e</code>
       <code>\ArtificialOwl\MySmallPhpTools\Exceptions\InvalidItemException</code>
     </UndefinedClass>
   </file>
   <file src="lib/Service/CollectiveService.php">
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>File</code>
     </UndefinedClass>
   </file>
   <file src="lib/Service/PageService.php">
-    <UndefinedClass occurrences="4">
+    <UndefinedClass>
       <code>$this-&gt;pushQueue</code>
       <code>?IQueue</code>
       <code>IQueue</code>
@@ -44,7 +76,7 @@
     </UndefinedClass>
   </file>
   <file src="lib/Versions/VersionsBackend.php">
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>getDirectoryListing</code>
     </UndefinedInterfaceMethod>
   </file>

--- a/webpack.js
+++ b/webpack.js
@@ -2,5 +2,6 @@ const path = require('path')
 const webpackConfig = require('@nextcloud/webpack-vue-config')
 
 webpackConfig.entry['files'] = path.join(__dirname, 'src', 'files.js')
+webpackConfig.entry['reference'] = path.join(__dirname, 'src', 'reference.js')
 
 module.exports = webpackConfig


### PR DESCRIPTION
closes #509 

Hey how. Here is a reference provider using the existing search provider.
It comes with a basic reference widget.

Not sure about the `PageReferenceProvider::resolveReference` implementation which might be a bit brutal but I didn't find a simpler way to get the page and the collective entities.

Also not sure about the widget content. Feel free to completely change it.

I took the liberty to display the emojis in the search results which I find nicer but that's just a suggestion. Feel free to get rid of this.

One more doubt: I didn't find an easy way to resolve the link without the file ID (when the fileId GET param is not there). Should we make it possible to resolve without the page file ID?

### The widget

![image](https://user-images.githubusercontent.com/11291457/215856108-180c025a-dadf-4626-a788-d3eb272fbac9.png)

### The link picker provider in action

![image](https://user-images.githubusercontent.com/11291457/215856276-0119c2cb-bcfd-4df6-82d9-45d7756ab897.png)
