### PR TITLE
fix(dasbhoard): Respect item limit

### DIFF
--- a/lib/Dashboard/RecentPagesWidget.php
+++ b/lib/Dashboard/RecentPagesWidget.php
@@ -12,7 +12,6 @@ use OCP\IUserSession;
 
 class RecentPagesWidget implements IReloadableWidget {
 	public const REFRESH_INTERVAL_IN_SECS = 33;
-	public const MAX_ITEMS = 10;
 
 	protected IL10N $l10n;
 	protected IURLGenerator $urlGenerator;
@@ -36,7 +35,7 @@ class RecentPagesWidget implements IReloadableWidget {
 			return new WidgetItems();
 		}
 
-		$recentPages = $this->recentPagesService->forUser($user, self::MAX_ITEMS);
+		$recentPages = $this->recentPagesService->forUser($user, $limit);
 
 		$items = [];
 		foreach ($recentPages as $recentPage) {


### PR DESCRIPTION
### 📝 Summary

The widget didn't respect the limit. This limit can be specified in the dashboard API so it is important to follow it.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
