### PR TITLE
fix: Switch to ObjectStoreScanner if NoopScanner is not available

### DIFF
--- a/lib/Mount/CollectiveStorage.php
+++ b/lib/Mount/CollectiveStorage.php
@@ -6,6 +6,7 @@ namespace OCA\Collectives\Mount;
 
 use OC\Files\Cache\Scanner;
 use OC\Files\ObjectStore\NoopScanner;
+use OC\Files\ObjectStore\ObjectStoreScanner;
 use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\Storage\Wrapper\Wrapper;
 use OCP\Files\Cache\ICacheEntry;
@@ -75,7 +76,8 @@ class CollectiveStorage extends Wrapper {
 			$storage = $this;
 		}
 		if ($storage->instanceOfStorage(ObjectStoreStorage::class)) {
-			$storage->scanner = new NoopScanner($storage);
+			// NoopScanner is private API and kept here for compatibility with older releases
+			$storage->scanner = class_exists(NoopScanner::class) ? new NoopScanner($storage) : new ObjectStoreScanner($storage);
 		} elseif (!isset($storage->scanner)) {
 			$storage->scanner = new Scanner($storage);
 		}


### PR DESCRIPTION
Adapt to the rename of the internal scanner class for object storage. I kept the NoopScanner to not break compatibility with old releases. 

This originates from https://github.com/nextcloud/server/pull/37691 so it would be good to include it in the next bugfix release for 27 as well.

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
