### PR TITLE
fix(NewCollectiveModal): Mention that own user is part of collective

### DIFF
--- a/cypress/e2e/collective.spec.js
+++ b/cypress/e2e/collective.spec.js
@@ -85,7 +85,7 @@ describe('Collective', function() {
 				cy.get('button span.circles-icon').click()
 				// cy.get('.circle-selector ul').should('not.contain', 'Foreign')
 				cy.get('.circle-selector li [title*=History]').click()
-				cy.get('button').contains('Add people').click()
+				cy.get('button').contains('Add members').click()
 				cy.get('button').contains('Create').click()
 
 				cy.get('#titleform input').invoke('val').should('contain', 'History Club')

--- a/src/components/Member/MemberPicker.vue
+++ b/src/components/Member/MemberPicker.vue
@@ -23,6 +23,7 @@
 			<!-- Selected members (optional) -->
 			<SelectedMembers v-if="currentUserIsAdmin && !showCurrentSkeleton && showSelection"
 				:selected-members="selectedMembers"
+				:no-delete-members="noDeleteMembers"
 				@delete-from-selection="deleteFromSelection" />
 
 			<!-- Searched and picked members -->
@@ -35,7 +36,7 @@
 			<!-- No search results -->
 			<template v-else-if="currentUserIsAdmin && !showCurrentSkeleton">
 				<NcAppNavigationCaption class="member-picker-caption" :title="t('collectives', 'Add users, groups or circles…')" />
-				<Hint v-if="!isSearching" :hint="t('collectives', 'Search for members to add')" />
+				<Hint v-if="!isSearching" :hint="t('collectives', 'Search for members to add.')" />
 				<Hint v-else-if="isSearchLoading" :hint="t('collectives', 'Loading…')" />
 				<Hint v-else :hint="t('collectives', 'No search results')" />
 			</template>
@@ -99,6 +100,12 @@ export default {
 			type: Object,
 			default() {
 				return {}
+			},
+		},
+		noDeleteMembers: {
+			type: Array,
+			default() {
+				return []
 			},
 		},
 		onClickSearched: {

--- a/src/components/Member/MemberPicker.vue
+++ b/src/components/Member/MemberPicker.vue
@@ -5,7 +5,7 @@
 			:value.sync="searchQuery"
 			type="text"
 			:show-trailing-button="isSearching"
-			:label="t('collectives', 'Search users, groups, circles…')"
+			:label="t('collectives', 'Search accounts, groups, circles…')"
 			@trailing-button-click="clearSearch"
 			@input="onSearch">
 			<MagnifyIcon :size="16" />
@@ -35,7 +35,7 @@
 
 			<!-- No search results -->
 			<template v-else-if="currentUserIsAdmin && !showCurrentSkeleton">
-				<NcAppNavigationCaption class="member-picker-caption" :title="t('collectives', 'Add users, groups or circles…')" />
+				<NcAppNavigationCaption class="member-picker-caption" :title="t('collectives', 'Add accounts, groups or circles…')" />
 				<Hint v-if="!isSearching" :hint="t('collectives', 'Search for members to add.')" />
 				<Hint v-else-if="isSearchLoading" :hint="t('collectives', 'Loading…')" />
 				<Hint v-else :hint="t('collectives', 'No search results')" />

--- a/src/components/Member/MemberSearchResults.vue
+++ b/src/components/Member/MemberSearchResults.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="member-search-results">
 		<template v-if="addableUsers.length !== 0">
-			<NcAppNavigationCaption :title="t('collectives', 'Add users')"
+			<NcAppNavigationCaption :title="t('collectives', 'Add accounts')"
 				class="member-picker-caption" />
 			<Member v-for="item in addableUsers"
 				:key="generateKey(item)"

--- a/src/components/Member/SelectedMembers.vue
+++ b/src/components/Member/SelectedMembers.vue
@@ -10,7 +10,7 @@
 			:display-name="member.label"
 			:avatar-image="selectedMemberAvatarImage(member)"
 			class="selected-member-bubble">
-			<template #title>
+			<template v-if="selectedMemberDeletable(member)" #title>
 				<a href="#"
 					:title="t('collectives', 'Remove {name}', { name: member.label })"
 					class="selected-member-bubble-delete"
@@ -39,6 +39,12 @@ export default {
 			type: Object,
 			required: true,
 		},
+		noDeleteMembers: {
+			type: Array,
+			default() {
+				return []
+			},
+		},
 	},
 
 	computed: {
@@ -47,9 +53,11 @@ export default {
 		},
 
 		selectedMemberAvatarImage() {
-			return function(member) {
-				return member.source === 'users' ? null : 'icon-group-white'
-			}
+			return (member) => member.source === 'users' ? null : 'icon-group-white'
+		},
+
+		selectedMemberDeletable() {
+			return (member) => !this.noDeleteMembers.includes(`${member.source}-${member.id}`)
 		},
 	},
 

--- a/src/components/Nav/NewCollectiveModal.vue
+++ b/src/components/Nav/NewCollectiveModal.vue
@@ -73,14 +73,14 @@
 						:disabled="!newCollectiveName || nameIsInvalid"
 						class="modal-buttons-right"
 						@click="advanceToMembers">
-						{{ t('collectives', 'Add people') }}
+						{{ t('collectives', 'Add members') }}
 					</NcButton>
 				</div>
 			</div>
 
 			<div v-else-if="state === 1" class="modal-collective-wrapper">
 				<h2 class="modal-collective-title">
-					{{ t('collectives', 'Add people') }}
+					{{ t('collectives', 'Add members to {name}', { name: newCollectiveName }) }}
 				</h2>
 
 				<div class="modal-collective-members">
@@ -99,7 +99,7 @@
 						:disabled="loading"
 						class="modal-buttons-right"
 						@click="onCreate">
-						{{ t('collectives', 'Create') }}
+						{{ createButtonString }}
 					</NcButton>
 				</div>
 			</div>
@@ -206,6 +206,12 @@ export default {
 
 		hasSelectedMembersWithoutSelf() {
 			return Object.keys(this.selectedMembersWithoutSelf).length !== 0
+		},
+
+		createButtonString() {
+			return this.hasSelectedMembersWithoutSelf
+				? t('collectives', 'Create')
+				: t('collectives', 'Create without members')
 		},
 	},
 


### PR DESCRIPTION
People got confused by searching their own user.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![screenshot](https://github.com/nextcloud/collectives/assets/3582805/2a8db5c2-4908-4bd2-8527-2f836502426f) | ![recording1](https://github.com/nextcloud/collectives/assets/3582805/f08cb865-17d8-4bf9-8c86-e6bf062ac6f5)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
