### PR TITLE
Revert "chore(info.xml): Add `ext-pdo` and `ext-pdo_sqlite` as lib dependencies"

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -43,8 +43,6 @@ In your Nextcloud instance, simply navigate to **»Apps«**, find the
 		https://raw.githubusercontent.com/nextcloud/collectives/main/docs/static/images/screenshot.png
 	</screenshot>
 	<dependencies>
-		<lib>pdo</lib>
-		<lib>pdo_sqlite</lib>
 		<nextcloud min-version="25" max-version="27" />
 	</dependencies>
 	<background-jobs>


### PR DESCRIPTION
This reverts commit ded9ccef908be28b9f9567f162495ba16035cf42.


Unfortunately Nextcloud chokes on either `ext-pdo` or `pdo` as lib dependencies:
* https://github.com/nextcloud/collectives/actions/runs/6782002055/job/18433356004?pr=936#step:11:269
* https://github.com/nextcloud/collectives/actions/runs/6782055403/job/18433521697?pr=936#step:11:269