### PR TITLE
Update engines workflow for prevent deprecation warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,13 @@ updates:
   labels:
   - 3. to review
   - dependencies
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  labels:
+  - 3. to review
+  - dependencies

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -107,7 +107,7 @@ jobs:
         run: composer i --no-dev
 
       - name: Read package.json node and npm engines version
-        uses: skjnldsv/read-package-engines-version-actions@v1.2
+        uses: skjnldsv/read-package-engines-version-actions@v2
         id: versions
         with:
           path: apps/${{ env.APP_NAME }}


### PR DESCRIPTION
### 📝 Summary
Update engines workflow to v2 to prevent node 12 deprecation warnings.
And let Dependabot update the workflows.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
