### PR TITLE
List recent pages and members on landing page

### DIFF
--- a/cypress/e2e/page-landingpage.spec.js
+++ b/cypress/e2e/page-landingpage.spec.js
@@ -1,0 +1,79 @@
+/**
+ * @copyright Copyright (c) 2023 Jonas <jonas@nextcloud.com>
+ *
+ * @author Jonas <jonas@nextcloud.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ *  Tests for page details.
+ */
+
+const collective = 'Landingpage Collective'
+
+describe('Page landing page', function() {
+	before(function() {
+		cy.login('bob', { route: '/apps/collectives' })
+		cy.deleteAndSeedCollective(collective)
+		cy.seedCircleMember(collective, 'alice')
+		cy.seedCircleMember(collective, 'jane')
+		cy.seedCircleMember(collective, 'john')
+		cy.seedPage('Page 1', '', 'Readme.md')
+		cy.seedPage('Page 2', '', 'Readme.md')
+		cy.seedPage('Page 3', '', 'Readme.md')
+	})
+
+	beforeEach(function() {
+		cy.login('bob', { route: `/apps/collectives/${collective}` })
+		// make sure the page list loaded properly
+		cy.contains('.app-content-list-item a', 'Page 1')
+	})
+
+	describe('Displays recent pages', function() {
+		it('Allows to display/close TOC and switch page modes in between', function() {
+			cy.get('.recent-pages-widget .recent-page-tile')
+				.contains('Page 2')
+				.click()
+
+			cy.url().should('include', `/apps/collectives/${encodeURIComponent(collective)}/${encodeURIComponent('Page 2')}`)
+		})
+	})
+
+	describe('Displays recent members', function() {
+		it('Allows to open members modal as admin', function() {
+			cy.get('.members-widget .avatardiv[title="alice"]')
+			cy.get('.members-widget .button-vue[title="Show members"]')
+				.click()
+
+			cy.get('.current-members').contains('.member-row', 'alice')
+				.find('.member-row__actions')
+				.should('exist')
+		})
+
+		it('Allows to open members modal as member', function() {
+			cy.login('alice', { route: `/apps/collectives/${collective}` })
+			cy.get('.members-widget .avatardiv[title="bob"]')
+			cy.get('.members-widget .button-vue[title="Show members"]')
+				.click()
+
+			cy.get('.current-members').contains('.member-row', 'bob')
+				.find('.member-row__actions')
+				.should('not.exist')
+		})
+	})
+})

--- a/src/components/LastUserBubble.vue
+++ b/src/components/LastUserBubble.vue
@@ -8,7 +8,9 @@
 			:show-user-status="false">
 			{{ lastEditedUserMessage }}
 		</NcUserBubble>
-		{{ lastUpdate }}
+		<span class="timestamp">
+			{{ lastUpdate }}
+		</span>
 	</div>
 </template>
 

--- a/src/components/LastUserBubble.vue
+++ b/src/components/LastUserBubble.vue
@@ -1,5 +1,8 @@
 <template>
 	<div>
+		<template v-if="showPrefixString">
+			{{ t('collectives', 'Last changed by') }}
+		</template>
 		<NcUserBubble :display-name="lastUserDisplayName"
 			:user="lastUserId"
 			:show-user-status="false">
@@ -32,6 +35,10 @@ export default {
 		timestamp: {
 			type: Number,
 			required: true,
+		},
+		showPrefixString: {
+			type: Boolean,
+			default: false,
 		},
 	},
 

--- a/src/components/Member/CurrentMembers.vue
+++ b/src/components/Member/CurrentMembers.vue
@@ -5,6 +5,7 @@
 		<Member v-for="item in searchedMembers"
 			:key="item.singleId"
 			:circle-id="circleId"
+			:current-user-is-admin="currentUserIsAdmin"
 			:member-id="item.id"
 			:user-id="item.userId"
 			:display-name="item.displayName"
@@ -45,6 +46,10 @@ export default {
 		searchQuery: {
 			type: String,
 			default: '',
+		},
+		currentUserIsAdmin: {
+			type: Boolean,
+			default: true,
 		},
 	},
 

