### PR TITLE
Test/cypress fixes

### DIFF
--- a/cypress/e2e/page-details.spec.js
+++ b/cypress/e2e/page-details.spec.js
@@ -30,6 +30,8 @@ describe('Page details', function() {
 		cy.deleteAndSeedCollective('Our Garden')
 		cy.seedPage('Day 1', '', 'Readme.md')
 		cy.seedPageContent('Our Garden/Day 2.md', 'A test string with Day 2 in the middle and a [link to Day 1](/index.php/apps/collectives/Our%20Garden/Day%201).')
+		cy.seedPage('TableOfContents', '', 'Readme.md')
+		cy.seedPageContent('Our Garden/TableOfContents.md', '## Second-Level Heading')
 	})
 
 	beforeEach(function() {
@@ -40,8 +42,6 @@ describe('Page details', function() {
 
 	describe('Display table of contents', function() {
 		it('Allows to display/close TOC and switch page modes in between', function() {
-			cy.seedPage('TableOfContents', '', 'Readme.md')
-			cy.seedPageContent('Our Garden/TableOfContents.md', '## Second-Level Heading')
 			cy.visit('/apps/collectives/Our%20Garden/TableOfContents')
 			cy.get('#titleform .action-item__menutoggle')
 				.click()

--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -123,12 +123,9 @@ describe('Page', function() {
 			cy.get('#titleform input.title')
 				.blur()
 			cy.wait('@renamePage')
-			// Flaky on stable25
-			if (Cypress.env('ncVersion') !== 'stable25') {
-				cy.getEditor(Cypress.config('defaultCommandTimeout') * 2)
-					.should('be.visible')
-					.contains('This is going to be our template.')
-			}
+			cy.getEditor(Cypress.config('defaultCommandTimeout') * 2)
+				.should('be.visible')
+				.contains('This is going to be our template.')
 			cy.get('.app-content-list-item').eq(1)
 				.should('contain', 'New page from Template')
 		})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -360,3 +360,11 @@ Cypress.Commands.add('seedCircleMember', (name, userId, type = 1, level) => {
 			}
 		})
 })
+
+/**
+ * Fail the test on the initial run to check if retries work
+ */
+Cypress.Commands.add('testRetry', () => {
+	cy.wrap(cy.state('test').currentRetry())
+		.should('be.equal', 2)
+})


### PR DESCRIPTION
### 📝 Summary

* Enable editor check in templates test for `stable25`.
* Make toc test retriable by seeding the page once.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required
