### PR TITLE
Bring back file list header in Nextcloud 28

### DIFF
--- a/cypress/e2e/collective.spec.js
+++ b/cypress/e2e/collective.spec.js
@@ -56,11 +56,8 @@ describe('Collective', function() {
 			cy.get(breadcrumbsSelector).should('contain', 'Preexisting Collective')
 			cy.get(fileListSelector).should('contain', 'Readme')
 			cy.get(fileListSelector).should('contain', '.md')
-			// TODO: Fix FileListInfo for Nextcloud 28+ (Github issue #860)
-			if (['stable25', 'stable26', 'stable27'].includes(Cypress.env('ncVersion'))) {
-				cy.get('.filelist-collectives-wrapper')
-					.should('contain', 'The content of this folder is best viewed in the Collectives app.')
-			}
+			cy.get('.filelist-collectives-wrapper')
+				.should('contain', 'The content of this folder is best viewed in the Collectives app.')
 		})
 	})
 

--- a/lib/Listeners/BeforeTemplateRenderedListener.php
+++ b/lib/Listeners/BeforeTemplateRenderedListener.php
@@ -49,6 +49,11 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			$userFolder = $this->userFolderHelper->getUserFolderSetting($userId);
 		}
 
+		// only available since Nextcloud 28
+		if (method_exists(Util::class, 'addInitScript')) {
+			Util::addInitScript('collectives', 'collectives-init');
+		}
+
 		Util::addScript('collectives', 'collectives-files');
 		// Provide Collectives user folder as initial state
 		$this->initialState->provideInitialState('user_folder', $userFolder);

--- a/src/files/FilesCollectiveHeader.js
+++ b/src/files/FilesCollectiveHeader.js
@@ -1,0 +1,37 @@
+import FileListInfo from '../views/FileListInfo.vue'
+import Vue from 'vue'
+import { loadState } from '@nextcloud/initial-state'
+import { Header } from '@nextcloud/files'
+
+let vm = null
+
+const FilesCollectiveHeader = new Header({
+	id: 'collective',
+	order: 9,
+
+	enabled(folder, view) {
+		return view.id === 'files' || view.id === 'files.public'
+	},
+
+	render(el, folder, view) {
+		el.id = 'files-collective-wrapper'
+		Vue.prototype.t = window.t
+		Vue.prototype.n = window.n
+		const collectivesFolder = loadState('collectives', 'user_folder', null)
+		const View = Vue.extend(FileListInfo)
+		vm = new View({
+			propsData: {
+				collectivesFolder,
+				path: folder.path,
+			},
+		}).$mount(el)
+	},
+
+	updated(folder, view) {
+		vm.path = folder.path
+	},
+})
+
+export {
+	FilesCollectiveHeader,
+}

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import FileListInfo from '../views/FileListInfo.vue'
 import { loadState } from '@nextcloud/initial-state'
 
+// For Nextcloud <= 27
 const FilesCollectivesPlugin = {
 	el: null,
 

--- a/src/init.js
+++ b/src/init.js
@@ -1,0 +1,4 @@
+import { registerFileListHeaders } from '@nextcloud/files'
+import { FilesCollectiveHeader } from './files/FilesCollectiveHeader.js'
+
+registerFileListHeaders(FilesCollectiveHeader)

--- a/webpack.js
+++ b/webpack.js
@@ -13,6 +13,7 @@ if (isDevServer) {
 }
 
 webpackConfig.entry['files'] = path.join(__dirname, 'src', 'files.js')
+webpackConfig.entry['init'] = path.join(__dirname, 'src', 'init.js')
 webpackConfig.entry['reference'] = path.join(__dirname, 'src', 'reference.js')
 
 module.exports = webpackConfig


### PR DESCRIPTION
### 📝 Summary

* Resolves: #860

#### 🖼️ Screenshots

![grafik](https://github.com/nextcloud/collectives/assets/97337118/0e0bda5b-4a8a-4a86-8f7b-65bcc0fecfde)


### :heavy_check_mark: TODO

- [x] figure out if we can continue to use the `import Vue` as we did in the past
- [x] determine if we want to load the `init.js` only on 28.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- Documentation is not required
