### PR TITLE
fix(PageActionMenu): Fix link to file in files app on Nextcloud 28

### DIFF
--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -231,7 +231,7 @@ export default {
 		},
 
 		filesUrl() {
-			return generateUrl(`/apps/files/?fileid=${this.currentPage.id}`)
+			return generateUrl(`/f/${this.currentPage.id}`)
 		},
 
 		editTemplateString() {


### PR DESCRIPTION
Apparently `/apps/files/?fileId=<id>` no longer works. Let's use `/f/<id>` instead.
