### PR TITLE
fix(cypress): selector for mention autocompletion

### DIFF
--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -227,7 +227,7 @@ describe('Page', function() {
 			cy.getEditor()
 				.should('be.visible')
 				.type('@admi')
-			cy.get('.tippy-content > .items')
+			cy.get('.tippy-content')
 				.contains('admin')
 				.click()
 


### PR DESCRIPTION
* Fixes CI failures such as https://github.com/nextcloud/collectives/actions/runs/4103191125/jobs/7077067180
  (Please note that the retries fail for a different reason)

#### 🖼️ Screenshots

![Page -- Editing a page -- Supports page content editing and switching to read mode (failed)](https://user-images.githubusercontent.com/97337118/218152225-ac4c5cbf-2258-44ba-81a2-1181926b057c.png)


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required as this is a fix in tests
