### PR TITLE
Readonly view fixes in page titlebar

### DIFF
--- a/cypress/e2e/collective-readonly.spec.js
+++ b/cypress/e2e/collective-readonly.spec.js
@@ -32,9 +32,10 @@ describe('Read-only collective', function() {
 	})
 
 	describe('in read-only collective', function() {
-		before(function() {
+		beforeEach(function() {
 			cy.login('bob', { route: '/apps/collectives/PermissionCollective/SecondPage' })
 		})
+
 		it('not able to edit collective', function() {
 			cy.get('#titleform input').should('have.attr', 'disabled')
 			cy.get('button.titleform-button').should('not.exist')
@@ -43,6 +44,13 @@ describe('Read-only collective', function() {
 				.should('not.exist')
 			cy.getEditor()
 				.should('not.exist')
+		})
+
+		it('actions menu with outline toggle is there', function() {
+			cy.get('#titleform button.action-item__menutoggle')
+				.click()
+			cy.get('button.action-button')
+				.contains('Show outline')
 		})
 	})
 })

--- a/src/components/Page.vue
+++ b/src/components/Page.vue
@@ -3,12 +3,15 @@
 		<h1 id="titleform" class="page-title">
 			<div class="page-title-icon"
 				:class="{ 'mobile': isMobile }">
+				<!-- Landing page: collective emoji or CollectivesIcon -->
 				<div v-if="landingPage && currentCollective.emoji">
 					{{ currentCollective.emoji }}
 				</div>
 				<CollectivesIcon v-else-if="landingPage" :size="pageTitleIconSize" fill-color="var(--color-text-maxcontrast)" />
 				<PageTemplateIcon v-else-if="isTemplatePage" :size="pageTitleIconSize" fill-color="var(--color-text-maxcontrast)" />
-				<NcEmojiPicker v-else
+
+				<!-- Emoji picker if editable -->
+				<NcEmojiPicker v-else-if="currentCollectiveCanEdit"
 					ref="page-emoji-picker"
 					:show-preview="true"
 					@select="setPageEmoji">
@@ -32,6 +35,17 @@
 						</template>
 					</NcButton>
 				</NcEmojiPicker>
+
+				<!-- Page emoji or PageIcon if not editable -->
+				<template v-else>
+					<div v-if="currentPage.emoji">
+						{{ currentPage.emoji }}
+					</div>
+					<EmoticonOutlineIcon v-else
+						class="emoji-picker-emoticon"
+						:size="pageTitleIconSize"
+						fill-color="var(--color-text-maxcontrast)" />
+				</template>
 			</div>
 			<form @submit.prevent="focusEditor()">
 				<input v-if="landingPage"

--- a/src/components/Page.vue
+++ b/src/components/Page.vue
@@ -1,6 +1,7 @@
 <template>
 	<div>
 		<h1 id="titleform" class="page-title">
+			<!-- Page emoji or icon -->
 			<div class="page-title-icon"
 				:class="{ 'mobile': isMobile }">
 				<!-- Landing page: collective emoji or CollectivesIcon -->
@@ -47,6 +48,8 @@
 						fill-color="var(--color-text-maxcontrast)" />
 				</template>
 			</div>
+
+			<!-- Page title -->
 			<form @submit.prevent="focusEditor()">
 				<input v-if="landingPage"
 					ref="landingPageTitle"
@@ -73,14 +76,17 @@
 					:disabled="!currentCollectiveCanEdit"
 					@blur="renamePage()">
 			</form>
+
+			<!-- Edit button if editable -->
 			<EditButton v-if="currentCollectiveCanEdit"
 				:edit-mode="editMode"
 				:loading="titleFormButtonIsLoading"
 				:mobile="isMobile"
 				class="edit-button"
 				@click="editMode ? stopEdit() : startEdit()" />
-			<PageActionMenu v-if="currentCollectiveCanEdit"
-				:show-files-link="!isPublic"
+
+			<!-- Actions menu -->
+			<PageActionMenu :show-files-link="!isPublic"
 				:page-id="currentPage.id"
 				:parent-id="currentPage.parentId"
 				:timestamp="currentPage.timestamp"
@@ -88,6 +94,8 @@
 				:last-user-display-name="currentPage.lastUserDisplayName"
 				:is-landing-page="landingPage"
 				:is-template="isTemplatePage" />
+
+			<!-- Sidebar toggle -->
 			<NcActions v-if="!showing('sidebar') && !isMobile">
 				<NcActionButton icon="icon-menu-sidebar"
 					:aria-label="t('collectives', 'Open page sidebar')"

--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -33,7 +33,7 @@
 				:close-after-click="true">
 				{{ t('collectives', 'Show in Files') }}
 			</NcActionLink>
-			<NcActionButton v-if="!isTemplate && !isLandingPage"
+			<NcActionButton v-if="currentCollectiveCanEdit && !isTemplate && !isLandingPage"
 				:close-after-click="true"
 				@click.native="show('details')"
 				@click="gotoPageEmojiPicker">
@@ -42,7 +42,7 @@
 				</template>
 				{{ setEmojiString }}
 			</NcActionButton>
-			<NcActionButton v-if="!isTemplate"
+			<NcActionButton v-if="currentCollectiveCanEdit && !isTemplate"
 				:close-after-click="true"
 				class="action-button-template"
 				@click.native="show('details')"
@@ -52,7 +52,7 @@
 				</template>
 				{{ editTemplateString }}
 			</NcActionButton>
-			<NcActionButton v-if="!isLandingPage"
+			<NcActionButton v-if="currentCollectiveCanEdit && !isLandingPage"
 				:close-after-click="true"
 				@click="onOpenMoveModal">
 				<template #icon>
@@ -60,7 +60,7 @@
 				</template>
 				{{ t('collectives', 'Move page') }}
 			</NcActionButton>
-			<NcActionButton v-if="!isLandingPage"
+			<NcActionButton v-if="currentCollectiveCanEdit && !isLandingPage"
 				:close-after-click="true"
 				:disabled="hasSubpages"
 				@click="deletePage(parentId, pageId)">
@@ -172,6 +172,7 @@ export default {
 	computed: {
 		...mapGetters([
 			'currentCollective',
+			'currentCollectiveCanEdit',
 			'loading',
 			'pagesTreeWalk',
 			'showing',


### PR DESCRIPTION
### 📝 Summary

* Don't load emoji picker if collective is readonly
* Show stripped-down page actions menu in readonly mode
* Resolves: #559
