### PR TITLE
test(cypress): Make page list trash test retriable

### DIFF
--- a/cypress/e2e/page-list.spec.js
+++ b/cypress/e2e/page-list.spec.js
@@ -148,15 +148,18 @@ describe('Page list', function() {
 	})
 
 	describe('Page trash', function() {
-		it('allows to trash and restore page with subpage and attachment', function() {
-			cy.visit('/apps/collectives/Our%20Garden/Day%201')
 
-			// Insert attachment
+		// Insert attachment once
+		before(function() {
+			cy.visit('/apps/collectives/Our%20Garden/Day%201')
 			cy.intercept({ method: 'POST', url: '**/text/attachment/upload*' }).as('attachmentUpload')
 			cy.get('input[data-text-el="attachment-file-input"]')
 				.selectFile('cypress/fixtures/test.png', { force: true })
 			cy.wait('@attachmentUpload')
 			cy.switchPageMode(0)
+		})
+
+		it('allows to trash and restore page with subpage and attachment', function() {
 
 			// Trash page
 			cy.contains('.page-list .app-content-list-item', 'Day 1')


### PR DESCRIPTION
Only insert the attachment once.

When opening the page for the first time
it is in edit mode and the attachment can be inserted.

On test retries the attachment was already there
and the page opened in view mode.
This led to test failures when attempting to switch to view mode.
