### PR TITLE
fix(ui): title prop is deprecated since @nextcloud/vue 7

### DIFF
--- a/src/components/Nav/CollectiveListItem.vue
+++ b/src/components/Nav/CollectiveListItem.vue
@@ -1,6 +1,6 @@
 <template>
 	<NcAppNavigationItem :key="collective.circleId"
-		:title="collective.name"
+		:name="collective.name"
 		:to="collectivePath(collective)"
 		:force-menu="true"
 		:force-display-actions="isMobile"

--- a/src/components/Nav/CollectivesTrash.vue
+++ b/src/components/Nav/CollectivesTrash.vue
@@ -15,7 +15,7 @@
 				<ul class="app-navigation__list">
 					<NcAppNavigationItem v-for="collective in trashCollectives"
 						:key="collective.circleId"
-						:title="collective.name"
+						:name="collective.name"
 						:force-menu="true"
 						:force-display-actions="isMobile"
 						class="collectives_trash_list_item">


### PR DESCRIPTION
### 📝 Summary

See https://github.com/nextcloud-libraries/nextcloud-vue/pull/4052.


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- Test warnings in console were fixed with this.
- Documentation is not required
