### PR TITLE
Improve link handling

### DIFF
--- a/cypress/e2e/pages-links.spec.js
+++ b/cypress/e2e/pages-links.spec.js
@@ -24,20 +24,22 @@
  *  Tests for basic Page functionality.
  */
 
-let imageId
-let textId
-let targetPageId
-const sourceUrl = new URL(`${Cypress.env('baseUrl')}/index.php/apps/collectives/Link%20Testing/Link%20Source`)
+const baseUrl = Cypress.env('baseUrl')
+const sourceUrl = new URL(`${baseUrl}/index.php/apps/collectives/Link%20Testing/Link%20Source`)
+let imageId, textId
+let anotherCollectiveFirstPageId, linkTargetPageId
 
 describe('Page', function() {
 	before(function() {
 		cy.login('bob', { route: '/apps/collectives' })
 		cy.deleteAndSeedCollective('Another Collective')
 		cy.seedPage('First Page', '', 'Readme.md').then((id) => {
-			targetPageId = id
+			anotherCollectiveFirstPageId = id
 		})
 		cy.deleteAndSeedCollective('Link Testing')
-		cy.seedPage('Link Target', '', 'Readme.md')
+		cy.seedPage('Link Target', '', 'Readme.md').then((id) => {
+			linkTargetPageId = id
+		})
 		cy.seedPageContent('Link%20Testing/Link%20Target.md', 'Some content')
 		cy.seedPage('Link Source', '', 'Readme.md')
 		cy.uploadFile('test.md', 'text/markdown').then((id) => {
@@ -50,19 +52,25 @@ describe('Page', function() {
 			cy.seedPageContent('Link%20Testing/Link%20Source.md', `
 ## Links supposed to open in viewer
 
-* Relative link to image in Nextcloud: [image](//test.png?fileId=${imageId})
-* Relative link to text file in Nextcloud: [test.md](//test.md?fileId=${textId})
+* Absolute path to image in Nextcloud: [image](//test.png?fileId=${imageId})
+* Absolute path to text file in Nextcloud: [test.md](//test.md?fileId=${textId})
 
 ## Links supposed to open in same window
 
-* Link to page in this collective: [Link Target](${Cypress.env('baseUrl')}/index.php/apps/collectives/Link%20Testing/Link%20Target)
-* Link to page in other collective: [Another Collective/First Page](${Cypress.env('baseUrl')}/index.php/apps/collectives/Another%20Collective/First%20Page?fileId=${targetPageId})
+* URL to page in this collective: [Link Target](${baseUrl}/index.php/apps/collectives/Link%20Testing/Link%20Target)
+* Absolute path to page in this collective:  [Link Target](/index.php/apps/collectives/Link%20Testing/Link%20Target)
+* Relative path to page in this collective with fileId:  [Link Target](./Link%20Target?fileId=${linkTargetPageId})
+* Relative path to page in this collective without fileId:  [Link Target](./Link%20Target)
+
+* URL to page in other collective with fileId: [Another Collective/First Page](${baseUrl}/index.php/apps/collectives/Another%20Collective/First%20Page?fileId=${anotherCollectiveFirstPageId})
+* Absolute path to page in other collective without fileId: [Another Collective/First Page](/index.php/apps/collectives/Another%20Collective/First%20Page)
 
 ## Links supposed to open in new window
 
-* Absolute link to another app in Nextcloud: [Contacts absolute](${Cypress.env('baseUrl')}/index.php/apps/contacts)
-* Relative link to another app in Nextcloud: [Contacts relative](/index.php/apps/contacts)
-* Link to external page: [example.org](http://example.org/)
+* URL to another app in Nextcloud: [Contacts](${baseUrl}/index.php/apps/contacts)
+* Absolute path to another app in Nextcloud: [Contacts](/index.php/apps/contacts)
+* URL to a page in Collectives on another instance: [Foreign Page](https://cloud.example.org/apps/collectives/Foreign%20Collective/Foreign%20Page?fileId=123)
+* URL to external website: [example.org](http://example.org/)
 			`)
 		})
 	})
@@ -90,6 +98,7 @@ describe('Page', function() {
 	// Expected to open file in viewer and stay on same page
 	const testLinkToViewer = function(href, { fileName, viewerFileElement, edit = false }) {
 		clickLink(href, edit)
+
 		cy.location().should((loc) => {
 			expect(loc.pathname).to.eq(sourceUrl.pathname)
 			expect(loc.search).to.eq(sourceUrl.search)
@@ -102,92 +111,131 @@ describe('Page', function() {
 	}
 
 	// Expected to open in same tab
-	const testLinkToSameTab = function(href, { edit = false, isPublic = false, keepRelative = false } = {}) {
-		if (keepRelative) {
-			clickLink(href, edit)
-			href = `${Cypress.env('baseUrl')}${href}`
-		} else {
-			href = `${Cypress.env('baseUrl')}${href}`
-			clickLink(href, edit)
-		}
+	const testLinkToSameTab = function(href, { edit = false, isPublic = false } = {}) {
+		clickLink(href, edit)
 
-		const url = new URL(href)
-		const encodedCollectiveName = encodeURIComponent('Link Testing')
-		const pathname = isPublic
-			? url.pathname.replace(`/${encodedCollectiveName}`, `/p/\\w+/${encodedCollectiveName}`)
-			: url.pathname
-		cy.location().should((loc) => {
-			expect(loc.pathname).to.match(new RegExp(`^${pathname}$`))
-			expect(loc.search).to.eq(url.search)
+		cy.url().then((newBaseUrl) => {
+			const url = new URL(href, newBaseUrl)
+			const encodedCollectiveName = encodeURIComponent('Link Testing')
+			const pathname = isPublic
+				? url.pathname.replace(`/${encodedCollectiveName}`, `/p/\\w+/${encodedCollectiveName}`)
+				: url.pathname
+			cy.location().should((loc) => {
+				expect(loc.pathname).to.match(new RegExp(`^${pathname}$`))
+				expect(loc.search).to.eq(url.search)
+			})
 		})
 
 		cy.go('back')
 	}
 
 	// Expected to open in new tab
-	const testLinkToNewTab = function(href, { edit = false, isPublic = false, keepRelative = false, isAbsolute = false } = {}) {
+	const testLinkToNewTab = function(href, { edit = false, isPublic = false } = {}) {
 		let openStub = null
 		cy.window().then(win => {
 			openStub = cy.stub(win, 'open').as('open')
 		})
-		if (keepRelative || isAbsolute) {
-			clickLink(href, edit)
-		} else {
-			href = `${Cypress.env('baseUrl')}${href}`
-			clickLink(href, edit)
-		}
-		cy.get('@open')
-			.should('be.calledWith', href)
-			.then(() => {
-				openStub.restore()
-			})
+		clickLink(href, edit)
 
-		const encodedCollectiveName = encodeURIComponent('Link Testing')
-		const pathname = isPublic
-			? sourceUrl.pathname.replace(`/${encodedCollectiveName}`, `/p/\\w+/${encodedCollectiveName}`)
-			: sourceUrl.pathname
-		cy.location().should((loc) => {
-			expect(loc.pathname).to.match(new RegExp(`^${pathname}$`))
-			expect(loc.search).to.eq(sourceUrl.search)
+		cy.url().then((newBaseUrl) => {
+			const url = new URL(href, newBaseUrl)
+			// Text always calls full URLs
+			const calledUrl = edit
+				? url.href
+				: href
+			cy.get('@open')
+				.should('be.calledWith', calledUrl)
+				.then(() => {
+					openStub.restore()
+				})
+
+			const encodedCollectiveName = encodeURIComponent('Link Testing')
+			const pathname = isPublic
+				? sourceUrl.pathname.replace(`/${encodedCollectiveName}`, `/p/\\w+/${encodedCollectiveName}`)
+				: sourceUrl.pathname
+			cy.location().should((loc) => {
+				expect(loc.pathname).to.match(new RegExp(`^${pathname}$`))
+				expect(loc.search).to.eq(sourceUrl.search)
+			})
 		})
 	}
 
-	describe('Link handling internal', function() {
-		it('Opens link to image in Nextcloud in viewer', function() {
+	describe('Link handling to viewer', function() {
+		it('Opens link with absolute path to image in Nextcloud in viewer', function() {
 			const href = `/index.php/apps/files/?dir=/&openfile=${imageId}#relPath=//test.png`
 			testLinkToViewer(href, { fileName: 'test.png', viewerFileElement: 'img' })
 			testLinkToViewer(href, { fileName: 'test.png', viewerFileElement: 'img', edit: true })
 		})
-		it('Opens link to text file in Nextcloud in viewer', function() {
+		it('Opens link with absolute path to text file in Nextcloud in viewer', function() {
 			const href = `/index.php/apps/files/?dir=/&openfile=${textId}#relPath=//test.md`
 			testLinkToViewer(href, { fileName: 'test.md', viewerFileElement: '[data-text-el="editor-container"]' })
-			testLinkToViewer(href, { fileName: 'test.md', viewerFileElement: '[data-text-el="editor-container"]', edit: true })
+			testLinkToViewer(href, {
+				fileName: 'test.md',
+				viewerFileElement: '[data-text-el="editor-container"]',
+				edit: true,
+			})
 		})
-		it('Opens link to page in this collective in same/new tab depending on view/edit mode', function() {
+	})
+
+	describe('Link handling to collectives', function() {
+		it('Opens link with URL to page in this collective in same/new tab depending on view/edit mode', function() {
+			const href = `${baseUrl}/index.php/apps/collectives/Link%20Testing/Link%20Target`
+			testLinkToSameTab(href)
+			testLinkToNewTab(href, { edit: true })
+		})
+		it('Opens link with absolute path to page in this collective in same/new tab depending on view/edit mode', function() {
 			const href = '/index.php/apps/collectives/Link%20Testing/Link%20Target'
 			testLinkToSameTab(href)
 			testLinkToNewTab(href, { edit: true })
 		})
-		it('Opens link to page in other collective in same/new tab depending on view/edit mode', function() {
-			const href = `/index.php/apps/collectives/Another%20Collective/First%20Page?fileId=${targetPageId}`
+		/* Link without origin and containing `fileId` param gets rewritten by editor rendering, so unable to test for now
+		it('Opens link with relative path to page in this collective with fileId in same/new tab depending on view/edit mode', function() {
+			const href = './Link%20Target?fileId=${linkTargetPageId}'
 			testLinkToSameTab(href)
 			testLinkToNewTab(href, { edit: true })
 		})
-		it('Opens absolute link to another Nextcloud app in new tab', function() {
+		 */
+		it('Opens link with relative path to page in this collective without fileId in same/new tab depending on view/edit mode', function() {
+			const href = './Link%20Target'
+			testLinkToSameTab(href)
+			testLinkToNewTab(href, { edit: true })
+		})
+
+		it('Opens link with URL to page in other collective with fileId in same/new tab depending on view/edit mode', function() {
+			const href = `${baseUrl}/index.php/apps/collectives/Another%20Collective/First%20Page?fileId=${anotherCollectiveFirstPageId}`
+			testLinkToSameTab(href)
+			testLinkToNewTab(href, { edit: true })
+		})
+		it('Opens link with absolute path to page in other collective without fileId in same/new tab depending on view/edit mode', function() {
+			const href = '/index.php/apps/collectives/Another%20Collective/First%20Page'
+			testLinkToSameTab(href)
+			testLinkToNewTab(href, { edit: true })
+		})
+	})
+
+	describe('Link handling to Nextcloud', function() {
+		it('Opens link with URL to another Nextcloud app in new tab', function() {
+			const href = `${baseUrl}/index.php/apps/contacts`
+			testLinkToNewTab(href)
+			testLinkToNewTab(href, { edit: true })
+		})
+		it('Opens link with absolute path to another Nextcloud app in new tab', function() {
 			const href = '/index.php/apps/contacts'
 			testLinkToNewTab(href)
 			testLinkToNewTab(href, { edit: true })
 		})
-		it('Opens relative link to another Nextcloud app in new tab', function() {
-			const href = '/index.php/apps/contacts'
-			testLinkToNewTab(href, { keepRelative: true })
-			// In edit mode, URL gets opened as absolute.
-			// testLinkToNewTab(href, { edit: true, keepRelative: true })
-		})
-		it('Opens link to external page in new tab', function() {
+	})
+
+	describe('Link handling to external', function() {
+		it('Opens link to external website in new tab', function() {
 			const href = 'http://example.org/'
-			testLinkToNewTab(href, { isAbsolute: true })
-			testLinkToNewTab(href, { edit: true, isAbsolute: true })
+			testLinkToNewTab(href)
+			testLinkToNewTab(href, { edit: true })
+		})
+		it('Opens link to foreign Collectives page in new tab', function() {
+			const href = 'https://cloud.example.org/apps/collectives/Foreign%20Collective/Foreign%20Page?fileId=123'
+			testLinkToNewTab(href)
+			testLinkToNewTab(href, { edit: true })
 		})
 	})
 
@@ -233,19 +281,19 @@ describe('Page', function() {
 				.click()
 			cy.get('@clipBoardWriteText').should('have.been.calledOnce')
 		})
-		it('Public share: opens link to page in this collective in same/new tab depending on view/edit mode', function() {
+		it('Public share: opens link with absolute path to page in this collective in same/new tab depending on view/edit mode', function() {
 			cy.logout()
 			cy.visit(`${shareUrl}/Link Source`)
 			const href = '/index.php/apps/collectives/Link%20Testing/Link%20Target'
 			testLinkToSameTab(href, { isPublic: true })
-			// testLinkToNewTab(href, { edit: true, isPublic: true })
+			testLinkToNewTab(href, { edit: true, isPublic: true })
 		})
-		it('Public share: opens link to external page in new tab', function() {
+		it('Public share: opens link to external website in new tab', function() {
 			cy.logout()
 			cy.visit(`${shareUrl}/Link Source`)
 			const href = 'http://example.org/'
-			testLinkToNewTab(href, { isPublic: true, isAbsolute: true })
-			testLinkToNewTab(href, { edit: true, isPublic: true, isAbsolute: true })
+			testLinkToNewTab(href, { isPublic: true })
+			testLinkToNewTab(href, { edit: true, isPublic: true })
 		})
 	})
 })

--- a/cypress/e2e/pages-links.spec.js
+++ b/cypress/e2e/pages-links.spec.js
@@ -187,7 +187,10 @@ describe('Page', function() {
 		it('Opens link with absolute path to page in this collective in same/new tab depending on view/edit mode', function() {
 			const href = '/index.php/apps/collectives/Link%20Testing/Link%20Target'
 			testLinkToSameTab(href)
-			testLinkToNewTab(href, { edit: true })
+			// Broken in Text on Nextcloud 25
+			if (Cypress.env('ncVersion') !== 'stable25') {
+				testLinkToNewTab(href, { edit: true })
+			}
 		})
 		/* Link without origin and containing `fileId` param gets rewritten by editor rendering, so unable to test for now
 		it('Opens link with relative path to page in this collective with fileId in same/new tab depending on view/edit mode', function() {
@@ -199,7 +202,10 @@ describe('Page', function() {
 		it('Opens link with relative path to page in this collective without fileId in same/new tab depending on view/edit mode', function() {
 			const href = './Link%20Target'
 			testLinkToSameTab(href)
-			testLinkToNewTab(href, { edit: true })
+			// Broken in Text on Nextcloud 25
+			if (Cypress.env('ncVersion') !== 'stable25') {
+				testLinkToNewTab(href, { edit: true })
+			}
 		})
 		it('Opens link with relative path to markdown file in this collective without fileId in same/new tab depending on view/edit mode', function() {
 			// TODO: We want '.md' to be stripped when opening the link
@@ -217,7 +223,10 @@ describe('Page', function() {
 		it('Opens link with absolute path to page in other collective without fileId in same/new tab depending on view/edit mode', function() {
 			const href = '/index.php/apps/collectives/Another%20Collective/First%20Page'
 			testLinkToSameTab(href)
-			testLinkToNewTab(href, { edit: true })
+			// Broken in Text on Nextcloud 25
+			if (Cypress.env('ncVersion') !== 'stable25') {
+				testLinkToNewTab(href, { edit: true })
+			}
 		})
 	})
 
@@ -230,7 +239,10 @@ describe('Page', function() {
 		it('Opens link with absolute path to another Nextcloud app in new tab', function() {
 			const href = '/index.php/apps/contacts'
 			testLinkToNewTab(href)
-			testLinkToNewTab(href, { edit: true })
+			// Broken in Text on Nextcloud 25
+			if (Cypress.env('ncVersion') !== 'stable25') {
+				testLinkToNewTab(href, { edit: true })
+			}
 		})
 	})
 
@@ -293,7 +305,10 @@ describe('Page', function() {
 			cy.logout()
 			cy.visit(`${shareUrl}/Link Source`)
 			const href = '/index.php/apps/collectives/Link%20Testing/Link%20Target'
-			testLinkToSameTab(href, { isPublic: true })
+			// Broken in Text on Nextcloud 25
+			if (Cypress.env('ncVersion') !== 'stable25') {
+				testLinkToSameTab(href, { isPublic: true })
+			}
 			testLinkToNewTab(href, { edit: true, isPublic: true })
 		})
 		it('Public share: opens link to external website in new tab', function() {

--- a/cypress/e2e/pages-links.spec.js
+++ b/cypress/e2e/pages-links.spec.js
@@ -61,6 +61,7 @@ describe('Page', function() {
 * Absolute path to page in this collective:  [Link Target](/index.php/apps/collectives/Link%20Testing/Link%20Target)
 * Relative path to page in this collective with fileId:  [Link Target](./Link%20Target?fileId=${linkTargetPageId})
 * Relative path to page in this collective without fileId:  [Link Target](./Link%20Target)
+* Relative path to markdown file in this collective:  [Link Target](./Link%20Target.md)
 
 * URL to page in other collective with fileId: [Another Collective/First Page](${baseUrl}/index.php/apps/collectives/Another%20Collective/First%20Page?fileId=${anotherCollectiveFirstPageId})
 * Absolute path to page in other collective without fileId: [Another Collective/First Page](/index.php/apps/collectives/Another%20Collective/First%20Page)
@@ -111,7 +112,7 @@ describe('Page', function() {
 	}
 
 	// Expected to open in same tab
-	const testLinkToSameTab = function(href, { edit = false, isPublic = false } = {}) {
+	const testLinkToSameTab = function(href, { edit = false, isPublic = false, expectedPathname = null } = {}) {
 		clickLink(href, edit)
 
 		cy.url().then((newBaseUrl) => {
@@ -121,7 +122,7 @@ describe('Page', function() {
 				? url.pathname.replace(`/${encodedCollectiveName}`, `/p/\\w+/${encodedCollectiveName}`)
 				: url.pathname
 			cy.location().should((loc) => {
-				expect(loc.pathname).to.match(new RegExp(`^${pathname}$`))
+				expect(loc.pathname).to.match(new RegExp(`^${expectedPathname || pathname}$`))
 				expect(loc.search).to.eq(url.search)
 			})
 		})
@@ -199,6 +200,13 @@ describe('Page', function() {
 			const href = './Link%20Target'
 			testLinkToSameTab(href)
 			testLinkToNewTab(href, { edit: true })
+		})
+		it('Opens link with relative path to markdown file in this collective without fileId in same/new tab depending on view/edit mode', function() {
+			// TODO: We want '.md' to be stripped when opening the link
+			const href = './Link%20Target.md'
+			testLinkToSameTab(href, { expectedPathname: '/index.php/apps/collectives/Link%20Testing/Link%20Target' })
+			// Special handling of links to markdown files is only in Collectives link handler
+			// testLinkToNewTab(href, { edit: true, expectedPathname: '/index.php/apps/collectives/Link%20Testing/Link%20Target' })
 		})
 
 		it('Opens link with URL to page in other collective with fileId in same/new tab depending on view/edit mode', function() {

--- a/src/components/Page/RichText.vue
+++ b/src/components/Page/RichText.vue
@@ -173,7 +173,12 @@ export default {
 
 		handleRelativeFileLink({ href }) {
 			if (!href.match(/^[a-zA-Z]*:/)) {
-				const encodedRelPath = href.match(/^([^?]*)\?fileId=(\d+)/)[1]
+				const fileIdMatches = href.match(/^([^?]*)\?fileId=(\d+)/)
+				if (!fileIdMatches || fileIdMatches.length < 2) {
+					// href search params don't contain a fileId
+					return false
+				}
+				const encodedRelPath = fileIdMatches[1]
 				const relPath = decodeURI(encodedRelPath)
 				const path = resolvePath(`/${this.currentPageFilePath}`, relPath)
 				this.OCA.Viewer.open({ path })

--- a/src/components/Page/RichText.vue
+++ b/src/components/Page/RichText.vue
@@ -124,7 +124,6 @@ export default {
 
 		followLink(_event, attrs) {
 			return this.handleCollectiveLink(attrs)
-				|| this.handleRelativeMarkdownLink(attrs)
 				|| this.handleSameOriginLink(attrs)
 				|| this.handleRelativeFileLink(attrs)
 				|| window.open(attrs.href, '_blank')
@@ -142,6 +141,18 @@ export default {
 				return false
 			}
 
+			// Try to resolve relative links to markdown files
+			if (href.includes('.md?fileId=')) {
+				// With `fileId` parameter
+				href = href.replace('.md?', '?')
+			} else if (href.endsWith('.md')) {
+				// Without `fileId` parameter
+				href = href.slice(0, -'.md'.length)
+				if (href.endsWith('/Readme')) {
+					href = href.slice(0, -'/Readme'.length)
+				}
+			}
+
 			let collectivePath = href.replace(baseUrl.href, '')
 			const publicPrefix = `/p/${this.currentCollective.shareToken}`
 
@@ -157,24 +168,6 @@ export default {
 
 			this.$router.push(collectivePath)
 			return true
-		},
-
-		// E.g. `../SomeOtherPage.md?fileId=123` or `../SomeOtherPage.md`
-		handleRelativeMarkdownLink({ href }) {
-			const full = new URL(href, window.location)
-			const pageParamOmitsReadme = this.currentPage.fileName === 'Readme.md'
-				&& this.pageParam !== 'Readme.md'
-			const prefix = pageParamOmitsReadme
-				? (this.pageParam || this.collectiveParam) + '/'
-				: ''
-
-			if (full.origin === window.location.origin) {
-				if (href.includes('.md?fileId=')) {
-					// With `fileId` parameter
-					this.$router.push(prefix + href.replace('.md?', '?'))
-					return true
-				}
-			}
 		},
 
 		// E.g. `https://cloud.example.org/


### PR DESCRIPTION
### 📝 Summary

* Make sure `handleRelativeFileLink` doesn't fail if the search params of `href` don't contain a fileId param.
* Treat links with absolute and relative paths to local collective the same as links with full URLs with origin.
* Attempt to resolve links to relative paths to markdown files

Fixes: #385

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
