### PR TITLE
Fix path to collective in navigation of public share

### DIFF
--- a/src/components/Nav/CollectiveListItem.vue
+++ b/src/components/Nav/CollectiveListItem.vue
@@ -1,7 +1,7 @@
 <template>
 	<NcAppNavigationItem :key="collective.circleId"
 		:title="collective.name"
-		:to="`/${encodeURIComponent(collective.name)}`"
+		:to="collectivePath(collective)"
 		:force-menu="true"
 		:force-display-actions="isMobile"
 		class="collectives_list_item">
@@ -20,6 +20,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { NcAppNavigationItem } from '@nextcloud/vue'
 import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 import CollectiveActions from '../Collective/CollectiveActions.vue'
@@ -43,6 +44,12 @@ export default {
 			type: Object,
 			required: true,
 		},
+	},
+
+	computed: {
+		...mapGetters([
+			'collectivePath',
+		]),
 	},
 }
 </script>

--- a/src/store/collectives.js
+++ b/src/store/collectives.js
@@ -53,12 +53,18 @@ export default {
 			)
 		},
 
-		currentCollectivePath(state, getters) {
-			if (getters.isPublic) {
-				return `/p/${getters.shareTokenParam}/${encodeURIComponent(getters.currentCollective.name)}`
-			} else {
-				return `/${encodeURIComponent(getters.currentCollective.name)}`
+		collectivePath(state, getters) {
+			return (collective) => {
+				if (getters.isPublic && collective.shareToken) {
+					return `/p/${collective.shareToken}/${encodeURIComponent(collective.name)}`
+				} else {
+					return `/${encodeURIComponent(collective.name)}`
+				}
 			}
+		},
+
+		currentCollectivePath(state, getters) {
+			return getters.collectivePath(getters.currentCollective)
 		},
 
 		currentCollectiveTitle(_state, getters) {


### PR DESCRIPTION
Fixes: #697

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
