### PR TITLE
chore: Update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -20,31 +20,17 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
+**Server details:**
+- Collectives app version: [e.g. 2.8.2; see Nextcloud apps page]
+- Nextcloud version: [e.g. 26.0.1]
+- PHP Version: [e.g. 8.2]
+- Database: [e.g. MariaDB 10.6]
+
 **Client details:**
- - OS: [e.g. iOS]
- - Browser: [e.g. chrome, safari]
- - Version: [e.g. 24]
+ - OS: [e.g. Windows/macOS/Ubuntu]
+ - Browser: [e.g. Firefox, Chrome]
+ - Browser version: [e.g. 22]
  - Device: [e.g. iPhone6, desktop]
-
-<details>
-<summary>Server details</summary>
-<!--
-You can use the Issue Template application to prefill most of the required information: https://apps.nextcloud.com/apps/issuetemplate
--->
-
-**Collectives app version:** (see Nextcloud apps page)
-
-**Operating system:**
-
-**Web server:**
-
-**Database:**
-
-**PHP version:**
-
-**Nextcloud version:** (see Nextcloud admin page)
-
-</details>
 
 <details>
 <summary>Logs</summary>


### PR DESCRIPTION
### 📝 Summary

https://github.com/nextcloud/text/pull/4261 improved the text issue template but that change wasn't copied here. The updated template is more specific on what it wants be filled out and simplifies the overall process.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
