### PR TITLE
fix(composer): Add dependency on `php-pdo_sqlite`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": ">=7.4",
         "ext-json": "*",
         "ext-pdo": "*",
+        "ext-pdo_sqlite": "*",
         "teamtnt/tntsearch": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Our dependency tntsearch requires it.

Fixes psalm and php lint CI workflows with PHP 8.2