### PR TITLE
Cypress: Refactor link handling tests

### DIFF
--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -175,7 +175,7 @@ describe('Page', function() {
 				.should('not.have.attr', 'disabled')
 			cy.get('#titleform input.title')
 				.type('{selectAll}New page from Template{enter}')
-			cy.getEditor()
+			cy.getEditor(Cypress.config('defaultCommandTimeout') * 2)
 				.should('be.visible')
 				.contains('This is going to be our template.')
 			cy.get('.app-content-list-item').eq(1)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -218,6 +218,11 @@ Cypress.Commands.add('seedPage', (name, parentFilePath, parentFileName) => {
 					&& p.fileName === parentFileName
 			}).id
 			await app.$store.dispatch(NEW_PAGE, { title: name, pagePath: name, parentId })
+			// Return pageId of created page
+			return app.$store.state.pages.pages.find(function(p) {
+				return p.parentId === parentId
+					&& p.title === name
+			}).id
 		})
 })
 


### PR DESCRIPTION
Make sure that the search part of URLs matches the expected value.
