### PR TITLE
fix: Prevent empty additional pages added when printing

### DIFF
--- a/src/views/CollectivePrintView.vue
+++ b/src/views/CollectivePrintView.vue
@@ -42,6 +42,11 @@ export default {
 
 <style>
 @media print {
+	/* Shrink to body to prevent empty pages */
+	body {
+		height: fit-content;
+	}
+
 	#content-vue {
 		position: static;
 		overflow: visible;


### PR DESCRIPTION
### 📝 Summary
Currently an additional page is printed because of the height setting of the body tag,
this is fixed by setting the body height to fit the content.

#### 🖼️ Screenshots
See page number(s):

🏚️ Before | 🏡 After
---|---
![two pages are printed, one empty](https://user-images.githubusercontent.com/1855448/218146714-9091d574-0691-4005-9fa2-ce747aabcaf9.png) | ![only one page is printed](https://user-images.githubusercontent.com/1855448/218146924-09ce9f3b-40f9-4647-b114-ea7f6c3ddb2f.png)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
