### PR TITLE
fix(CollectiveFolderManager): Use our own LazyFolder implementation

### DIFF
--- a/lib/Mount/CollectiveFolderManager.php
+++ b/lib/Mount/CollectiveFolderManager.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OCA\Collectives\Mount;
 
-use OC\Files\Node\LazyFolder;
 use OC\Files\Storage\Wrapper\Jail;
 use OC\Files\Storage\Wrapper\PermissionsMask;
 use OCA\Collectives\ACL\ACLStorageWrapper25;
@@ -35,8 +34,7 @@ class CollectiveFolderManager {
 	private IRequest $request;
 	private ?string $rootPath = null;
 
-	/** @var int|null */
-	private $rootFolderStorageId = null;
+	private ?int $rootFolderStorageId = null;
 
 	/**
 	 * CollectiveFolderManager constructor.
@@ -78,14 +76,7 @@ class CollectiveFolderManager {
 	 * @return Folder
 	 */
 	public function getRootFolder(): Folder {
-		$rootFolder = $this->rootFolder;
-		return (new LazyFolder(function () use ($rootFolder) {
-			try {
-				return $rootFolder->get($this->getRootPath());
-			} catch (NotFoundException $e) {
-				return $rootFolder->newFolder($this->getRootPath());
-			}
-		}));
+		return new LazyFolder($this->rootFolder, $this->getRootPath());
 	}
 
 	/**
@@ -120,6 +111,8 @@ class CollectiveFolderManager {
 	 * @return IMountPoint|null
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
+	 *
+	 *
 	 */
 	public function getMount(int $id,
 		string $mountPoint,

--- a/lib/Mount/LazyFolder.php
+++ b/lib/Mount/LazyFolder.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Collectives\Mount;
+
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+
+class LazyFolder implements Folder {
+	private IRootFolder $rootFolder;
+	private string $rootPath;
+	private ?Folder $folder = null;
+
+	public function __construct(IRootFolder $rootFolder, string $rootPath) {
+		$this->rootFolder = $rootFolder;
+		$this->rootPath = $rootPath;
+	}
+
+	/**
+	 * @return Folder
+	 * @throws NotPermittedException
+	 */
+	private function getFolder(): Folder {
+		if ($this->folder === null) {
+			try {
+				$folder = $this->rootFolder->get($this->rootPath);
+				if (!$folder instanceof Folder) {
+					throw new NotFoundException('Not a folder: ' . $folder->getPath());
+				}
+				$this->folder = $folder;
+			} catch (NotFoundException $e) {
+				$this->folder = $this->rootFolder->newFolder($this->rootPath);
+			}
+		}
+
+		return $this->folder;
+	}
+
+	/**
+	 * Magic method to first get the real rootFolder and then
+	 * call $method with $args on it
+	 *
+	 * @param $method
+	 * @param $args
+	 * @return mixed
+	 */
+	public function __call($method, $args) {
+		$folder = $this->getFolder();
+
+		return call_user_func_array([$folder, $method], $args);
+	}
+
+	public function getMtime() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getMimetype() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getMimePart() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function isEncrypted() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getType() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function isShared() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function isMounted() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getMountPoint() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getOwner() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getChecksum() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getExtension(): string {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getCreationTime(): int {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getUploadTime(): int {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getParentId(): int {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getFullPath($path) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getRelativePath($path) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function isSubNode($node) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getDirectoryListing() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function get($path) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function nodeExists($path) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function newFolder($path) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function newFile($path, $content = null) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function search($query) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function searchByMime($mimetype) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function searchByTag($tag, $userId) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function searchBySystemTag(string $tagName, string $userId, int $limit = 0, int $offset = 0) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getById($id) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getFreeSpace() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function isCreatable() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getNonExistingName($name) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getRecent($limit, $offset = 0) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function move($targetPath) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function delete() {
+		$this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function copy($targetPath) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function touch($mtime = null) {
+		$this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getStorage() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getPath() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getInternalPath() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getId() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function stat() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getSize($includeMounts = true) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getEtag() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getPermissions() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function isReadable() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function isUpdateable() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function isDeletable() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function isShareable() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getParent() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getName() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function lock($type) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function changeLock($targetType) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function unlock($type) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+}

--- a/lib/Trash/PageTrashBackend.php
+++ b/lib/Trash/PageTrashBackend.php
@@ -539,7 +539,8 @@ class PageTrashBackend implements ITrashBackend {
 			$trashNode = $this->getTrashNodeById($user, $fileId);
 			// Get parent folder for index pages
 			if ($trashNode instanceof File && NodeHelper::isIndexPage($trashNode)) {
-				$trashNode = $trashNode->getParent();
+				// The extra `get()` is required to resolve the lazy folder from getParent()
+				$trashNode = $trashNode->getParent()->get('');
 			}
 			$trashItem = $this->trashManager->getTrashItemByFileId($trashNode->getId());
 			if ($trashItem && method_exists($trashNode, 'getFileInfo')) {

--- a/tests/Integration/features/pagesDisabledTrashAndVersion.feature
+++ b/tests/Integration/features/pagesDisabledTrashAndVersion.feature
@@ -1,4 +1,4 @@
-Feature: pages
+Feature: pagesDisabledTrashbin
 
   Scenario: Disable trashbin and versions apps
     When app "files_trashbin" is "disabled"


### PR DESCRIPTION
Required because constructor parameters changed for the private LazyFolder class with Nextcloud 28.

