### PR TITLE
docs(changelog): correct styling removing unwanted strike-through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * 🐛 Fix dashboard issue for users without a collective.
 * 💄 Fix alignment of page heading loading skeleton.
 * 📋 Improve wording around user entities: members can be accounts, circles or groups.
-* ⌨️ Save document on <Ctrl>-<S> when page title is focussed. (#989)
+* ⌨️ Save document on `<Ctrl>-<S>` when page title is focussed. (#989)
 * ℹ️ Don't always show file app info header for guest users. (#893)
 * 🧹 Fix `ExpireTrashPages` background job if no trash backend available. (#968)
 


### PR DESCRIPTION
### 📝 Summary

* Resolves: most of the changelog content being "stricken through"

There was a markdown formatting issue.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
