### PR TITLE
test(ci): only use cypress cloud if var is set in github

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -138,7 +138,7 @@ jobs:
         server-versions: ['stable25', 'stable27', 'master']
         # Only use cypress cloud for PRs
         use-cypress-cloud:
-          - ${{ !!github.head_ref }}
+          - ${{ vars.USE_CYPRESS_CLOUD && !!github.head_ref }}
         exclude:
           - php-versions: '8.0'
             server-versions: 'stable27'


### PR DESCRIPTION
## Before: 

Luckily cypress handles this pretty well and only the first runner per version will actually run the tests. But still 8 minutes of CI time just for setting up test runners that do nothing.

![grafik](https://github.com/nextcloud/collectives/assets/97337118/6318c956-6bcf-4733-942f-e8b4cdeacbb6)


## After

Only one runner per version as the var is not set.

![grafik](https://github.com/nextcloud/collectives/assets/97337118/0e1977ad-4560-45f8-887f-b9f8739ff05a)
