### PR TITLE
fix: Use shared init file to properly set nonce for async component loading

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -25,12 +25,11 @@ import Collectives from './Collectives.vue'
 import router from './router.js'
 import store from './store/store.js'
 import { sync } from 'vuex-router-sync'
-import { generateFilePath } from '@nextcloud/router'
 
 /** Global directives */
 import VTooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
-__webpack_public_path__ = generateFilePath('collectives', '', 'js/') // eslint-disable-line
+import './shared-init.js'
 
 // Register global directives
 Vue.directive('Tooltip', VTooltip)

--- a/src/shared-init.js
+++ b/src/shared-init.js
@@ -1,9 +1,12 @@
+import { getRequestToken } from '@nextcloud/auth'
+import { generateFilePath } from '@nextcloud/router'
+
 // eslint-disable-next-line
-__webpack_nonce__ = btoa(OC.requestToken)
+__webpack_nonce__ = btoa(getRequestToken())
 
 if (!process.env.WEBPACK_SERVE) {
 	// eslint-disable-next-line
-	__webpack_public_path__ = OC.linkTo('collectives', 'js/')
+	__webpack_public_path__ = generateFilePath('collectives', '', 'js/')
 } else {
 	// eslint-disable-next-line
 	__webpack_public_path__ = 'http://127.0.0.1:3000/'


### PR DESCRIPTION
Otherwise mermaid diagrams are not loaded in read only view as the async chunks cannot be fetched due to CSP errors

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
