### PR TITLE
Add extra default route without path parameter

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -99,14 +99,17 @@ return [
 		['name' => 'publicPageTrash#restore', 'url' => '/_api/p/{token}/_pages/trash/{id}', 'verb' => 'PATCH',
 			'requirements' => ['id' => '\d+']],
 
-		// default public route (Vue.js frontend)
+		// default Vue.js router route (Vue.js frontend)
+		['name' => 'start#index', 'url' => '/', 'verb' => 'GET'],
+
+		// Vue.js router public route (Vue.js frontend)
 		['name' => 'publicStart#publicIndex', 'url' => '/p/{token}/{path}', 'verb' => 'GET',
 			'requirements' => ['path' => '.*'],	'defaults' => ['path' => '']],
 
-		// default route (Vue.js frontend)
-		['name' => 'start#index', 'url' => '/{path}', 'verb' => 'GET',
+		// Vue.js router route (Vue.js frontend)
+		['name' => 'start#indexPath', 'url' => '/{path}', 'verb' => 'GET',
 			'requirements' => ['path' => '.*'],
-			'defaults' => ['path' => '']],
+			'defaults' => ['path' => '/']],
 	],
 	'ocs' => [
 		['name' => 'settings#getUserSetting', 'url' => '/api/v{apiVersion}/settings/user/{key}', 'verb' => 'GET',

--- a/lib/Controller/StartController.php
+++ b/lib/Controller/StartController.php
@@ -27,20 +27,12 @@ class StartController extends Controller {
 	}
 
 	/**
-	 * CAUTION: the @Stuff turns off security checks; for this page no admin is
-	 *          required and no CSRF check. If you don't know what CSRF is, read
-	 *          it up in the docs or you might create a security hole. This is
-	 *          basically the only required method to add this exemption, don't
-	 *          add it to any other method if you don't exactly know what it does
-	 *
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 *
-	 * @param string $path
-	 *
 	 * @return TemplateResponse
 	 */
-	public function index(string $path): TemplateResponse {
+	public function index(): TemplateResponse {
 		if ($appsMissing = $this->checkDependencies()) {
 			return new TemplateResponse('collectives', 'error', ['appsMissing' => $appsMissing]);  // templates/error.php
 		}
@@ -50,6 +42,18 @@ class StartController extends Controller {
 			'id-app-content' => '#app-content-vue',
 			'id-app-navigation' => '#app-navigation-vue',
 		]);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @param string $path
+	 *
+	 * @return TemplateResponse
+	 */
+	public function indexPath(string $path): TemplateResponse {
+		return $this->index();
 	}
 
 	/**


### PR DESCRIPTION
This is required to have a trailing slash in our default route (`collectives.start.index`).

Fixes: #727
Fixes: #411

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
