### PR TITLE
Fix localization section for select emoji

### DIFF
--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -197,7 +197,7 @@ export default {
 		},
 
 		setEmojiString() {
-			return t('collective', 'Select emoji')
+			return t('collectives', 'Select emoji')
 		},
 
 		deletePageString() {


### PR DESCRIPTION
I corrected a simple bug where a letter 's' was missing from the section name in the string `t('collective', 'Select emoji')`