### PR TITLE
fix(migrations): set default value for new not null column

### DIFF
--- a/lib/Migration/Version020800Date20230911000000.php
+++ b/lib/Migration/Version020800Date20230911000000.php
@@ -35,6 +35,7 @@ class Version020800Date20230911000000 extends SimpleMigrationStep {
 		if (!$table->hasColumn('settings')) {
 			$table->addColumn('settings', Types::JSON, [
 				'notnull' => true,
+				'default' => '[]'
 			]);
 			$this->runPageModeMigration = true;
 


### PR DESCRIPTION
Otherwise: `Not null violation: 7 ERREUR:  la colonne « settings » contient des valeurs NULL`

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
