### PR TITLE
Migrate to nextcloud-vue components in sidebar and CollectiveSettings

### DIFF
--- a/src/components/Collective/CollectiveActions.vue
+++ b/src/components/Collective/CollectiveActions.vue
@@ -10,10 +10,13 @@
 		<NcActionSeparator v-if="showManageMembers" />
 		<NcActionButton v-if="collectiveCanShare(collective)"
 			v-show="!isShared"
-			:icon="shareIcon"
 			:close-after-click="false"
 			@click="share(collective)">
 			{{ t('collectives', 'Share link') }}
+			<template #icon>
+				<NcLoadingIcon v-if="loading('share')" :size="16" />
+				<LinkVariantIcon v-else :size="16" />
+			</template>
 		</NcActionButton>
 		<NcActionButton v-if="!isPublic"
 			v-show="isShared"
@@ -35,9 +38,12 @@
 		</NcActionCheckbox>
 		<NcActionButton v-if="!isPublic"
 			v-show="isShared"
-			:icon="unshareIcon"
 			:close-after-click="false"
 			@click="unshare(collective)">
+			<template #icon>
+				<NcLoadingIcon v-if="loading('unshare')" :size="16" />
+				<LinkVariantIcon v-else :size="16" />
+			</template>
 			{{ t('collectives', 'Unshare') }}
 		</NcActionButton>
 		<NcActionSeparator v-if="collectiveCanShare(collective) && !isPublic" />
@@ -78,6 +84,7 @@ import CirclesIcon from '../Icon/CirclesIcon.vue'
 import CogIcon from 'vue-material-design-icons/Cog.vue'
 import ContentPasteIcon from 'vue-material-design-icons/ContentPaste.vue'
 import DownloadIcon from 'vue-material-design-icons/Download.vue'
