### PR TITLE
Reuse the circle we already have to get the level for the user

### DIFF
--- a/lib/Service/CollectiveHelper.php
+++ b/lib/Service/CollectiveHelper.php
@@ -47,14 +47,15 @@ class CollectiveHelper {
 		$collectives = $this->collectiveMapper->findByCircleIds($cids);
 		foreach ($collectives as $c) {
 			$cid = $c->getCircleId();
-			$level = $getLevel ? $this->circleHelper->getLevel($cid, $userId): 0;
+			$circle = $circles[$cid];
+			$level = $getLevel ? $circle->getInitiator()->getLevel(): 0;
 			$userPageOrder = null;
 			if ($getUserSettings) {
 				// TODO: merge queries for collective and user settings into one?
 				$userPageOrder = $this->collectiveUserSettingsMapper->getPageOrder($c->getId(), $userId) ?? Collective::defaultPageOrder;
 			}
 			$collectiveInfos[] = new CollectiveInfo($c,
-				$circles[$cid]->getSanitizedName(),
+				$circle->getSanitizedName(),
 				$level,
 				null,
 				false,


### PR DESCRIPTION
### 📝 Summary

Instead of getting the circle power level by re-querying each circle from the database, simply reuse the circle we already have

this saves having to query N circles when getting collectives for user

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
