### PR TITLE
Javascript wrapper for collectives API

### DIFF
--- a/cypress/e2e/circle-with-group.spec.js
+++ b/cypress/e2e/circle-with-group.spec.js
@@ -32,7 +32,6 @@
 describe('Pages are accessible via group membership to circle', function() {
 	before(function() {
 		cy.loginAs('jane')
-		cy.visit('apps/collectives')
 		cy.deleteAndSeedCollective('Group Collective')
 		cy.circleFind('Group Collective')
 			.circleAddMember('Bobs Group', 2)

--- a/cypress/e2e/collective-members.spec.js
+++ b/cypress/e2e/collective-members.spec.js
@@ -27,7 +27,6 @@
 describe('Collective members', function() {
 	before(function() {
 		cy.loginAs('bob')
-		cy.visit('apps/collectives')
 		cy.deleteAndSeedCollective('Members Collective')
 	})
 

--- a/cypress/e2e/collective-page-mode.spec.js
+++ b/cypress/e2e/collective-page-mode.spec.js
@@ -1,0 +1,61 @@
+/**
+ * @copyright Copyright (c) 2021 Azul <azul@riseup.net>
+ *
+ * @author Azul <azul@riseup.net>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+describe('Collective page mode', function() {
+
+	before(function() {
+		cy.loginAs('bob')
+		cy.deleteAndSeedCollective('Our Garden')
+			.seedPage('Day 1', '', 'Readme.md')
+			.seedPage('Day 2', '', 'Readme.md')
+	})
+
+	beforeEach(function() {
+		cy.loginAs('bob')
+	})
+
+	describe('Changing page mode', function() {
+		it('Opens edit mode per default', function() {
+			cy.seedCollectivePageMode('Our Garden', 1)
+			cy.visit('/apps/collectives/Our Garden')
+			// make sure the page list loaded properly
+			cy.contains('.app-content-list-item a', 'Day 1')
+			cy.openPage('Day 2')
+			cy.getEditor()
+				.should('be.visible')
+			cy.getReadOnlyEditor()
+				.should('not.be.visible')
+		})
+
+		it('Opens view mode per default', function() {
+			cy.seedCollectivePageMode('Our Garden', 0)
+			cy.visit('/apps/collectives/Our Garden')
+			// make sure the page list loaded properly
+			cy.contains('.app-content-list-item a', 'Day 1')
+			cy.openPage('Day 2')
+			cy.getReadOnlyEditor()
+				.should('be.visible')
+			cy.getEditor()
+				.should('not.be.visible')
+		})
+	})
+})

--- a/cypress/e2e/collective-readonly.spec.js
+++ b/cypress/e2e/collective-readonly.spec.js
@@ -24,12 +24,11 @@ describe('Read-only collective', function() {
 
 	before(function() {
 		cy.loginAs('alice')
-		cy.visit('apps/collectives')
 		cy.deleteAndSeedCollective('PermissionCollective')
-		cy.seedPage('SecondPage', '', 'Readme.md')
-		cy.seedCollectivePermissions('PermissionCollective', 'edit', 4)
+			.seedPage('SecondPage')
 		cy.circleFind('PermissionCollective')
 			.circleAddMember('bob')
+		cy.seedCollectivePermissions('PermissionCollective', 'edit', 4)
 	})
 
 	describe('in read-only collective', function() {

--- a/cypress/e2e/collective-settings.spec.js
+++ b/cypress/e2e/collective-settings.spec.js
@@ -27,7 +27,6 @@
 describe('Collective settings', function() {
 	before(function() {
 		cy.loginAs('bob')
-		cy.visit('apps/collectives')
 		cy.deleteCollective('Change me now')
 		cy.deleteAndSeedCollective('Change me')
 	})

--- a/cypress/e2e/collective-share.spec.js
+++ b/cypress/e2e/collective-share.spec.js
@@ -29,7 +29,6 @@ describe('Collective Share', function() {
 
 	before(function() {
 		cy.loginAs('bob')
-		cy.visit('/apps/collectives')
 		cy.deleteAndSeedCollective('Share me')
 	})
 

--- a/cypress/e2e/collective.spec.js
+++ b/cypress/e2e/collective.spec.js
@@ -29,7 +29,6 @@ describe('Collective', function() {
 
 	before(function() {
 		cy.loginAs('bob')
-		cy.visit('apps/collectives')
 		cy.deleteCollective('Preexisting Circle')
 		cy.deleteCollective('History Club')
 		cy.deleteCollective(specialCollective)
@@ -39,7 +38,6 @@ describe('Collective', function() {
 		cy.seedCircle('Preexisting Circle')
 		cy.seedCircle('History Club', { visible: true, open: true })
 		cy.loginAs('jane')
-		cy.visit('apps/collectives')
 		cy.deleteCollective('Foreign Circle')
 		cy.seedCircle('Foreign Circle', { visible: true, open: true })
 	})

--- a/cypress/e2e/collectives-trash.spec.js
+++ b/cypress/e2e/collectives-trash.spec.js
@@ -28,7 +28,6 @@ describe('Collective', function() {
 	describe('move collective to trash and restore', function() {
 		before(function() {
 			cy.loginAs('bob')
-			cy.visit('apps/collectives')
 			cy.deleteAndSeedCollective('Delete me')
 		})
 		it('Allows moving the collective to trash', function() {

--- a/cypress/e2e/dashboard-widget.spec.js
+++ b/cypress/e2e/dashboard-widget.spec.js
@@ -30,9 +30,8 @@ describe('Collectives dashboard widget', function() {
 			before(function() {
 				cy.loginAs('bob')
 				cy.enableDashboardWidget('collectives-recent-pages')
-				cy.visit('apps/collectives')
 				cy.deleteAndSeedCollective('Dashboard Collective1')
-				cy.seedPage('Page 1', '', 'Readme.md')
+					.seedPage('Page 1', '', 'Readme.md')
 			})
 			it('Lists pages in the dashboard widget', function() {
 				cy.visit('/apps/dashboard/')

--- a/cypress/e2e/page-details.spec.js
+++ b/cypress/e2e/page-details.spec.js
@@ -27,11 +27,10 @@
 describe('Page details', function() {
 	before(function() {
 		cy.loginAs('bob')
-		cy.visit('/apps/collectives')
 		cy.deleteAndSeedCollective('Our Garden')
-		cy.seedPage('Day 1', '', 'Readme.md')
+			.seedPage('Day 1', '', 'Readme.md')
+			.seedPage('TableOfContents', '', 'Readme.md')
 		cy.seedPageContent('Our Garden/Day 2.md', 'A test string with Day 2 in the middle and a [link to Day 1](/index.php/apps/collectives/Our%20Garden/Day%201).')
-		cy.seedPage('TableOfContents', '', 'Readme.md')
 		cy.seedPageContent('Our Garden/TableOfContents.md', '## Second-Level Heading')
 	})
 

--- a/cypress/e2e/page-landingpage.spec.js
+++ b/cypress/e2e/page-landingpage.spec.js
@@ -29,16 +29,18 @@ const collective = 'Landingpage Collective'
 describe('Page landing page', function() {
 	before(function() {
 		cy.loginAs('bob')
-		cy.visit('/apps/collectives')
 		cy.deleteAndSeedCollective(collective)
+			.seedPage('Page 1', '', 'Readme.md')
+			.seedPage('Page 2', '', 'Readme.md')
+			.then(collective => {
+				// Wait 1 to make sure that page order by time is right
+				cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
+				cy.wrap(collective)
+					.seedPage('Page 3', '', 'Readme.md')
+			})
 		cy.circleFind(collective).circleAddMember('alice')
 		cy.circleFind(collective).circleAddMember('jane')
 		cy.circleFind(collective).circleAddMember('john')
-		cy.seedPage('Page 1', '', 'Readme.md')
-		cy.seedPage('Page 2', '', 'Readme.md')
-		// Wait 1 second to make sure that page order by time is right
-		cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
-		cy.seedPage('Page 3', '', 'Readme.md')
 	})
 
 	beforeEach(function() {

--- a/cypress/e2e/page-list.spec.js
+++ b/cypress/e2e/page-list.spec.js
@@ -27,24 +27,25 @@
 describe('Page list', function() {
 	before(function() {
 		cy.loginAs('bob')
-		cy.visit('apps/collectives')
 		cy.deleteAndSeedCollective('Our Garden')
-		cy.seedPage('Target', '', 'Readme.md')
-		cy.seedPage('Target Subpage', '', 'Target.md')
+			.as('garden')
+			.seedPage('Target', '', 'Readme.md')
+			.seedPage('Target Subpage', '', 'Target.md')
 		// Wait 1 second to make sure that page order by time is right
 		cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
-		cy.seedPage('Day 1', '', 'Readme.md')
-		cy.seedPage('Subpage Title', '', 'Day 1.md')
-		cy.seedPage('Day 2', '', 'Readme.md')
-		cy.seedPage('Page Title', '', 'Readme.md')
-		cy.seedPage('Move me internal', '', 'Readme.md')
-		cy.seedPage('Copy me internal', '', 'Readme.md')
-		cy.seedPage('Move me external', '', 'Readme.md')
-		cy.seedPage('Copy me external', '', 'Readme.md')
-		cy.seedPage('#% special chars', '', 'Readme.md')
+		cy.then(() => this.garden)
+			.seedPage('Day 1', '', 'Readme.md')
+			.seedPage('Subpage Title', '', 'Day 1.md')
+			.seedPage('Day 2', '', 'Readme.md')
+			.seedPage('Page Title', '', 'Readme.md')
+			.seedPage('Move me internal', '', 'Readme.md')
+			.seedPage('Copy me internal', '', 'Readme.md')
+			.seedPage('Move me external', '', 'Readme.md')
+			.seedPage('Copy me external', '', 'Readme.md')
+			.seedPage('#% special chars', '', 'Readme.md')
 		cy.deleteAndSeedCollective('MoveCopyTargetCollective')
-		cy.seedPage('Target external', '', 'Readme.md')
-		cy.seedPage('Target Subpage external', '', 'Target external.md')
+			.seedPage('Target external', '', 'Readme.md')
+			.seedPage('Target Subpage external', '', 'Target external.md')
 	})
 
 	beforeEach(function() {
@@ -94,7 +95,6 @@ describe('Page list', function() {
 
 	describe('Move and copy a page using the modal', function() {
 		it('Moves page to a subpage', function() {
-			cy.visit('apps/collectives/Our%20Garden')
 			cy.openPageMenu('Move me internal')
 			cy.clickMenuButton('Move or copy')
 			cy.get('.picker-list li')
@@ -118,7 +118,6 @@ describe('Page list', function() {
 		})
 
 		it('Copies page to a subpage', function() {
-			cy.visit('/apps/collectives/Our%20Garden')
 			cy.openPageMenu('Copy me internal')
 			cy.clickMenuButton('Move or copy')
 			cy.get('.picker-list li')
@@ -146,7 +145,6 @@ describe('Page list', function() {
 		})
 
 		it('Moves page to a subpage in another collective', function() {
-			cy.visit('/apps/collectives/Our%20Garden')
 			cy.openPageMenu('Move me external')
 			cy.clickMenuButton('Move or copy')
 			cy.get('.crumbs-home')
@@ -176,7 +174,6 @@ describe('Page list', function() {
 		})
 
 		it('Copies page to a subpage in another collective', function() {
-			cy.visit('/apps/collectives/Our%20Garden')
 			cy.openPageMenu('Copy me external')
 			cy.clickMenuButton('Move or copy')
 			cy.get('.crumbs-home')

--- a/cypress/e2e/page-share.spec.js
+++ b/cypress/e2e/page-share.spec.js
@@ -29,10 +29,9 @@ describe('Collective Share', function() {
 
 	before(function() {
 		cy.loginAs('bob')
-		cy.visit('/apps/collectives')
 		cy.deleteAndSeedCollective('Share me')
-		cy.seedPage('Sharepage', '', 'Readme.md')
-		cy.seedPage('Sharesubpage', '', 'Sharepage.md')
+			.seedPage('Sharepage', '', 'Readme.md')
+			.seedPage('Sharesubpage', '', 'Sharepage.md')
 		cy.seedPageContent('Share%20me/Sharepage/Readme.md', '## Shared page')
 	})
 

--- a/cypress/e2e/pages-links.spec.js
+++ b/cypress/e2e/pages-links.spec.js
@@ -32,19 +32,18 @@ let anotherCollectiveFirstPageId, linkTargetPageId
 describe('Page Link Handling', function() {
 	before(function() {
 		cy.loginAs('bob')
-		cy.visit('/apps/collectives')
 		cy.deleteAndSeedCollective('Another Collective')
-		cy.seedPage('First Page', '', 'Readme.md').then((id) => {
-			anotherCollectiveFirstPageId = id
-		})
+			.seedPage('First Page', '', 'Readme.md').then(({ pageId }) => {
+				anotherCollectiveFirstPageId = pageId
+			})
 		cy.deleteAndSeedCollective('Link Testing')
-		cy.seedPage('Parent', '', 'Readme.md')
-		cy.seedPage('Child', '', 'Parent.md')
-		cy.seedPage('Link Target', '', 'Readme.md').then((id) => {
-			linkTargetPageId = id
-		})
+			.seedPage('Parent', '', 'Readme.md')
+			.seedPage('Child', '', 'Parent.md')
+			.seedPage('Link Target', '', 'Readme.md').then(({ pageId }) => {
+				linkTargetPageId = pageId
+			})
+			.seedPage('Link Source', '', 'Readme.md')
 		cy.seedPageContent('Link%20Testing/Link%20Target.md', 'Some content')
-		cy.seedPage('Link Source', '', 'Readme.md')
 		cy.uploadFile('test.md', 'text/markdown').then((id) => {
 			textId = id
 		}).then(() => {

--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -25,18 +25,19 @@
  */
 
 describe('Page', function() {
+
 	before(function() {
 		cy.loginAs('bob')
-		cy.visit('/apps/collectives')
-		cy.deleteAndSeedCollective('Our Garden')
-		cy.seedPage('Day 1', '', 'Readme.md')
+		cy.deleteAndSeedCollective('Our Garden').as('garden')
+			.seedPage('Day 1', '', 'Readme.md')
 		// Wait 1 second to make sure that page order by time is right
 		cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
-		cy.seedPage('Day 2', '', 'Readme.md')
-		cy.seedPage('Page Title', '', 'Readme.md')
-		cy.seedPage('#% special chars', '', 'Readme.md')
+		cy.then(() => this.garden)
+			.seedPage('Day 2', '', 'Readme.md')
+			.seedPage('Page Title', '', 'Readme.md')
+			.seedPage('#% special chars', '', 'Readme.md')
+			.seedPage('Template', '', 'Readme.md')
 		cy.seedPageContent('Our Garden/Day 2.md', 'A test string with Day 2 in the middle and a [link to Day 1](/index.php/apps/collectives/Our%20Garden/Day%201).')
-		cy.seedPage('Template', '', 'Readme.md')
 		cy.seedPageContent('Our Garden/Template.md', 'This is going to be our template.')
 	})
 
@@ -271,26 +272,6 @@ describe('Page', function() {
 			})
 		})
 	}
-
-	describe('Changing page mode', function() {
-		it('Opens edit mode per default', function() {
-			cy.seedCollectivePageMode('Our Garden', 1)
-			cy.openPage('Day 2')
-			cy.getEditor()
-				.should('be.visible')
-			cy.getReadOnlyEditor()
-				.should('not.be.visible')
-		})
-
-		it('Opens view mode per default', function() {
-			cy.seedCollectivePageMode('Our Garden', 0)
-			cy.openPage('Day 2')
-			cy.getReadOnlyEditor()
-				.should('be.visible')
-			cy.getEditor()
-				.should('not.be.visible')
-		})
-	})
 
 	describe('Full width view', function() {
 		it('Allows to toggle persistent full-width view', function() {

--- a/cypress/e2e/settings.spec.js
+++ b/cypress/e2e/settings.spec.js
@@ -27,7 +27,6 @@
 describe('Settings', function() {
 	before(function() {
 		cy.loginAs('bob')
-		cy.visit('apps/collectives')
 		cy.deleteAndSeedCollective('A Collective')
 	})
 

--- a/cypress/support/navigation.js
+++ b/cypress/support/navigation.js
@@ -17,8 +17,7 @@ Cypress.Commands.add('openPageMenu', (pageName) => {
 
 Cypress.Commands.add('openCollective', (collectiveName) => {
 	Cypress.log()
-	cy.get(`.collectives_list_item a[title="${collectiveName}"]`)
-		.click()
+	cy.routeTo(collectiveName)
 })
 
 Cypress.Commands.add('openCollectiveMenu', (collectiveName) => {

--- a/src/apis/collectives/collectives.js
+++ b/src/apis/collectives/collectives.js
@@ -1,0 +1,119 @@
+import axios from '@nextcloud/axios'
+import { collectivesUrl } from './urls.js'
+
+/**
+ * Get all active (i.e. not trashed) collectives for the current user
+ */
+export function getCollectives() {
+	return axios.get(collectivesUrl())
+}
+
+/**
+ * Get the shared collective for a given share token.
+ *
+ * @param {string} shareToken authentication token from the share
+ */
+export function getSharedCollective(shareToken) {
+	return axios.get(collectivesUrl('p', shareToken))
+}
+
+/**
+ * Get all trashed collectives for the current user
+ */
+export function getTrashCollectives() {
+	return axios.get(collectivesUrl('trash'))
+}
+
+/**
+ * Create a new collective with the given properties.
+ *
+ * @param {object} collective - properties for the new collective
+ */
+export function newCollective(collective) {
+	return axios.post(
+		collectivesUrl(),
+		collective,
+	)
+}
+
+/**
+ * Trash the collective with the given id
+ *
+ * @param {number} collectiveId - Id of the collective to trash.
+ */
+export function trashCollective(collectiveId) {
+	return axios.delete(collectivesUrl(collectiveId))
+}
+
+/**
+ * Delete the collective with the given id.
+ *
+ * @param {number} collectiveId - id of the collective to delete
+ * @param {boolean} removeCircle - also remove the circle if true
+ */
+export function deleteCollective(collectiveId, removeCircle) {
+	const query = removeCircle ? '?circle=1' : ''
+	return axios.delete(collectivesUrl('trash', collectiveId + query))
+}
+
+/**
+ * Restore a collective with the given id from trash
+ *
+ * @param {number} collectiveId Id of the colletive to be restored
+ */
+export function restoreCollective(collectiveId) {
+	return axios.patch(collectivesUrl('trash', collectiveId))
+}
+
+/**
+ * Update a collective with the given properties
+ *
+ * @param {object} collective Properties for the collective
+ */
+export function updateCollective(collective) {
+	return axios.put(
+		collectivesUrl(collective.id),
+		collective,
+	)
+}
+
+/**
+ * Set the permission level required for editing.
+ *
+ * @param {number} collectiveId - id of the collective to update
+ * @param {number} level - required level for editing
+ */
+export function updateCollectiveEditPermissions(collectiveId, level) {
+	return axios.put(
+		collectivesUrl(collectiveId, 'editLevel'),
+		{ level },
+	)
+}
+
+/**
+ * Set the permission level required for sharing.
+ *
+ * @param {number} collectiveId - id of the collective to update
+ * @param {number} level - required level for sharing
+ */
+export function updateCollectiveSharePermissions(collectiveId, level) {
+	return axios.put(
+		collectivesUrl(collectiveId, 'shareLevel'),
+		{ level },
+	)
+}
+
+/**
+ * Set the edit mode for the given collective
+ *
+ * @param {number} collectiveId - id of the collective to update
+ * @param {number} mode - pageMode to use.
+ *
+ * Possible modes: pageModes.MODE_VIEW or pageModes.MODE_EDIT
+ */
+export function updateCollectivePageMode(collectiveId, mode) {
+	return axios.put(
+		collectivesUrl(collectiveId, 'pageMode'),
+		{ mode },
+	)
+}

--- a/src/apis/collectives/index.js
+++ b/src/apis/collectives/index.js
@@ -1,0 +1,6 @@
+export * from './urls.js'
+export * from './collectives.js'
+export * from './pages.js'
+export * from './userSettings.js'
+export * from './settings.js'
+export * from './shares.js'

--- a/src/apis/collectives/pages.js
+++ b/src/apis/collectives/pages.js
@@ -1,0 +1,207 @@
+import axios from '@nextcloud/axios'
+import { pagesUrl } from './urls.js'
+
+/**
+ * Get all pages in the given context (collective or public share)
+ *
+ * @param {object} context - either the current collective or a share context
+ */
+export function getPages(context) {
+	return axios.get(pagesUrl(context))
+}
+
+/**
+ * Get all trashed pages in the given context.
+ *
+ * @param {object} context - either the current collective or a share context
+ */
+export function getTrashPages(context) {
+	return axios.get(pagesUrl(context, 'trash'))
+}
+
+/**
+ * Create a new page in the given context (collective or public share)
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {object} page - properties of the new page
+ */
+export function createPage(context, page) {
+	return axios.post(
+		pagesUrl(context, page.parentId),
+		page,
+	)
+}
+
+/**
+ * Get a page in the given context (collective or public share)
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to retrieve
+ */
+export function getPage(context, pageId) {
+	return axios.get(pagesUrl(context, pageId))
+}
+
+/**
+ * Touch a page in the given context (collective or public share)
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to touch
+ */
+export function touchPage(context, pageId) {
+	return axios.get(pagesUrl(context, pageId, '/touch'))
+}
+
+/**
+ * Rename a page in the given context (collective or public share)
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to rename
+ * @param {string} title - New title for the page
+ */
+export function renamePage(context, pageId, title) {
+	return axios.put(
+		pagesUrl(context, pageId),
+		{ title },
+	)
+}
+
+/**
+ * Copy a page inside the given context (collective or public share)
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to copy
+ * @param {number} parentId - Id of the page to copy to
+ * @param {number} index - Index for subpage order of parent page
+ */
+export function copyPage(context, pageId, parentId, index) {
+	return axios.put(
+		pagesUrl(context, pageId),
+		{ parentId, index, copy: true },
+	)
+}
+
+/**
+ * Move a page inside the given context (collective or public share)
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to move
+ * @param {number} parentId - Id of the page to move to
+ * @param {number} index - Index for subpage order of parent page
+ */
+export function movePage(context, pageId, parentId, index) {
+	return axios.put(
+		pagesUrl(context, pageId),
+		{ parentId, index },
+	)
+}
+
+/**
+ * Copy page to another collective
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to move
+ * @param {number} collectiveId - Id of the new collective
+ * @param {number} parentId - Id of the page to move to
+ * @param {number} index - Index for subpage order of parent page
+ */
+export function copyPageToCollective(context, pageId, collectiveId, parentId, index) {
+	return axios.put(
+		pagesUrl(context, pageId, 'to', collectiveId),
+		{ parentId, index, copy: true },
+	)
+}
+
+/**
+ * Move page to another collective
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to move
+ * @param {number} collectiveId - Id of the new collective
+ * @param {number} parentId - Id of the page to move to
+ * @param {number} index - Index for subpage order of parent page
+ */
+export function movePageToCollective(context, pageId, collectiveId, parentId, index) {
+	return axios.put(
+		pagesUrl(context, pageId, 'to', collectiveId),
+		{ parentId, index },
+	)
+}
+
+/**
+ * Set emoji for a page
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to update
+ * @param {string} emoji - New emojie for the page
+ */
+export function setPageEmoji(context, pageId, emoji) {
+	return axios.put(
+		pagesUrl(context, pageId, 'emoji'),
+		{ emoji },
+	)
+}
+
+/**
+ * Set subpageOrder for a page
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to update
+ * @param {string} subpageOrder - New subpageOrdere for the page
+ */
+export function setPageSubpageOrder(context, pageId, subpageOrder) {
+	return axios.put(
+		pagesUrl(context, pageId, 'subpageOrder'),
+		{ subpageOrder },
+	)
+}
+
+/**
+ * Trash a page in the given context (collective or public share)
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to trash
+ */
+export function trashPage(context, pageId) {
+	return axios.delete(pagesUrl(context, pageId))
+}
+
+/**
+ * Restore the page with the given id from trash
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to restore
+ */
+export function restorePage(context, pageId) {
+	return axios.patch(pagesUrl(context, '/trash', pageId))
+}
+
+/**
+ * Delete the page with the given id from trash
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to trash
+ */
+export function deletePage(context, pageId) {
+	return axios.delete(pagesUrl(context, '/trash', pageId))
+}
+
+/**
+ * Get list of attachments for a page
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to list attachments for
+ */
+export function getPageAttachments(context, pageId) {
+	return axios.get(pagesUrl(context, pageId, 'attachments'))
+}
+
+/**
+ * Get list of backlinks for a page
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to list backlinks for
+ */
+export function getPageBacklinks(context, pageId) {
+	return axios.get(pagesUrl(context, pageId, 'backlinks'))
+}

--- a/src/apis/collectives/settings.js
+++ b/src/apis/collectives/settings.js
@@ -1,0 +1,20 @@
+import axios from '@nextcloud/axios'
+import { apiUrl } from './urls.js'
+
+/**
+ * Get collectives folder setting for the current user
+ */
+export function getCollectivesFolder() {
+	return axios.get(apiUrl('v1.0', 'settings/user/user_folder'))
+}
+
+/**
+ * Set collectives folder setting for the current user
+ * @param {string} value Name of the collective folder to use
+ */
+export function setCollectivesFolder(value) {
+	return axios.post(
+		apiUrl('v1.0', 'settings/user'),
+		{ key: 'user_folder', value },
+	)
+}

--- a/src/apis/collectives/shares.js
+++ b/src/apis/collectives/shares.js
@@ -1,0 +1,76 @@
+import axios from '@nextcloud/axios'
+import { collectivesUrl } from './urls.js'
+
+/**
+ * Get shares of a collective and its pages
+ *
+ * @param {number} collectiveId Id of the colletive
+ */
+export function getShares(collectiveId) {
+	return axios.get(collectivesUrl(collectiveId, 'shares'))
+}
+
+/**
+ * Create a public collective share
+ *
+ * @param {number} collectiveId Id of the colletive to be shared
+ */
+export function createCollectiveShare(collectiveId) {
+	return axios.post(collectivesUrl(collectiveId, 'share'))
+}
+
+/**
+ * Create a public page share
+ *
+ * @param {number} collectiveId Id of the colletive the page belongs to
+ * @param {number} pageId Id of the page to be shared
+ */
+export function createPageShare(collectiveId, pageId) {
+	return axios.post(
+		collectivesUrl(collectiveId, '_pages', pageId, 'share'),
+	)
+}
+
+/**
+ * Update a public collective share
+ *
+ * @param {object} share Share to update
+ * @param {number} share.collectiveId Id of the colletive
+ * @param {number} share.pageId Id of the colletive
+ * @param {string} share.token Token of the share to be updated
+ * @param {boolean} share.editable editable state to set
+ */
+export function updateShare(share) {
+	return axios.put(
+		shareUrl(share),
+		{ editable: share.editable },
+	)
+}
+
+/**
+ * Delete a public collective share
+ *
+ * @param {object} share Share to update
+ * @param {number} share.collectiveId Id of the colletive
+ * @param {number} share.pageId Id of the colletive
+ * @param {string} share.token Token of the share to be updated
+ */
+export function deleteShare(share) {
+	return axios.delete(
+		shareUrl(share),
+	)
+}
+
+/**
+ * Url of a share
+ *
+ * @param {object} share Share to update
+ * @param {number} share.collectiveId Id of the colletive
+ * @param {number} share.pageId Id of the colletive
+ * @param {string} share.token Token of the share to be updated
+ */
+function shareUrl({ collectiveId, pageId, token }) {
+	return pageId
+		? collectivesUrl(collectiveId, '_pages', pageId, 'share', token)
+		: collectivesUrl(collectiveId, 'share', token)
+}

--- a/src/apis/collectives/urls.js
+++ b/src/apis/collectives/urls.js
@@ -1,0 +1,36 @@
+import { generateUrl, generateOcsUrl } from '@nextcloud/router'
+
+/**
+ * Url for the versioned collectives api
+ *
+ * @param {string} version - Version of the api - currently `v1.0`
+ * @param {...any} parts - url parts to append - will be joined with `/`
+ */
+export function apiUrl(version, ...parts) {
+	const path = ['apps/collectives/api', version, ...parts]
+		.join('/')
+	return generateOcsUrl(path)
+}
+
+/**
+ * Url for the collectives app endpoints
+ *
+ * @param {...any} parts - url parts to append - will be joined with `/`
+ */
+export function collectivesUrl(...parts) {
+	const path = ['apps/collectives/_api', ...parts]
+		.join('/')
+	return generateUrl(path)
+}
+
+/**
+ * Url for pages paths inside the given context.
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {...any} parts - url parts to append.
+ */
+export function pagesUrl(context, ...parts) {
+	return context.isPublic
+		? collectivesUrl('p', context.shareTokenParam, '_pages', ...parts)
+		: collectivesUrl(context.collectiveId, '_pages', ...parts)
+}

--- a/src/apis/collectives/userSettings.js
+++ b/src/apis/collectives/userSettings.js
@@ -1,0 +1,28 @@
+import axios from '@nextcloud/axios'
+import { collectivesUrl } from './urls.js'
+
+/**
+ * Set the page order for the current user
+ *
+ * @param {number} collectiveId ID of the colletive to be updated
+ * @param {number} pageOrder the desired page order for the current user
+ */
+export function setCollectiveUserSettingPageOrder(collectiveId, pageOrder) {
+	return axios.put(
+		collectivesUrl(collectiveId, '_userSettings', 'pageOrder'),
+		{ pageOrder },
+	)
+}
+
+/**
+ * Set the the `show recent pages` toggle for the current user
+ *
+ * @param {number} collectiveId ID of the colletive to be updated
+ * @param {boolean} showRecentPages the desired value
+ */
+export function setCollectiveUserSettingShowRecentPages(collectiveId, showRecentPages) {
+	return axios.put(
+		collectivesUrl(collectiveId, '_userSettings', 'showRecentPages'),
+		{ showRecentPages },
+	)
+}

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -1,10 +1,9 @@
-import axios from '@nextcloud/axios'
-import { generateOcsUrl } from '@nextcloud/router'
 import {
 	GET_COLLECTIVES_FOLDER,
 	UPDATE_COLLECTIVES_FOLDER,
 } from './actions.js'
 import { SET_COLLECTIVES_FOLDER } from './mutations.js'
+import * as settings from '../apis/collectives/settings.js'
 
 export default {
 	state: {
@@ -25,7 +24,7 @@ export default {
 		 * @param {Function} store.commit commit changes
 		 */
 		async [GET_COLLECTIVES_FOLDER]({ commit }) {
-			const response = await axios.get(generateOcsUrl('apps/collectives/api/v1.0/settings/user/user_folder'))
+			const response = await settings.getCollectivesFolder()
 			commit(SET_COLLECTIVES_FOLDER, response.data.ocs.data)
 		},
 
@@ -37,10 +36,7 @@ export default {
 		 * @param {string} collectivesFolder path to collectives folder
 		 */
 		async [UPDATE_COLLECTIVES_FOLDER]({ commit }, collectivesFolder) {
-			const response = await axios.post(generateOcsUrl('apps/collectives/api/v1.0/settings/user'), {
-				key: 'user_folder',
-				value: collectivesFolder,
-			})
+			const response = await settings.setCollectivesFolder(collectivesFolder)
 			commit(SET_COLLECTIVES_FOLDER, response.data.ocs.data)
 		},
 	},


### PR DESCRIPTION
Wrap all usage of the collectives api in a simple functional interface.
This will allow us to change the layout of the api
and only update it in a single place.

## Refactor client (browser) app

Separate the API handling from the store.
The api is concerned with axios and generateUrl
while the store is only concerned with the current state of the app.

### Url generation from parts

Accept multiple arguments to `collectivesUrl` and `pagesUrl`
and join them with `/` to build the url:

Example:
```js
api.pagesUrl({collectiveId: 10}, 'trash', 12)
```
results in `/apps/collectives/_api/10/_pages/trash/12`

## Tests (Cypress)

Use the api directly in the cypress commands.
That way we do not require the page to be loaded.

Also extract `collective-edit-mode.spec.js` from `pages.spec.js`.
It requires a different beforeEach function
to seed the edit mode before visiting the collective.

Signed-off-by: Max <max@nextcloud.com>


## 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
