### PR TITLE
fix(RecentPagesWidget): Remove margin of slider button

### DIFF
--- a/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
@@ -145,7 +145,7 @@ export default {
 	top: 0;
 	bottom: 0;
 	padding: 0;
-	margin: 0;
+	margin: 0 !important;
 	border: 0;
 	border-radius: 0;
 	z-index: 2;


### PR DESCRIPTION
### 📝 Summary

Seems like recent upstream CSS changes introduced a margin for buttons. See screenshot.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![2023-09-05T12:18:44,407621562+02:00](https://github.com/nextcloud/collectives/assets/3582805/c4f47c84-870b-4a5a-afbc-42912cb2ae34) | ![2023-09-05T12:19:35,628725173+02:00](https://github.com/nextcloud/collectives/assets/3582805/0b669fe9-f7d9-443c-992c-8e02e92ea922)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
