### PR TITLE
fix(PageTrashBackend): Ignore emty relativePath in `getTrashNodeById()`

### DIFF
--- a/lib/Trash/PageTrashBackend.php
+++ b/lib/Trash/PageTrashBackend.php
@@ -509,6 +509,9 @@ class PageTrashBackend implements ITrashBackend {
 			}
 			$absolutePath = $this->getAppFolder()->getMountPoint()->getMountPoint() . $path;
 			$relativePath = $trashFolder->getRelativePath($absolutePath);
+			if (!$relativePath) {
+				return null;
+			}
 			[, $collectiveId, $nameAndTime] = explode('/', $relativePath);
 
 			if ($this->userHasAccessToFolder($user, (int)$collectiveId)) {


### PR DESCRIPTION
### 📝 Summary

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
