### PR TITLE
fix(PageService): preg_quote `trusted_domains` before using in regexp

### DIFF
--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -971,8 +971,10 @@ class PageService {
 		$suffix = '\)/';
 
 		$protocol = 'https?:\/\/';
-		$trustedDomainConfig = (array)$this->config->getSystemValue('trusted_domains', []);
-		$trustedDomains = $trustedDomainConfig !== [] ? '(' . implode('|', $trustedDomainConfig) . ')' : 'localhost';
+		$trustedDomainArray = array_map(static function (string $domain) {
+			return preg_quote($domain, '/');
+		}, (array)$this->config->getSystemValue('trusted_domains', []));
+		$trustedDomains = $trustedDomainArray !== [] ? '(' . implode('|', $trustedDomainArray) . ')' : 'localhost';
 
 		$basePath = str_replace('/', '/+', str_replace('/', '/+', preg_quote(trim(\OC::$WEBROOT, '/'), '/'))) . '(\/+index\.php)?';
 

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -972,7 +972,7 @@ class PageService {
 
 		$protocol = 'https?:\/\/';
 		$trustedDomainArray = array_map(static function (string $domain) {
-			return preg_quote($domain, '/');
+			return str_replace('\*', '\w*', preg_quote($domain, '/'));
 		}, (array)$this->config->getSystemValue('trusted_domains', []));
 		$trustedDomains = $trustedDomainArray !== [] ? '(' . implode('|', $trustedDomainArray) . ')' : 'localhost';
 

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -990,10 +990,10 @@ class PageService {
 		$relativePathPattern = $prefix . $relativeUrl . $basePath . $appPath . $pagePath . $suffix;
 		$absolutePathPattern = $prefix . $absoluteUrl . $basePath . $appPath . $pagePath . $suffix;
 
-		return preg_match($relativeFileIdPattern, $content, $linkMatches) ||
-			preg_match($relativePathPattern, $content, $linkMatches) ||
-			preg_match($absoluteFileIdPattern, $content, $linkMatches) ||
-			preg_match($absolutePathPattern, $content, $linkMatches);
+		return preg_match($relativeFileIdPattern, $content) ||
+			preg_match($relativePathPattern, $content) ||
+			preg_match($absoluteFileIdPattern, $content) ||
+			preg_match($absolutePathPattern, $content);
 	}
 
 	/**


### PR DESCRIPTION
### 📝 Summary

Fixes: #330 