### PR TITLE
fix(search): handle removed files gracefully

### DIFF
--- a/lib/Search/PageContentProvider.php
+++ b/lib/Search/PageContentProvider.php
@@ -109,17 +109,19 @@ class PageContentProvider implements IProvider {
 			try {
 				$collectiveRoot = $this->pageService->getCollectiveFolder($collective->getId(), $user->getUID());
 				$results = $this->indexedSearchService->searchCollective($collective, $query->getTerm());
-				foreach ($results as $fileId => $fileData) {
-					$file = $collectiveRoot->getById($fileId);
-					$pages[$fileId] = reset($file);
-					$collectiveMap[$fileId] = $collective;
-				}
 			} catch (FileSearchException|NotFoundException $e) {
 				$this->logger->warning('Collectives file content search failed.', [
 					'error' => $e->getMessage(),
 					'trace' => $e->getTraceAsString()
 				]);
 				continue;
+			}
+			foreach ($results as $fileId => $fileData) {
+				$fileEntries = $collectiveRoot->getById($fileId);
+				if (!empty($fileEntries)) {
+					$pages[$fileId] = $fileEntries[0];
+					$collectiveMap[$fileId] = $collective;
+				}
 			}
 		}
 

--- a/tests/Unit/Search/PageContentProviderTest.php
+++ b/tests/Unit/Search/PageContentProviderTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Unit\Service;
+
+use OC\Files\Node\Folder;
+use OC\Search\SearchQuery;
+use OCA\Collectives\Db\Collective;
+use OCA\Collectives\Search\PageContentProvider;
+use OCA\Collectives\Service\CollectiveHelper;
+use OCA\Collectives\Service\PageService;
+use OCA\Collectives\Service\SearchService;
+use OCP\App\IAppManager;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\Search\ISearchQuery;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class PageContentProviderTest extends TestCase {
+	private PageContentProvider $provider;
+
+	protected function setUp(): void {
+		$collective = new Collective();
+		$collective->setId(123);
+
+		/** @var IL10N&MockObject $l10n */
+		$l10n = $this->createMock(IL10N::class);
+		/** @var IURLGenerator&MockObject $urlGenerator */
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		/** @var CollectiveHelper&MockObject $collectiveHelper */
+		$collectiveHelper = $this->createMock(CollectiveHelper::class);
+		$collectiveHelper->method('getCollectivesForUser')
+			->willReturn([$collective]);
+		/** @var Folder&MockObject $folder */
+		$folder = $this->createMock(Folder::class);
+		$folder->method('getById')
+			->willReturn([]);
+		/** @var PageService&MockObject $pageService */
+		$pageService = $this->createMock(PageService::class);
+		$pageService->method('getCollectiveFolder')
+			->willReturn($folder);
+		/** @var SearchService&MockObject $indexedSearchService */
+		$indexedSearchService = $this->createMock(SearchService::class);
+		$indexedSearchService->method('searchCollective')
+			->willReturn(array(404 => 'fileData'));
+		/** @var LoggerInterface&MockObject $logger  */
+		$logger = $this->createMock(LoggerInterface::class);
+		/** @var IAppManager&MockObject $appManager */
+		$appManager = $this->createMock(IAppManager::class);
+		$appManager->method('isEnabledForUser')
+			->willReturn(true);
+
+		$this->provider = new PageContentProvider(
+			$l10n,
+			$urlGenerator,
+			$collectiveHelper,
+			$pageService,
+			$indexedSearchService,
+			$logger,
+			$appManager
+		);
+	}
+
+	public function testId(): void {
+		$this->assertEquals('collectives-page-content', $this->provider->getId());
+	}
+
+	public function testSearchWithMissingFile(): void {
+		/** @var IUser&MockObject $user */
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')
+			->willReturn('jane');
+		$query = new SearchQuery(
+			'Search me!',
+			ISearchQuery::SORT_DATE_DESC,
+			SearchQuery::LIMIT_DEFAULT,
+			null,
+			'collectives.'
+		);
+		$response = json_encode($this->provider->search($user, $query));
+		$result = json_decode($response, true);
+
+		$this->assertEquals(
+			'[]',
+			json_encode($result['entries'])
+		);
+	}
+}


### PR DESCRIPTION
When a result is found in the index
but the corresponding file does not exist in the storage anymore skip the result and return the other search results.

Fixes #873.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- no docs needed as this is a bugfix.