### PR TITLE
fix: Adapt return type for Nextcloud 26

### DIFF
--- a/lib/ACL/ACLStorageWrapper.php
+++ b/lib/ACL/ACLStorageWrapper.php
@@ -177,7 +177,7 @@ class ACLStorageWrapper extends Wrapper {
 		return parent::filetype($path);
 	}
 
-	public function filesize($path) {
+	public function filesize($path): false|int|float {
 		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
 			return false;
 		}

--- a/lib/ACL/ACLStorageWrapper.php
+++ b/lib/ACL/ACLStorageWrapper.php
@@ -10,7 +10,7 @@ use OC\Files\Cache\Wrapper\CacheWrapper;
 use OC\Files\Storage\Wrapper\Wrapper;
 use OCP\Constants;
 
-class ACLStorageWrapper extends Wrapper {
+abstract class ACLStorageWrapper extends Wrapper {
 	private int $permissions;
 	private bool $inShare;
 
@@ -175,13 +175,6 @@ class ACLStorageWrapper extends Wrapper {
 			return false;
 		}
 		return parent::filetype($path);
-	}
-
-	public function filesize($path): false|int|float {
-		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
-			return false;
-		}
-		return parent::filesize($path);
 	}
 
 	public function file_exists($path): bool {

--- a/lib/ACL/ACLStorageWrapper25.php
+++ b/lib/ACL/ACLStorageWrapper25.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Collectives\ACL;
+
+use OC\Files\Cache\Cache;
+use OC\Files\Cache\Scanner;
+use OC\Files\Cache\Wrapper\CacheWrapper;
+use OC\Files\Storage\Wrapper\Wrapper;
+use OCP\Constants;
+
+class ACLStorageWrapper25 extends ACLStorageWrapper {
+	public function filesize($path) {
+		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
+			return false;
+		}
+		return parent::filesize($path);
+	}
+}

--- a/lib/ACL/ACLStorageWrapper25.php
+++ b/lib/ACL/ACLStorageWrapper25.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace OCA\Collectives\ACL;
 
-use OC\Files\Cache\Cache;
-use OC\Files\Cache\Scanner;
-use OC\Files\Cache\Wrapper\CacheWrapper;
-use OC\Files\Storage\Wrapper\Wrapper;
 use OCP\Constants;
 
 class ACLStorageWrapper25 extends ACLStorageWrapper {

--- a/lib/ACL/ACLStorageWrapper26.php
+++ b/lib/ACL/ACLStorageWrapper26.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Collectives\ACL;
+
+use OCP\Constants;
+
+class ACLStorageWrapper26 extends ACLStorageWrapper {
+	/** @psalm-suppress ParseError */
+	public function filesize($path): float|false|int {
+		if (!$this->checkPermissions(Constants::PERMISSION_READ)) {
+			return false;
+		}
+		return parent::filesize($path);
+	}
+}

--- a/lib/Mount/CollectiveFolderManager.php
+++ b/lib/Mount/CollectiveFolderManager.php
@@ -5,7 +5,8 @@ namespace OCA\Collectives\Mount;
 use OC\Files\Node\LazyFolder;
 use OC\Files\Storage\Wrapper\Jail;
 use OC\Files\Storage\Wrapper\PermissionsMask;
-use OCA\Collectives\ACL\ACLStorageWrapper;
+use OCA\Collectives\ACL\ACLStorageWrapper26;
+use OCA\Collectives\ACL\ACLStorageWrapper25;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -140,11 +141,21 @@ class CollectiveFolderManager {
 		// apply acl before jail
 		if ($user) {
 			$inShare = $this->getCurrentUID() === null || $this->getCurrentUID() !== $user->getUID();
-			$storage = new ACLStorageWrapper([
-				'storage' => $storage,
-				'permissions' => $permissions,
-				'in_share' => $inShare
-			]);
+			[$major, $minor, $micro] = \OCP\Util::getVersion();
+			if ($major >= 26) {
+				/** @psalm-suppress UndefinedClass */
+				$storage = new ACLStorageWrapper26([
+					'storage' => $storage,
+					'permissions' => $permissions,
+					'in_share' => $inShare
+				]);
+			} else {
+				$storage = new ACLStorageWrapper25([
+					'storage' => $storage,
+					'permissions' => $permissions,
+					'in_share' => $inShare
+				]);
+			}
 			$cacheEntry['permissions'] &= $permissions;
 		}
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,6 +13,7 @@
     <projectFiles>
         <directory name="lib" />
         <ignoreFiles>
+            <file name="lib/ACL/ACLStorageWrapper26.php" />
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>

--- a/tests/Unit/ACL/ACLStorageWrapperTest.php
+++ b/tests/Unit/ACL/ACLStorageWrapperTest.php
@@ -6,6 +6,8 @@ namespace Unit\ACL;
 
 use OC\Files\Storage\Temporary;
 use OCA\Collectives\ACL\ACLStorageWrapper;
+use OCA\Collectives\ACL\ACLStorageWrapper25;
+use OCA\Collectives\ACL\ACLStorageWrapper26;
 use OCP\Constants;
 use OCP\Files\Storage\IStorage;
 use OCP\IDBConnection;
@@ -27,7 +29,7 @@ class ACLStorageWrapperTest extends TestCase {
 	public function testNoReadImpliesNothing(): void {
 		$this->source->mkdir('foo');
 
-		$storage = new ACLStorageWrapper([
+		$storage = $this->createStorage([
 			'storage' => $this->source,
 			'permissions' => Constants::PERMISSION_ALL - Constants::PERMISSION_READ,
 			'in_share' => false,
@@ -42,7 +44,7 @@ class ACLStorageWrapperTest extends TestCase {
 	public function testInShareWithoutSharingPermissions(): void {
 		$this->source->mkdir('foo');
 
-		$storage = new ACLStorageWrapper([
+		$storage = $this->createStorage([
 			'storage' => $this->source,
 			'permissions' => Constants::PERMISSION_ALL - Constants::PERMISSION_SHARE,
 			'in_share' => true,
@@ -56,7 +58,7 @@ class ACLStorageWrapperTest extends TestCase {
 		$this->source->mkdir('foo');
 		$this->source->touch('file1');
 
-		$storage = new ACLStorageWrapper([
+		$storage = $this->createStorage([
 			'storage' => $this->source,
 			'permissions' => Constants::PERMISSION_READ,
 			'in_share' => false,
@@ -65,12 +67,22 @@ class ACLStorageWrapperTest extends TestCase {
 		$this->assertFalse($storage->rename('file1', 'foo/file1'));
 
 
-		$storage = new ACLStorageWrapper([
+		$storage = $this->createStorage([
 			'storage' => $this->source,
 			'permissions' => Constants::PERMISSION_ALL,
 			'in_share' => false,
 		]);
 
 		$this->assertTrue($storage->rename('file1', 'foo/file1'));
+	}
+
+	private function createStorage($options): ACLStorageWrapper {
+		[$major, $minor, $micro] = \OCP\Util::getVersion();
+		if ($major >= 26) {
+			/** @psalm-suppress UndefinedClass */
+			return new ACLStorageWrapper26($options);
+		} else {
+			return new ACLStorageWrapper25($options);
+		}
 	}
 }


### PR DESCRIPTION
Changed in https://github.com/nextcloud/server/pull/36120

Should still be compatible with 25 as adding the return type on the child class is ok if none is there on the parent.