### PR TITLE
test(ci): do not use group parameter when run without cypress cloud

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -215,11 +215,11 @@ jobs:
         with:
           record: '${{ !!matrix.use-cypress-cloud }}'
           parallel: '${{ !!matrix.use-cypress-cloud }}'
-          group: ${{ matrix.use-cypress-cloud && format('Nextcloud {0}',  matrix.server-versions) }}
+          group: "${{ !!matrix.use-cypress-cloud && format('Nextcloud {0}',  matrix.server-versions) || '' }}"
           wait-on: '${{ env.CYPRESS_baseUrl }}'
           working-directory: apps/${{ env.APP_NAME }}
           config: video=false,defaultCommandTimeout=20000
-          tag: ${{ matrix.use-cypress-cloud && github.event_name }}
+          tag: "${{ !!matrix.use-cypress-cloud && github.event_name || '' }}"
         env:
           # https://github.com/cypress-io/github-action/issues/124
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
Cypress is currently failing on the main branch with:
```
You passed the --ci-build-id, --group, --tag, --parallel, or --auto-cancel-after-failures flag without also passing the --record flag.

The --ci-build-id flag you passed was: Cypress - 2f6588277fb008bc1e918726f469df2e01e50d1d

These flags can only be used when recording to Cypress Cloud.
```

Frankly... I have no idea why as i thought all these options were blank when not using cypress cloud.
So this is an attempt at fixings this.

The `ci-build-id` is not in our yml file and will only be passed if either `parallel` or `group` are given.
https://github.com/cypress-io/github-action/blob/bd9dda317ed2d4fbffc808ba6cdcd27823b2a13b/index.js#L667-L680

So I suspect we're still passing group.