### PR TITLE
fix: Make sure collectives own scroll area is used for menubar stickyness

### DIFF
--- a/src/Collectives.vue
+++ b/src/Collectives.vue
@@ -131,6 +131,10 @@ export default {
 	padding-bottom: 200px;
 }
 
+#titleform {
+	z-index: 10022;
+}
+
 #version-title, #titleform input[type='text'] {
 	font-size: 35px;
 	border: none;

--- a/src/components/Page.vue
+++ b/src/components/Page.vue
@@ -302,8 +302,6 @@ export default {
 
 <style lang="scss" scoped>
 #titleform {
-	z-index: 10022;
-
 	form {
 		flex: auto;
 	}

--- a/src/components/Page/Editor.vue
+++ b/src/components/Page/Editor.vue
@@ -80,6 +80,10 @@ export default {
 </script>
 
 <style lang="scss">
+[data-text-el='editor-container'] {
+	overflow: initial !important;
+}
+
 [data-text-el='editor-container'] .document-status {
 	max-width: 670px;
 	padding: 0 2px;


### PR DESCRIPTION
As https://github.com/nextcloud/text/pull/2832 introduced a max-height to properly handle `.text-editor` being the scroll container for any viewer rendered editor, we will need to adapt the styling here slightly as collectives comes with its own scroll container.

Note that the API for rendering the editor externally would solve that as this one doesn't bring its own scroll container https://github.com/nextcloud/text#%EF%B8%8F-integrate-text-in-your-app but needs more work to have feature parity for collectives.

- [x] Test with all compatible nextcloud releases
  - [x] 27.1
  - [x] 27.0
  - [x] 26
  - [x] 25
### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