+import LinkVariantIcon from 'vue-material-design-icons/LinkVariant.vue'
 import LogoutIcon from 'vue-material-design-icons/Logout.vue'
 import {
 	LEAVE_CIRCLE,
@@ -99,6 +106,7 @@ export default {
 		CogIcon,
 		ContentPasteIcon,
 		DownloadIcon,
+		LinkVariantIcon,
 		LogoutIcon,
 		NcActionButton,
 		NcActionCheckbox,
@@ -152,10 +160,6 @@ export default {
 			return !!this.collective.shareToken
 		},
 
-		shareIcon() {
-			return this.loading('share') ? 'icon-loading-small' : 'icon-public'
-		},
-
 		copyButtonText() {
 			if (this.copied) {
 				return this.copySuccess
@@ -163,10 +167,6 @@ export default {
 					: t('collectives', 'Cannot copy')
 			}
 			return t('collectives', 'Copy share link')
-		},
-
-		unshareIcon() {
-			return this.loading('unshare') ? 'icon-loading-small' : 'icon-public'
 		},
 
 		printLink() {

--- a/src/components/Collective/CollectiveActions.vue
+++ b/src/components/Collective/CollectiveActions.vue
@@ -3,7 +3,7 @@
 		<NcActionLink v-if="showManageMembers"
 			:href="circleLink">
 			<template #icon>
-				<CirclesIcon :size="16" />
+				<CirclesIcon :size="20" />
 			</template>
 			{{ t('collectives', 'Manage members') }}
 		</NcActionLink>
@@ -14,8 +14,8 @@
 			@click="share(collective)">
 			{{ t('collectives', 'Share link') }}
 			<template #icon>
-				<NcLoadingIcon v-if="loading('share')" :size="16" />
-				<LinkVariantIcon v-else :size="16" />
+				<NcLoadingIcon v-if="loading('share')" :size="20" />
+				<LinkVariantIcon v-else :size="20" />
 			</template>
 		</NcActionButton>
 		<NcActionButton v-if="!isPublic"
@@ -23,9 +23,9 @@
 			:close-after-click="false"
 			@click.stop.prevent="copyShare(collective)">
 			<template #icon>
-				<CheckIcon v-if="copySuccess" :size="16" />
-				<NcLoadingIcon v-else-if="copyLoading" :size="16" />
-				<ContentPasteIcon v-else :size="16" />
+				<CheckIcon v-if="copySuccess" :size="20" />
+				<NcLoadingIcon v-else-if="copyLoading" :size="20" />
+				<ContentPasteIcon v-else :size="20" />
 			</template>
 			{{ copyButtonText }}
 		</NcActionButton>
@@ -41,8 +41,8 @@
 			:close-after-click="false"
 			@click="unshare(collective)">
 			<template #icon>
-				<NcLoadingIcon v-if="loading('unshare')" :size="16" />
-				<LinkVariantIcon v-else :size="16" />
+				<NcLoadingIcon v-if="loading('unshare')" :size="20" />
+				<LinkVariantIcon v-else :size="20" />
 			</template>
 			{{ t('collectives', 'Unshare') }}
 		</NcActionButton>
@@ -52,14 +52,14 @@
 			target="_blank">
 			{{ t('collectives', 'Export or print') }}
 			<template #icon>
-				<DownloadIcon :size="16" />
+				<DownloadIcon :size="20" />
 			</template>
 		</NcActionLink>
 		<NcActionButton v-if="isCollectiveAdmin(collective)"
 			:close-after-click="true"
 			@click="openCollectiveSettings()">
 			<template #icon>
-				<CogIcon :size="16" />
+				<CogIcon :size="20" />
 			</template>
 			{{ t('collectives', 'Settings') }}
 		</NcActionButton>
@@ -68,7 +68,7 @@
 			@click="leaveCollectiveWithUndo(collective)">
 			{{ t('collectives', 'Leave collective') }}
 			<template #icon>
-				<LogoutIcon :size="16" />
+				<LogoutIcon :size="20" />
 			</template>
 		</NcActionButton>
 	</div>

--- a/src/components/Nav/CollectiveSettings.vue
+++ b/src/components/Nav/CollectiveSettings.vue
@@ -8,7 +8,7 @@
 					<NcButton type="tertiary"
 						:aria-label="t('collectives', 'Select emoji for collective')"
 						:title="emojiTitle"
-						:class="{'loading': loading('updateCollectiveEmoji')}"
+						:class="{'loading': loading('updateCollectiveEmoji') || loading('renameCollective')}"
 						class="button-emoji"
 						@click.prevent>
 						{{ collective.emoji }}
@@ -17,21 +17,25 @@
 						</template>
 					</NcButton>
 				</NcEmojiPicker>
-				<form @submit.prevent.stop="renameCollective()">
-					<input ref="nameField"
-						v-model="newCollectiveName"
-						v-tooltip="renameDisabledTooltip"
-						type="text"
-						:disabled="!isCollectiveOwner(collective)"
-						required>
-					<input v-tooltip="renameDisabledTooltip"
-						type="submit"
-						value=""
-						:aria-label="t('collectives', 'Save new collective name')"
-						class="icon-confirm"
-						:class="{ 'icon-loading-small': loading('renameCollective') }"
-						:disabled="!isCollectiveOwner(collective)">
-				</form>
+				<NcTextField ref="collectiveName"
+					:value.sync="newCollectiveName"
+					:disabled="!isCollectiveOwner(collective)"
+					:label="renameLabel"
+					:error="nameIsTooShort"
+					:show-trailing-button="!nameIsTooShort"
+					trailing-button-icon="arrowRight"
+					class="collective-name-input"
+					@blur="renameCollective()"
+					@keypress.enter.prevent="renameCollective()"
+					@trailing-button-click="renameCollective()" />
+			</div>
+			<div class="collective-name-error-placeholder">
+				<div v-if="nameError" class="collective-name-error">
+					<AlertCircleOutlineIcon :size="16" />
+					<label for="collective-name" class="modal-collective-name-error-label">
+						{{ nameError }}
+					</label>
+				</div>
 			</div>
 		</NcAppSettingsSection>
 
@@ -144,7 +148,8 @@
 import { memberLevels, pageModes } from '../../constants.js'
 import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
 import { showError, showSuccess } from '@nextcloud/dialogs'
-import { NcAppSettingsDialog, NcAppSettingsSection, NcButton, NcCheckboxRadioSwitch } from '@nextcloud/vue'
+import { NcAppSettingsDialog, NcAppSettingsSection, NcButton, NcCheckboxRadioSwitch, NcTextField } from '@nextcloud/vue'
+import AlertCircleOutlineIcon from 'vue-material-design-icons/AlertCircleOutline.vue'
 import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
 import EmoticonOutline from 'vue-material-design-icons/EmoticonOutline.vue'
 import { generateUrl } from '@nextcloud/router'
@@ -162,11 +167,13 @@ export default {
 	name: 'CollectiveSettings',
 
 	components: {
+		AlertCircleOutlineIcon,
 		NcAppSettingsDialog,
 		NcAppSettingsSection,
 		NcButton,
 		NcCheckboxRadioSwitch,
 		NcEmojiPicker,
+		NcTextField,
 		EmoticonOutline,
 	},
 
@@ -206,9 +213,10 @@ export default {
 			return this.collective.emoji ? t('collectives', 'Change emoji') : t('collectives', 'Add emoji')
 		},
 
-		renameDisabledTooltip() {
-			return !this.isCollectiveOwner(this.collective)
-				&& t('collectives', 'Renaming is limited to owners of the circle')
+		renameLabel() {
+			return this.isCollectiveOwner(this.collective)
+				? t('collectives', 'Name of the collective')
+				: t('collectives', 'Renaming is limited to owners of the circle')
 		},
 
 		membersDisabledTooltip() {
@@ -218,6 +226,17 @@ export default {
 
 		isContactsInstalled() {
 			return 'contacts' in this.OC.appswebroots
+		},
+
+		nameIsTooShort() {
+			return !!this.newCollectiveName && this.newCollectiveName.length < 3
+		},
+
+		nameError() {
+			if (this.nameIsTooShort) {
+				return t('collectives', 'Name too short, requires at least three characters')
+			}
+			return null
 		},
 	},
 
@@ -308,7 +327,7 @@ export default {
 		 */
 		async renameCollective() {
 			// Ignore rename to same name
-			if (this.newCollectiveName === this.collective.name) {
+			if (this.nameIsTooShort || this.newCollectiveName === this.collective.name) {
 				return
 			}
 
@@ -369,13 +388,23 @@ export default {
 .collective-name {
 	display: flex;
 
-	form {
-		display: flex;
-		flex-grow: 1;
+	.collective-name-input {
+		display: grid;
+		align-items: center;
+	}
+}
 
-		input[type='text'] {
-			flex-grow: 1;
-		}
+.collective-name-error-placeholder {
+	min-height: 24px;
+}
+
+.collective-name-error {
+	display: flex;
+	// Emoji button + input field padding
+	padding-left: calc(57px + 12px);
+
+	&-label {
+		padding-left: 4px;
 	}
 }
 

--- a/src/components/Nav/CollectiveSettings.vue
+++ b/src/components/Nav/CollectiveSettings.vue
@@ -20,9 +20,9 @@
 				<NcTextField ref="collectiveName"
 					:value.sync="newCollectiveName"
 					:disabled="!isCollectiveOwner(collective)"
-					:label="renameLabel"
-					:error="nameIsTooShort"
-					:show-trailing-button="!nameIsTooShort"
+					:label="getRenameLabel"
+					:error="isNameTooShort"
+					:show-trailing-button="!isNameTooShort"
 					trailing-button-icon="arrowRight"
 					class="collective-name-input"
 					@blur="renameCollective()"
@@ -30,10 +30,10 @@
 					@trailing-button-click="renameCollective()" />
 			</div>
 			<div class="collective-name-error-placeholder">
-				<div v-if="nameError" class="collective-name-error">
+				<div v-if="getNameError" class="collective-name-error">
 					<AlertCircleOutlineIcon :size="16" />
 					<label for="collective-name" class="modal-collective-name-error-label">
-						{{ nameError }}
+						{{ getNameError }}
 					</label>
 				</div>
 			</div>
@@ -213,7 +213,7 @@ export default {
 			return this.collective.emoji ? t('collectives', 'Change emoji') : t('collectives', 'Add emoji')
 		},
 
-		renameLabel() {
+		getRenameLabel() {
 			return this.isCollectiveOwner(this.collective)
 				? t('collectives', 'Name of the collective')
 				: t('collectives', 'Renaming is limited to owners of the circle')
@@ -228,12 +228,12 @@ export default {
 			return 'contacts' in this.OC.appswebroots
 		},
 
-		nameIsTooShort() {
+		isNameTooShort() {
 			return !!this.newCollectiveName && this.newCollectiveName.length < 3
 		},
 
-		nameError() {
-			if (this.nameIsTooShort) {
+		getNameError() {
+			if (this.isNameTooShort) {
 				return t('collectives', 'Name too short, requires at least three characters')
 			}
 			return null
@@ -327,7 +327,7 @@ export default {
 		 */
 		async renameCollective() {
 			// Ignore rename to same name
-			if (this.nameIsTooShort || this.newCollectiveName === this.collective.name) {
+			if (this.isNameTooShort || this.newCollectiveName === this.collective.name) {
 				return
 			}
 

--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -16,7 +16,7 @@
 				@click="collectiveExtraAction.click()">
 				{{ collectiveExtraAction.title }}
 				<template #icon>
-					<OpenInNewIcon :size="16" />
+					<OpenInNewIcon :size="20" />
 				</template>
 			</NcActionButton>
 			<NcActionButton v-if="!inPageList"
@@ -48,7 +48,7 @@
 				@click.native="show('details')"
 				@click="editTemplate(pageId)">
 				<template #icon>
-					<PagesTemplateIcon :size="14" />
+					<PagesTemplateIcon :size="18" />
 				</template>
 				{{ editTemplateString }}
 			</NcActionButton>

--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -30,7 +30,7 @@
 					:close-after-click="true"
 					@click="sortPagesAndScroll('byOrder')">
 					<template #icon>
-						<SortAscendingIcon :size="16" />
+						<SortAscendingIcon :size="20" />
 					</template>
 					{{ t('collectives', 'Sort by custom order') }}
 				</NcActionButton>
@@ -39,7 +39,7 @@
 					:close-after-click="true"
 					@click="sortPagesAndScroll('byTimestamp')">
 					<template #icon>
-						<SortClockAscendingOutlineIcon :size="16" />
+						<SortClockAscendingOutlineIcon :size="20" />
 					</template>
 					{{ t('collectives', 'Sort recently changed first') }}
 				</NcActionButton>
@@ -48,7 +48,7 @@
 					:close-after-click="true"
 					@click="sortPagesAndScroll('byTitle')">
 					<template #icon>
-						<SortAlphabeticalAscendingIcon :size="16" />
+						<SortAlphabeticalAscendingIcon :size="20" />
 					</template>
 					{{ t('collectives', 'Sort by title') }}
 				</NcActionButton>

--- a/src/store/pages.js
+++ b/src/store/pages.js
@@ -638,10 +638,8 @@ export default {
 		 * @param {object} page Page to get backlinks for
 		 */
 		async [GET_BACKLINKS]({ commit, getters }, page) {
-			commit('load', 'backlinks')
 			const response = await axios.get(getters.backlinksUrl(page.parentId, page.id))
 			commit(SET_BACKLINKS, { pages: response.data.data })
-			commit('done', 'backlinks')
 		},
 	},
 }


### PR DESCRIPTION
### 📝 Summary

* Migrate SidebarTabVersions to NcListItem
* Migrate SidebarTabBackLinks to NcListItem
* Migrate share icons to vue-material-design-icons
* Migrate name field in CollectiveSettings for NcTextField component

* Resolves: #608
* Resolves: #389 

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