--- a/src/components/Member/CurrentMembers.vue
+++ b/src/components/Member/CurrentMembers.vue
@@ -60,7 +60,7 @@ export default {
 		sortedMembers() {
 			return this.currentMembers
 				.slice()
-				.sort(this.sortMembers)
+				.sort(this.sortCurrentUserFirst)
 		},
 
 		searchedMembers() {
@@ -86,37 +86,18 @@ export default {
 
 	methods: {
 		/**
-		 *
 		 * @param {object} m1 First member
 		 * @param {string} m1.userId First member user ID
-		 * @param {string} m1.displayName First member display name
-		 * @param {number} m1.level First member level
-		 * @param {number} m1.userType First member user type
 		 * @param {object} m2 Second member
 		 * @param {string} m2.userId Second member user ID
-		 * @param {string} m2.displayName Second member display name
-		 * @param {number} m2.level Second member level
-		 * @param {number} m2.userType Second member user type
 		 */
-		sortMembers(m1, m2) {
+		sortCurrentUserFirst(m1, m2) {
 			if (m1.userId === this.currentUser) {
 				return -1
 			} else if (m2.userId === this.currentUser) {
 				return 1
 			}
-
-			// Sort by level (admin > moderator > member)
-			if (m1.level !== m2.level) {
-				return m1.level < m2.level
-			}
-
-			// Sort by user type (user > group > circle)
-			if (this.circleMemberType(m1) !== this.circleMemberType(m2)) {
-				return this.circleMemberType(m1) > this.circleMemberType(m2)
-			}
-
-			// Sort by display name
-			return m1.displayName.localeCompare(m2.displayName)
+			return 0
 		},
 	},
 }

--- a/src/components/Member/Member.vue
+++ b/src/components/Member/Member.vue
@@ -29,12 +29,12 @@
 		</div>
 
 		<!-- Checkmark icon for selected -->
-		<div v-if="isSearched && isSelected" class="member-row__checkmark">
+		<div v-if="currentUserIsAdmin && isSearched && isSelected" class="member-row__checkmark">
 			<CheckIcon :size="20" />
 		</div>
 
 		<!-- Action menu -->
-		<NcActions v-else-if="!isSearched && !isCurrentUser"
+		<NcActions v-else-if="currentUserIsAdmin && !isSearched && !isCurrentUser"
 			:force-menu="true"
 			class="member-row__actions">
 			<NcActionButton v-if="!isAdmin"
@@ -109,6 +109,10 @@ export default {
 		circleId: {
 			type: String,
 			default: null,
+		},
+		currentUserIsAdmin: {
+			type: Boolean,
+			default: true,
 		},
 		memberId: {
 			type: String,

--- a/src/components/Member/MemberPicker.vue
+++ b/src/components/Member/MemberPicker.vue
@@ -17,22 +17,23 @@
 			<CurrentMembers v-else-if="showCurrent"
 				:circle-id="circleId"
 				:current-members="currentMembers"
-				:search-query="searchQuery" />
+				:search-query="searchQuery"
+				:current-user-is-admin="currentUserIsAdmin" />
 
 			<!-- Selected members (optional) -->
-			<SelectedMembers v-if="!showCurrentSkeleton && showSelection"
+			<SelectedMembers v-if="currentUserIsAdmin && !showCurrentSkeleton && showSelection"
 				:selected-members="selectedMembers"
 				@delete-from-selection="deleteFromSelection" />
 
 			<!-- Searched and picked members -->
-			<MemberSearchResults v-if="!showCurrentSkeleton && hasSearchResults"
+			<MemberSearchResults v-if="currentUserIsAdmin && !showCurrentSkeleton && hasSearchResults"
 				:circle-id="circleId"
 				:search-results="filteredSearchResults"
 				:selection-set="selectedMembers"
 				:on-click-searched="onClickSearched" />
 
 			<!-- No search results -->
-			<template v-else-if="!showCurrentSkeleton">
+			<template v-else-if="currentUserIsAdmin && !showCurrentSkeleton">
 				<NcAppNavigationCaption class="member-picker-caption" :title="t('collectives', 'Add users, groups or circles…')" />
 				<Hint v-if="!isSearching" :hint="t('collectives', 'Search for members to add')" />
 				<Hint v-else-if="isSearchLoading" :hint="t('collectives', 'Loading…')" />
@@ -75,6 +76,10 @@ export default {
 		circleId: {
 			type: String,
 			default: null,
+		},
+		currentUserIsAdmin: {
+			type: Boolean,
+			default: true,
 		},
 		showCurrent: {
 			type: Boolean,
@@ -189,6 +194,11 @@ export default {
 		},
 
 		onSearch() {
+			// Don't search for new members if not admin
+			if (!this.currentUserIsAdmin) {
+				return
+			}
+
 			this.searchResults = []
 			this.isSearchLoading = true
 			this.debounceFetchSearchResults()

--- a/src/components/Nav/CollectiveMembersModal.vue
+++ b/src/components/Nav/CollectiveMembersModal.vue
@@ -9,7 +9,7 @@
 				<div class="modal-collective-members">
 					<MemberPicker :show-current="true"
 						:circle-id="collective.circleId"
-						:current-members="circleMembers(collective.circleId)"
+						:current-members="circleMembersSorted(collective.circleId)"
 						:on-click-searched="onClickSearched" />
 				</div>
 			</div>
@@ -47,7 +47,7 @@ export default {
 
 	computed: {
 		...mapGetters([
-			'circleMembers',
+			'circleMembersSorted',
 		]),
 	},
 

--- a/src/components/Nav/CollectiveMembersModal.vue
+++ b/src/components/Nav/CollectiveMembersModal.vue
@@ -9,6 +9,7 @@
 				<div class="modal-collective-members">
 					<MemberPicker :show-current="true"
 						:circle-id="collective.circleId"
+						:current-user-is-admin="currentUserIsAdmin"
 						:current-members="circleMembersSorted(collective.circleId)"
 						:on-click-searched="onClickSearched" />
 				</div>
@@ -48,7 +49,12 @@ export default {
 	computed: {
 		...mapGetters([
 			'circleMembersSorted',
+			'isCollectiveAdmin',
 		]),
+
+		currentUserIsAdmin() {
+			return this.isCollectiveAdmin(this.collective)
+		},
 	},
 
 	beforeMount() {
@@ -70,6 +76,10 @@ export default {
 		},
 
 		async onClickSearched(member) {
+			if (!this.currentUserIsAdmin) {
+				return
+			}
+
 			await this.dispatchAddMemberToCircle({
 				circleId: this.collective.circleId,
 				userId: member.id,

--- a/src/components/Page.vue
+++ b/src/components/Page.vue
@@ -101,6 +101,7 @@
 					@click="toggle('sidebar')" />
 			</NcActions>
 		</h1>
+		<LandingPageWidgets v-if="isLandingPage" />
 		<TextEditor :key="`text-editor-${currentPage.id}`"
 			ref="texteditor" />
 	</div>
@@ -113,6 +114,7 @@ import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
 import CollectivesIcon from './Icon/CollectivesIcon.vue'
 import EmoticonOutlineIcon from 'vue-material-design-icons/EmoticonOutline.vue'
 import EditButton from './Page/EditButton.vue'
+import LandingPageWidgets from './Page/LandingPageWidgets.vue'
 import PageActionMenu from './Page/PageActionMenu.vue'
 import PageTemplateIcon from './Icon/PageTemplateIcon.vue'
 import TextEditor from './Page/TextEditor.vue'
@@ -128,6 +130,7 @@ export default {
 		CollectivesIcon,
 		EditButton,
 		EmoticonOutlineIcon,
+		LandingPageWidgets,
 		NcActionButton,
 		NcActions,
 		NcButton,

--- a/src/components/Page/LandingPageWidgets.vue
+++ b/src/components/Page/LandingPageWidgets.vue
@@ -1,0 +1,32 @@
+<template>
+	<div class="landing-page-widgets">
+		<MembersWidget v-if="!isPublic" />
+	</div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import MembersWidget from './LandingPageWidgets/MembersWidget.vue'
+
+export default {
+	name: 'LandingPageWidgets',
+
+	components: {
+		MembersWidget,
+	},
+
+	computed: {
+		...mapGetters([
+			'isPublic',
+		]),
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.landing-page-widgets {
+	margin: auto;
+	padding-left: 12px;
+	max-width: 670px;
+}
+</style>

--- a/src/components/Page/LandingPageWidgets.vue
+++ b/src/components/Page/LandingPageWidgets.vue
@@ -1,5 +1,6 @@
 <template>
 	<div class="landing-page-widgets">
+		<RecentPagesWidget />
 		<MembersWidget v-if="!isPublic" />
 	</div>
 </template>
@@ -7,12 +8,14 @@
 <script>
 import { mapGetters } from 'vuex'
 import MembersWidget from './LandingPageWidgets/MembersWidget.vue'
+import RecentPagesWidget from './LandingPageWidgets/RecentPagesWidget.vue'
 
 export default {
 	name: 'LandingPageWidgets',
 
 	components: {
 		MembersWidget,
+		RecentPagesWidget,
 	},
 
 	computed: {

--- a/src/components/Page/LandingPageWidgets.vue
+++ b/src/components/Page/LandingPageWidgets.vue
@@ -26,7 +26,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .landing-page-widgets {
 	margin: auto;
 	padding-left: 12px;

--- a/src/components/Page/LandingPageWidgets/MembersWidget.vue
+++ b/src/components/Page/LandingPageWidgets/MembersWidget.vue
@@ -1,7 +1,11 @@
 <template>
 	<div class="members-widget">
 		<WidgetHeading :title="t('collectives', 'Collective members')" />
-		<div ref="members" class="members-widget-members">
+		<SkeletonLoading v-if="loading"
+			type="avatar"
+			:count="3"
+			class="members-widget-skeleton" />
+		<div v-else ref="members" class="members-widget-members">
 			<NcAvatar v-for="member in trimmedMembers"
 				:key="member.singleId"
 				:user="member.userId"
@@ -28,6 +32,7 @@ import debounce from 'debounce'
 import { mapActions, mapGetters, mapMutations } from 'vuex'
 import { NcAvatar, NcButton } from '@nextcloud/vue'
 import DotsHorizontalIcon from 'vue-material-design-icons/DotsHorizontal.vue'
+import SkeletonLoading from '../../SkeletonLoading.vue'
 import { GET_CIRCLE_MEMBERS } from '../../../store/actions.js'
 import { circlesMemberTypes } from '../../../constants.js'
 import WidgetHeading from './WidgetHeading.vue'
@@ -39,6 +44,7 @@ export default {
 		DotsHorizontalIcon,
 		NcAvatar,
 		NcButton,
+		SkeletonLoading,
 		WidgetHeading,
 	},
 
@@ -65,6 +71,10 @@ export default {
 		trimmedMembers() {
 			return this.sortedMembers
 				.slice(0, this.showMembersCount)
+		},
+
+		loading() {
+			return this.trimmedMembers.length === 0
 		},
 
 		isNoUser() {
@@ -142,6 +152,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.members-widget-skeleton {
+	height: 44px;
+	margin-top: 12px;
+}
+
 .members-widget-members {
 	display: flex;
 	flex-direction: row;

--- a/src/components/Page/LandingPageWidgets/MembersWidget.vue
+++ b/src/components/Page/LandingPageWidgets/MembersWidget.vue
@@ -1,0 +1,126 @@
+<template>
+	<div class="members-widget">
+		<WidgetHeading :title="t('collectives', 'Collective members')" />
+		<div class="members-widget-members">
+			<NcAvatar v-for="member in trimmedMembers"
+				:key="member.singleId"
+				:user="member.userId"
+				:display-name="member.displayName"
+				:is-no-user="isNoUser(member)"
+				:icon-class="iconClass(member)"
+				:disable-menu="true"
+				:tooltip-message="member.displayName"
+				:size="44" />
+			<NcButton v-if="showMoreButton"
+				type="secondary"
+				:aria-label="t('collectives', 'Show all members of the collective')"
+				@click="openCollectiveMembers()">
+				<template #icon>
+					<DotsHorizontalIcon :size="20" />
+				</template>
+			</NcButton>
+		</div>
+	</div>
+</template>
+
+<script>
+import { mapActions, mapGetters, mapMutations } from 'vuex'
+import { NcAvatar, NcButton } from '@nextcloud/vue'
+import DotsHorizontalIcon from 'vue-material-design-icons/DotsHorizontal.vue'
+import { GET_CIRCLE_MEMBERS } from '../../../store/actions.js'
+import { circlesMemberTypes } from '../../../constants.js'
+import WidgetHeading from './WidgetHeading.vue'
+
+const SHOW_MEMBERS_COUNT = 3
+
+export default {
+	name: 'MembersWidget',
+
+	components: {
+		DotsHorizontalIcon,
+		NcAvatar,
+		NcButton,
+		WidgetHeading,
+	},
+
+	computed: {
+		...mapGetters([
+			'circleMembersSorted',
+			'circleMemberType',
+			'currentCollective',
+			'isCollectiveAdmin',
+			'recentPagesUserIds',
+		]),
+
+		sortedMembers() {
+			return this.circleMembersSorted(this.currentCollective.circleId)
+				.slice()
+				.sort(this.sortLastActiveFirst)
+		},
+
+		trimmedMembers() {
+			return this.sortedMembers
+				.slice(0, SHOW_MEMBERS_COUNT)
+		},
+
+		isNoUser() {
+			return function(member) {
+				return this.circleMemberType(member) !== circlesMemberTypes.TYPE_USER
+			}
+		},
+
+		iconClass() {
+			return function(member) {
+				return this.isNoUser(member) ? 'icon-group-white' : null
+			}
+		},
+
+		showMoreButton() {
+			return this.isCollectiveAdmin(this.currentCollective)
+				|| this.sortedMembers.length > SHOW_MEMBERS_COUNT
+		},
+	},
+
+	beforeMount() {
+		this.dispatchGetCircleMembers(this.currentCollective.circleId)
+	},
+
+	methods: {
+		...mapActions({
+			dispatchGetCircleMembers: GET_CIRCLE_MEMBERS,
+		}),
+
+		...mapMutations([
+			'setMembersCollectiveId',
+		]),
+
+		openCollectiveMembers() {
+			this.setMembersCollectiveId(this.currentCollective.id)
+		},
+
+		/**
+		 * @param {object} m1 First member
+		 * @param {string} m1.userId First member user ID
+		 * @param {object} m2 Second member
+		 * @param {string} m2.userId Second member user ID
+		 */
+		sortLastActiveFirst(m1, m2) {
+			if (this.recentPagesUserIds.includes(m1.userId) && this.recentPagesUserIds.includes(m2.userId)) {
+				return this.recentPagesUserIds.indexOf(m1.userId) > this.recentPagesUserIds.indexOf(m2.userId)
+			} else if (this.recentPagesUserIds.includes(m1.userId)) {
+				return -1
+			} else if (this.recentPagesUserIds.includes(m2.userId)) {
+				return 1
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.members-widget-members {
+	display: flex;
+	flex-direction: row;
+	gap: 12px;
+}
+</style>

--- a/src/components/Page/LandingPageWidgets/MembersWidget.vue
+++ b/src/components/Page/LandingPageWidgets/MembersWidget.vue
@@ -122,5 +122,6 @@ export default {
 	display: flex;
 	flex-direction: row;
 	gap: 12px;
+	margin-top: 12px;
 }
 </style>

--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -9,7 +9,7 @@
 			</template>
 		</div>
 		<div class="recent-page-tile__title">
-			{{ page.title }}
+			{{ title }}
 		</div>
 		<LastUserBubble :last-user-id="page.lastUserId"
 			:last-user-display-name="page.lastUserDisplayName"
@@ -41,6 +41,12 @@ export default {
 		...mapGetters([
 			'pagePath',
 		]),
+
+		title() {
+			return this.page.title === 'Readme'
+				? t('collectives', 'Landing page')
+				: this.page.title
+		},
 	},
 }
 </script>

--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -61,6 +61,7 @@ export default {
 	box-sizing: content-box;
 	padding: 12px;
 
+	scroll-snap-align: start;
 	border-radius: var(--border-radius-rounded);
 
 	&:hover {

--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -1,0 +1,98 @@
+<template>
+	<router-link :to="pagePath(page)" class="recent-page-tile">
+		<div class="recent-page-tile__rectangle">
+			<template v-if="isTemplate">
+				<PageTemplateIcon :size="36" fill-color="var(--color-background-darker)" />
+			</template>
+			<template v-else-if="page.emoji">
+				{{ page.emoji }}
+			</template>
+			<template v-else>
+				<PageIcon :size="36" fill-color="var(--color-background-darker)" />
+			</template>
+		</div>
+		<div class="recent-page-tile__title">
+			{{ page.title }}
+		</div>
+		<LastUserBubble :last-user-id="page.lastUserId"
+			:last-user-display-name="page.lastUserDisplayName"
+			:timestamp="page.timestamp"
+			class="recent-page-tile__last-user-bubble" />
+	</router-link>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import LastUserBubble from '../../LastUserBubble.vue'
+import PageTemplateIcon from '../../Icon/PageTemplateIcon.vue'
+import PageIcon from '../../Icon/PageIcon.vue'
+
+export default {
+	name: 'RecentPageTile',
+	components: {
+		LastUserBubble,
+		PageIcon,
+		PageTemplateIcon,
+	},
+
+	props: {
+		page: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	computed: {
+		...mapGetters([
+			'pagePath',
+		]),
+
+		isTemplate() {
+			return this.page.title === 'Template'
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.recent-page-tile {
+	margin-right: 12px;
+	max-width: 150px;
+	box-sizing: content-box;
+	padding: 12px;
+
+	border-radius: var(--border-radius-rounded);
+
+	&:hover {
+		background-color: var(--color-background-hover);
+	}
+
+	&__rectangle {
+		display: flex;
+		height: 150px;
+		width: 150px;
+
+		font-size: 36px;
+		align-items: center;
+		align-content: center;
+		justify-content: center;
+		background-color: var(--color-primary-element-light);
+		border-radius: var(--border-radius-rounded);
+	}
+
+	&__title {
+		margin-top: 12px;
+		font-size: 20px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__last-user-bubble {
+		margin-top: 8px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+}
+</style>

--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -94,6 +94,12 @@ export default {
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+		display: flex;
+		flex-direction: column;
+
+		:deep(.timestamp) {
+			color: var(--color-text-maxcontrast);
+		}
 	}
 }
 </style>

--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -2,13 +2,13 @@
 	<router-link :to="pagePath(page)" class="recent-page-tile">
 		<div class="recent-page-tile__rectangle">
 			<template v-if="isTemplate">
-				<PageTemplateIcon :size="36" fill-color="var(--color-background-darker)" />
+				<PageTemplateIcon :size="36" fill-color="var(--color-text-maxcontrast)" />
 			</template>
 			<template v-else-if="page.emoji">
 				{{ page.emoji }}
 			</template>
 			<template v-else>
-				<PageIcon :size="36" fill-color="var(--color-background-darker)" />
+				<PageIcon :size="36" fill-color="var(--color-text-maxcontrast)" />
 			</template>
 		</div>
 		<div class="recent-page-tile__title">

--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -1,10 +1,7 @@
 <template>
 	<router-link :to="pagePath(page)" class="recent-page-tile">
 		<div class="recent-page-tile__rectangle">
-			<template v-if="isTemplate">
-				<PageTemplateIcon :size="36" fill-color="var(--color-text-maxcontrast)" />
-			</template>
-			<template v-else-if="page.emoji">
+			<template v-if="page.emoji">
 				{{ page.emoji }}
 			</template>
 			<template v-else>
@@ -24,7 +21,6 @@
 <script>
 import { mapGetters } from 'vuex'
 import LastUserBubble from '../../LastUserBubble.vue'
-import PageTemplateIcon from '../../Icon/PageTemplateIcon.vue'
 import PageIcon from '../../Icon/PageIcon.vue'
 
 export default {
@@ -32,7 +28,6 @@ export default {
 	components: {
 		LastUserBubble,
 		PageIcon,
-		PageTemplateIcon,
 	},
 
 	props: {
@@ -46,10 +41,6 @@ export default {
 		...mapGetters([
 			'pagePath',
 		]),
-
-		isTemplate() {
-			return this.page.title === 'Template'
-		},
 	},
 }
 </script>

--- a/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="recent-pages-widget">
-		<WidgetHeading :title="t('collectives', 'Recent pages')" />
+		<WidgetHeading :title="t('collectives', 'Recent pages')" :first="true" />
 		<div class="recent-pages-widget-container">
 			<div ref="pageslider" class="recent-pages-widget-pages">
 				<RecentPageTile v-for="page in trimmedRecentPages"

--- a/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
@@ -1,0 +1,124 @@
+<template>
+	<div class="recent-pages-widget">
+		<WidgetHeading :title="t('collectives', 'Recent pages')" />
+		<div ref="pageslider" class="recent-pages-widget-pages">
+			<button ref="buttonslideleft"
+				class="button-slide button-slide__left hidden"
+				:aria-label="t('collectives', 'Scroll recent pages to the left')"
+				@click="slideLeft"
+				@keypress.enter.prevent="slideLeft">
+				<ChevronLeftButton :size="44" />
+			</button>
+			<RecentPageTile v-for="page in trimmedRecentPages"
+				:key="page.id"
+				:page="page" />
+			<button ref="buttonslideright"
+				class="button-slide button-slide__right"
+				:aria-label="t('collectives', 'Scroll recent pages to the left')"
+				@click="slideRight"
+				@keypress.enter.prevent="slideRight">
+				<ChevronRightButton :size="44" />
+			</button>
+		</div>
+	</div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import ChevronLeftButton from 'vue-material-design-icons/ChevronLeft.vue'
+import ChevronRightButton from 'vue-material-design-icons/ChevronRight.vue'
+import RecentPageTile from './RecentPageTile.vue'
+import WidgetHeading from './WidgetHeading.vue'
+
+const SLIDE_OFFSET = 198
+
+export default {
+	name: 'RecentPagesWidget',
+
+	components: {
+		ChevronLeftButton,
+		ChevronRightButton,
+		RecentPageTile,
+		WidgetHeading,
+	},
+
+	computed: {
+		...mapGetters([
+			'recentPages',
+		]),
+
+		trimmedRecentPages() {
+			return this.recentPages
+				.slice(0, 10)
+		},
+	},
+
+	methods: {
+		updateButtons() {
+			const pagesliderEl = this.$refs.pageslider
+			if (pagesliderEl.scrollLeft <= 0) {
+				this.$refs.buttonslideleft.classList.add('hidden')
+			} else {
+				this.$refs.buttonslideleft.classList.remove('hidden')
+			}
+
+			console.debug('pageslider', this.$refs.pageslider)
+			if (pagesliderEl.scrollLeft >= pagesliderEl.scrollLeftMax) {
+				this.$refs.buttonslideright.classList.add('hidden')
+			} else {
+				this.$refs.buttonslideright.classList.remove('hidden')
+			}
+		},
+
+		slideLeft() {
+			this.$refs.pageslider.scrollLeft -= (SLIDE_OFFSET)
+			this.updateButtons()
+		},
+
+		slideRight() {
+			this.$refs.pageslider.scrollLeft += (SLIDE_OFFSET)
+			this.updateButtons()
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.recent-pages-widget-pages {
+	position: relative;
+	display: flex;
+	flex-direction: row;
+	gap: 12px;
+	padding-top: 12px;
+
+	max-width: 670px;
+	overflow-x: auto;
+	scrollbar-width: none;
+}
+
+.button-slide {
+	position: sticky;
+	display: flex;
+	top: 0;
+	padding: 0;
+	border: 0;
+	border-radius: 0;
+	z-index: 2;
+
+	&__left {
+		left: 0;
+		padding-right: 48px;
+		background: linear-gradient(to left, rgba(0, 0, 0, 0), var(--color-main-background));
+	}
+
+	&__right {
+		right: 0;
+		padding-left: 48px;
+		background: linear-gradient(to right, rgba(0, 0, 0, 0), var(--color-main-background));
+	}
+
+	&.hidden {
+		display: none;
+	}
+}
+</style>

--- a/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
@@ -1,29 +1,34 @@
 <template>
 	<div class="recent-pages-widget">
 		<WidgetHeading :title="t('collectives', 'Recent pages')" />
-		<div ref="pageslider" class="recent-pages-widget-pages">
-			<button ref="buttonslideleft"
-				class="button-slide button-slide__left hidden"
-				:aria-label="t('collectives', 'Scroll recent pages to the left')"
-				@click="slideLeft"
-				@keypress.enter.prevent="slideLeft">
-				<ChevronLeftButton :size="44" />
-			</button>
-			<RecentPageTile v-for="page in trimmedRecentPages"
-				:key="page.id"
-				:page="page" />
-			<button ref="buttonslideright"
-				class="button-slide button-slide__right"
-				:aria-label="t('collectives', 'Scroll recent pages to the left')"
-				@click="slideRight"
-				@keypress.enter.prevent="slideRight">
-				<ChevronRightButton :size="44" />
-			</button>
+		<div class="recent-pages-widget-container">
+			<div ref="pageslider" class="recent-pages-widget-pages">
+				<RecentPageTile v-for="page in trimmedRecentPages"
+					:key="page.id"
+					:page="page" />
+			</div>
+			<div class="recent-pages-widget-buttons">
+				<button ref="buttonslideleft"
+					class="button-slide button-slide__left hidden"
+					:aria-label="t('collectives', 'Scroll recent pages to the left')"
+					@click="slideLeft"
+					@keypress.enter.prevent="slideLeft">
+					<ChevronLeftButton :size="44" />
+				</button>
+				<button ref="buttonslideright"
+					class="button-slide button-slide__right hidden"
+					:aria-label="t('collectives', 'Scroll recent pages to the left')"
+					@click="slideRight"
+					@keypress.enter.prevent="slideRight">
+					<ChevronRightButton :size="44" />
+				</button>
+			</div>
 		</div>
 	</div>
 </template>
 
 <script>
+import debounce from 'debounce'
 import { mapGetters } from 'vuex'
 import ChevronLeftButton from 'vue-material-design-icons/ChevronLeft.vue'
 import ChevronRightButton from 'vue-material-design-icons/ChevronRight.vue'
@@ -53,8 +58,19 @@ export default {
 		},
 	},
 
+	mounted() {
+		this.$nextTick(() => {
+			this.updateButtons()
+		})
+		this.$refs.pageslider.addEventListener('scroll', this.updateButtons)
+	},
+
+	unmounted() {
+		this.$refs.pageslider.removeEventListener('scroll', this.updateButtons)
+	},
+
 	methods: {
-		updateButtons() {
+		updateButtons: debounce(function() {
 			const pagesliderEl = this.$refs.pageslider
 			if (pagesliderEl.scrollLeft <= 0) {
 				this.$refs.buttonslideleft.classList.add('hidden')
@@ -62,21 +78,32 @@ export default {
 				this.$refs.buttonslideleft.classList.remove('hidden')
 			}
 
-			console.debug('pageslider', this.$refs.pageslider)
 			if (pagesliderEl.scrollLeft >= pagesliderEl.scrollLeftMax) {
 				this.$refs.buttonslideright.classList.add('hidden')
 			} else {
 				this.$refs.buttonslideright.classList.remove('hidden')
 			}
-		},
+		}, 50),
 
 		slideLeft() {
-			this.$refs.pageslider.scrollLeft -= (SLIDE_OFFSET)
+			const pagesliderEl = this.$refs.pageslider
+			const newScrollLeft = Math.max(0, pagesliderEl.scrollLeft -= SLIDE_OFFSET)
+			pagesliderEl.scrollTo({
+				top: pagesliderEl.scrollTop,
+				left: pagesliderEl.scrollLeft = newScrollLeft,
+				behavior: 'smooth',
+			})
 			this.updateButtons()
 		},
 
 		slideRight() {
-			this.$refs.pageslider.scrollLeft += (SLIDE_OFFSET)
+			const pagesliderEl = this.$refs.pageslider
+			const newScrollLeft = Math.min(pagesliderEl.scrollLeftMax, pagesliderEl.scrollLeft += SLIDE_OFFSET)
+			pagesliderEl.scrollTo({
+				top: pagesliderEl.scrollTop,
+				left: pagesliderEl.scrollLeft = newScrollLeft,
+				behavior: 'smooth',
+			})
 			this.updateButtons()
 		},
 	},
@@ -84,37 +111,54 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.recent-pages-widget-pages {
+.recent-pages-widget-container {
 	position: relative;
-	display: flex;
-	flex-direction: row;
-	gap: 12px;
 	padding-top: 12px;
 
-	max-width: 670px;
-	overflow-x: auto;
-	scrollbar-width: none;
+	.recent-pages-widget-pages {
+		display: flex;
+		flex-direction: row;
+		gap: 12px;
+
+		max-width: 670px;
+		overflow-x: auto;
+		scroll-snap-type: x mandatory;
+		scrollbar-width: none;
+	}
 }
 
 .button-slide {
-	position: sticky;
+	position: absolute;
+	width: 100px;
+	height: 100%;
 	display: flex;
+	right: 0;
 	top: 0;
+	bottom: 0;
 	padding: 0;
+	margin: 0;
 	border: 0;
 	border-radius: 0;
 	z-index: 2;
 
 	&__left {
 		left: 0;
-		padding-right: 48px;
+		justify-content: left;
 		background: linear-gradient(to left, rgba(0, 0, 0, 0), var(--color-main-background));
+
+		&:active {
+			background: linear-gradient(to left, rgba(0, 0, 0, 0), var(--color-main-background)) !important;
+		}
 	}
 
 	&__right {
 		right: 0;
-		padding-left: 48px;
+		justify-content: right;
 		background: linear-gradient(to right, rgba(0, 0, 0, 0), var(--color-main-background));
+
+		&:active {
+			background: linear-gradient(to right, rgba(0, 0, 0, 0), var(--color-main-background)) !important;
+		}
 	}
 
 	&.hidden {

--- a/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
@@ -72,6 +72,9 @@ export default {
 	methods: {
 		updateButtons: debounce(function() {
 			const pagesliderEl = this.$refs.pageslider
+			if (!pagesliderEl) {
+				return
+			}
 			if (pagesliderEl.scrollLeft <= 0) {
 				this.$refs.buttonslideleft.classList.add('hidden')
 			} else {
@@ -98,7 +101,8 @@ export default {
 
 		slideRight() {
 			const pagesliderEl = this.$refs.pageslider
-			const newScrollLeft = Math.min(pagesliderEl.scrollLeftMax, pagesliderEl.scrollLeft += SLIDE_OFFSET)
+			const scrollLeftMax = pagesliderEl.scrollWidth - pagesliderEl.clientWidth
+			const newScrollLeft = Math.min(scrollLeftMax, pagesliderEl.scrollLeft += SLIDE_OFFSET)
 			pagesliderEl.scrollTo({
 				top: pagesliderEl.scrollTop,
 				left: pagesliderEl.scrollLeft = newScrollLeft,
@@ -123,7 +127,12 @@ export default {
 		max-width: 670px;
 		overflow-x: auto;
 		scroll-snap-type: x mandatory;
+		// Hide scrollbar
 		scrollbar-width: none;
+		-ms-overflow-style: none;
+		&::-webkit-scrollbar {
+			display: none;
+		}
 	}
 }
 

--- a/src/components/Page/LandingPageWidgets/WidgetHeading.vue
+++ b/src/components/Page/LandingPageWidgets/WidgetHeading.vue
@@ -1,0 +1,27 @@
+<template>
+	<div class="widget-heading">
+		{{ title }}
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'WidgetHeading',
+
+	props: {
+		title: {
+			type: String,
+			required: true,
+		},
+	},
+}
+</script>
+
+<style scoped>
+.widget-heading {
+	padding: 30px 0 12px 0;
+	font-size: 20px;
+	font-weight: bold;
+	color: var(--color-text-maxcontrast);
+}
+</style>

--- a/src/components/Page/LandingPageWidgets/WidgetHeading.vue
+++ b/src/components/Page/LandingPageWidgets/WidgetHeading.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="widget-heading">
+	<div class="widget-heading" :class="{'first': first}">
 		{{ title }}
 	</div>
 </template>
@@ -13,15 +13,23 @@ export default {
 			type: String,
 			required: true,
 		},
+		first: {
+			type: Boolean,
+			default: false,
+		},
 	},
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .widget-heading {
-	padding: 30px 0 12px 0;
+	padding: 36px 0 12px 0;
 	font-size: 20px;
 	font-weight: bold;
 	color: var(--color-text-maxcontrast);
+
+	&.first {
+		padding-top: 24px;
+	}
 }
 </style>

--- a/src/components/Page/PageInfoBar.vue
+++ b/src/components/Page/PageInfoBar.vue
@@ -4,7 +4,8 @@
 			<div class="item-text">
 				<LastUserBubble :last-user-id="currentPage.lastUserId"
 					:last-user-display-name="currentPage.lastUserDisplayName"
-					:timestamp="currentPage.timestamp" />
+					:timestamp="currentPage.timestamp"
+					:show-prefix-string="true" />
 			</div>
 		</div>
 	</div>

--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<WidgetHeading v-if="isLandingPage"
-			:title="t('collectives', 'Description')"
+			:title="t('collectives', 'Landing page')"
 			class="text-container-heading" />
 		<div v-show="showRichText"
 			id="text-container"

--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -1,5 +1,8 @@
 <template>
 	<div>
+		<WidgetHeading v-if="isLandingPage"
+			:title="t('collectives', 'Description')"
+			class="text-container-heading" />
 		<div v-show="showRichText"
 			id="text-container"
 			:key="'text-' + currentPage.id"
@@ -20,6 +23,7 @@
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import Editor from './Editor.vue'
 import RichText from './RichText.vue'
+import WidgetHeading from './LandingPageWidgets/WidgetHeading.vue'
 import { mapActions, mapGetters, mapMutations } from 'vuex'
 import {
 	GET_VERSIONS,
@@ -33,6 +37,7 @@ export default {
 	components: {
 		Editor,
 		RichText,
+		WidgetHeading,
 	},
 
 	mixins: [
@@ -56,6 +61,7 @@ export default {
 			'currentPage',
 			'currentPageDavUrl',
 			'hasVersionsLoaded',
+			'isLandingPage',
 			'isTemplatePage',
 			'isTextEdit',
 			'isPublic',
@@ -251,6 +257,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.text-container-heading {
+	max-width: 670px;
+	margin: auto;
+	padding-left: 14px;
+}
 
 #text-container {
 	display: block;

--- a/src/components/SkeletonLoading.vue
+++ b/src/components/SkeletonLoading.vue
@@ -11,7 +11,7 @@
 				</defs>
 			</svg>
 
-			<ul :key="'list' + suffix" :class="'placeholder-list placeholder-list' + suffix">
+			<ul :key="'list' + suffix" :class="'placeholder-list placeholder-list' + suffix + ' placeholder-list-' + type">
 				<li v-for="(width, index) in placeholderData" :key="'placeholder' + suffix + index">
 					<svg v-if="type === 'items' || type === 'members-list'"
 						:class="`${type}-placeholder`"
@@ -36,6 +36,12 @@
 						<rect class="text-placeholder-line-two" :style="textPlaceholderData[1]" />
 						<rect class="text-placeholder-line-three" :style="textPlaceholderData[2]" />
 						<rect class="text-placeholder-line-four" :style="textPlaceholderData[3]" />
+					</svg>
+					<svg v-if="type === 'avatar'"
+						class="avatar-placeholder"
+						xmlns="http://www.w3.org/2000/svg"
+						:fill="'url(#placeholder-gradient' + suffix + ')'">
+						<circle class="avatar-placeholder-icon" />
 					</svg>
 				</li>
 			</ul>
@@ -123,6 +129,11 @@ $messages-list-max-width: 670px;
 	animation-timing-function: linear;
 }
 
+.placeholder-list-avatar {
+	display: flex;
+	gap: 12px;
+}
+
 .placeholder-gradient {
 	position: fixed;
 	height: 0;
@@ -175,6 +186,20 @@ $messages-list-max-width: 670px;
 	&-line-one {
 		x: 60px;
 		y: 16px;
+	}
+}
+
+.avatar-placeholder {
+	$icon-size: 44px;
+	height: $icon-size;
+	width: $icon-size;
+
+	&-icon {
+		width: $icon-size;
+		height: $icon-size;
+		cx: calc(#{$icon-size} / 2);
+		cy: calc(#{$icon-size} / 2);
+		r: calc(#{$icon-size} / 2);
 	}
 }
 

--- a/src/store/circles.js
+++ b/src/store/circles.js
@@ -52,6 +52,39 @@ export default {
 				? member.userType
 				: member.basedOn.source
 		},
+
+		circleMembersSorted: (state, getters) => (circleId) => {
+			/**
+			 * @param {object} m1 First member
+			 * @param {string} m1.userId First member user ID
+			 * @param {string} m1.displayName First member display name
+			 * @param {number} m1.level First member level
+			 * @param {number} m1.userType First member user type
+			 * @param {object} m2 Second member
+			 * @param {string} m2.userId Second member user ID
+			 * @param {string} m2.displayName Second member display name
+			 * @param {number} m2.level Second member level
+			 * @param {number} m2.userType Second member user type
+			 */
+			function sortMembersByLevelAndType(m1, m2) {
+				// Sort by level (admin > moderator > member)
+				if (m1.level !== m2.level) {
+					return m1.level < m2.level
+				}
+
+				// Sort by user type (user > group > circle)
+				if (getters.circleMemberType(m1) !== getters.circleMemberType(m2)) {
+					return getters.circleMemberType(m1) > getters.circleMemberType(m2)
+				}
+
+				// Sort by display name
+				return m1.displayName.localeCompare(m2.displayName)
+			}
+
+			return getters.circleMembers(circleId)
+				.slice()
+				.sort(sortMembersByLevelAndType)
+		},
 	},
 
 	mutations: {

--- a/src/store/pages.js
+++ b/src/store/pages.js
@@ -320,6 +320,22 @@ export default {
 		trashPages(state) {
 			return state.trashPages.sort((a, b) => b.trashTimestamp - a.trashTimestamp)
 		},
+
+		recentPages(state) {
+			return state.pages
+				.slice()
+				.sort(sortOrders.byTimestamp)
+		},
+
+		recentPagesUserIds(_state, getters) {
+			return getters.recentPages
+				// take only userIds
+				.map(p => p.lastUserId)
+				// filter out duplicates
+				.filter((value, index, array) => {
+					return array.indexOf(value) === index
+				})
+		},
 	},
 
 	mutations: {

--- a/src/store/pages.js
+++ b/src/store/pages.js
@@ -324,6 +324,7 @@ export default {
 		recentPages(state) {
 			return state.pages
 				.slice()
+				.filter(p => p.title !== 'Template')
 				.sort(sortOrders.byTimestamp)
 		},
 


### PR DESCRIPTION
### 📝 Summary

* Show 10 most recent pages on landing page.
* Show 3 last active members on landing page if it's not a public share.
* Resolves: #311

#### 🖼️ Screenshots

| Overview |
|---|
| ![grafik](https://github.com/nextcloud/collectives/assets/3582805/3885eb23-fabb-43f2-beaa-5fd2bffe71bf) |

| Screencast (slightly outdated) |
|---|
| [recording1.webm](https://github.com/nextcloud/collectives/assets/3582805/7da61f0e-0954-4300-99fe-e9a0447f8dea) |

### 🚧 TODO

- [x] Animate scroll to left/right in recent pages slider
- [x] Update scroll buttons on scrolling (without using the buttons)
- [x] Don't display scroll to right button initially when not necessary
- [ ] Show status in members avatars
- [x] Cypress tests


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
