### PR TITLE
fix(editor): Use the `autofocus` command from Text if available

### DIFF
--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -145,7 +145,11 @@ export default {
 		},
 
 		focusEditor() {
-			this.wrapper()?.$editor?.commands.focus?.()
+			if (this.wrapper()?.$editor?.commands.autofocus) {
+				this.wrapper().$editor.commands.autofocus()
+			} else {
+				this.wrapper()?.$editor?.commands.focus?.()
+			}
 		},
 
 		addImage(name) {


### PR DESCRIPTION
Together with https://github.com/nextcloud/text/pull/4540, the cursor position will be restored when opening the editor for a page.
