### PR TITLE
test(cy): unified search now uses a button not an a

### DIFF
--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -310,7 +310,7 @@ describe('Page', function() {
 
 	describe('Using the search providers to search for a page', function() {
 		it('Search for page title', function() {
-			cy.get('.unified-search a').click()
+			cy.get('.unified-search a, .unified-search button').click()
 			cy.get('.unified-search__form input')
 				.type('Day')
 			cy.get('.unified-search__results-collectives-pages')
@@ -318,7 +318,7 @@ describe('Page', function() {
 		})
 
 		it('Search for page content', function() {
-			cy.get('.unified-search a').click()
+			cy.get('.unified-search a, .unified-search button').click()
 			cy.get('.unified-search__form input')
 				.type('share your thoughts')
 			cy.get('.unified-search__results-collectives-page-content')


### PR DESCRIPTION
### 📝 Summary

* Resolves: # <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

before: 
![cypress-screenshot](https://github.com/nextcloud/collectives/assets/97337118/7e8a1124-2a3d-4e3b-81dd-79bcb1e6bd73)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required
