### PR TITLE
fix(cy): use flexible selector for file list in Nextcloud 25-28

### DIFF
--- a/cypress/e2e/apps.spec.js
+++ b/cypress/e2e/apps.spec.js
@@ -51,7 +51,7 @@ describe('The apps', function() {
 
 		it('Renders the default files list', function() {
 			cy.login('jane', { route: 'apps/files' })
-			cy.get('.files-fileList tr').should('contain', 'welcome.txt')
+			cy.get('.files-fileList tr, .files-list__tbody tr').should('contain', 'welcome.txt')
 		})
 
 	})

--- a/cypress/e2e/collective.spec.js
+++ b/cypress/e2e/collective.spec.js
@@ -46,15 +46,16 @@ describe('Collective', function() {
 			cy.login('bob', { route: '/apps/files' })
 		})
 		it('has a matching folder', function() {
-			const fileListSelector = '.files-fileList'
-			const controlsSelector = '.files-controls'
+			const fileListSelector = '.files-fileList a, [data-cy-files-list-row] a'
+			const breadcrumbsSelector = '.files-controls .breadcrumb, [data-cy-files-content-breadcrumbs] a'
 			cy.get(fileListSelector).should('contain', 'Collectives')
-			cy.get(`${fileListSelector} a`).contains('Collectives').click()
-			cy.get(`${controlsSelector} .breadcrumb`).should('contain', 'Collectives')
+			cy.get(fileListSelector).contains('Collectives').click()
+			cy.get(breadcrumbsSelector).should('contain', 'Collectives')
 			cy.get(fileListSelector).should('contain', 'Preexisting Collective')
-			cy.get(`${fileListSelector} a`).contains('Preexisting Collective').click()
-			cy.get(`${controlsSelector} .breadcrumb`).should('contain', 'Preexisting Collective')
-			cy.get(fileListSelector).should('contain', 'Readme.md')
+			cy.get(fileListSelector).contains('Preexisting Collective').click()
+			cy.get(breadcrumbsSelector).should('contain', 'Preexisting Collective')
+			cy.get(fileListSelector).should('contain', 'Readme')
+			cy.get(fileListSelector).should('contain', '.md')
 			cy.get('.filelist-collectives-wrapper')
 				.should('contain', 'The content of this folder is best viewed in the Collectives app.')
 		})

--- a/cypress/e2e/settings.spec.js
+++ b/cypress/e2e/settings.spec.js
@@ -65,7 +65,7 @@ describe('Settings', function() {
 				.click()
 			cy.get('input[name="userFolder"]')
 				.click()
-			cy.get('[data-dir=""] > a')
+			cy.get('[data-dir=""] > a, a[title="Home"]')
 				.click()
 			cy.get('tr[data-entryname="Collectives"]')
 				.click()


### PR DESCRIPTION
### 📝 Summary

* Resolves: https://github.com/nextcloud/collectives/actions/runs/5981758520/job/16230201814

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![The apps -- Disabled circles app does not break files view -- Renders the default files list (failed)](https://github.com/nextcloud/collectives/assets/97337118/e5cb94e3-9cd2-4406-9fdc-7fb9b36ff8b0)
 | A


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required
