### PR TITLE
fix(FileListInfo): Don't show info header if collectivesFolder is `/`

### DIFF
--- a/src/views/FileListInfo.vue
+++ b/src/views/FileListInfo.vue
@@ -70,7 +70,7 @@ export default {
 
 	methods: {
 		setActive() {
-			this.active = this.collectivesFolder && this.path.startsWith(this.collectivesFolder)
+			this.active = this.collectivesFolder && this.collectivesFolder !== '/' && this.path.startsWith(this.collectivesFolder)
 		},
 	},
 }


### PR DESCRIPTION
This fixes the info header being always displayed for guest users.

* Fixes: #893
* Fixes: #863

