### PR TITLE
Force-display actions in collectives trash on mobile

### DIFF
--- a/src/components/Nav/CollectivesTrash.vue
+++ b/src/components/Nav/CollectivesTrash.vue
@@ -16,12 +16,16 @@
 					<NcAppNavigationItem v-for="collective in trashCollectives"
 						:key="collective.circleId"
 						:title="collective.name"
+						:force-menu="true"
+						:force-display-actions="isMobile"
 						class="collectives_trash_list_item">
-						<template v-if="collective.emoji" #icon>
-							{{ collective.emoji }}
-						</template>
-						<template v-else #icon>
-							<CollectivesIcon :size="20" />
+						<template #icon>
+							<template v-if="collective.emoji">
+								{{ collective.emoji }}
+							</template>
+							<template v-else>
+								<CollectivesIcon :size="20" />
+							</template>
 						</template>
 						<template #actions>
 							<NcActionButton :close-after-click="true" @click="restoreCollective(collective)">
@@ -77,6 +81,7 @@
 <script>
 import { mapGetters, mapState } from 'vuex'
 import { NcActionButton, NcAppNavigationItem, NcButton, NcModal } from '@nextcloud/vue'
+import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 import CollectivesIcon from '../Icon/CollectivesIcon.vue'
 import DeleteIcon from 'vue-material-design-icons/Delete.vue'
 import RestoreIcon from 'vue-material-design-icons/Restore.vue'
@@ -84,9 +89,11 @@ import { directive as ClickOutside } from 'v-click-outside'
 
 export default {
 	name: 'CollectivesTrash',
+
 	directives: {
 		ClickOutside,
 	},
+
 	components: {
 		NcActionButton,
 		NcAppNavigationItem,
@@ -96,6 +103,11 @@ export default {
 		NcModal,
 		RestoreIcon,
 	},
+
+	mixins: [
+		isMobile,
+	],
+
 	data() {
 		return {
 			open: false,
@@ -106,6 +118,7 @@ export default {
 			},
 		}
 	},
+
 	computed: {
 		...mapState({
 			trashCollectives: (state) => state.collectives.trashCollectives,


### PR DESCRIPTION
Also harmonize the component code more with the CollectiveListItem component.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
