### PR TITLE
feat(editor): Pass fileId to editor API for reader

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -34,3 +34,5 @@ export const pageModes = {
 	MODE_VIEW: 0,
 	MODE_EDIT: 1,
 }
+
+export const editorApiReaderFileId = 'READER_FILE_ID'

--- a/src/mixins/editorMixin.js
+++ b/src/mixins/editorMixin.js
@@ -2,6 +2,7 @@ import debounce from 'debounce'
 import { mapGetters, mapMutations } from 'vuex'
 import linkHandlerMixin from '../mixins/linkHandlerMixin.js'
 import PageInfoBar from '../components/Page/PageInfoBar.vue'
+import { editorApiReaderFileId } from '../constants.js'
 
 export default {
 	mixins: [
@@ -23,6 +24,7 @@ export default {
 			'currentCollectiveCanEdit',
 			'currentPage',
 			'currentPageFilePath',
+			'editorApiFlags',
 			'loading',
 			'shareTokenParam',
 			'showing',
@@ -61,8 +63,13 @@ export default {
 		]),
 
 		async setupReader() {
+			const fileId = this.editorApiFlags.includes(editorApiReaderFileId)
+				? this.currentPage.id
+				: null
 			this.reader = await window.OCA.Text.createEditor({
 				el: this.$refs.reader,
+				fileId,
+				useSession: false,
 				content: this.pageContent,
 				filePath: `/${this.currentPageFilePath}`,
 				readOnly: true,

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -6,7 +6,7 @@ import collectives from './collectives.js'
 import pages from './pages.js'
 import settings from './settings.js'
 import versions from './versions.js'
-import { pageModes } from '../constants.js'
+import { editorApiReaderFileId, pageModes } from '../constants.js'
 
 Vue.use(Vuex)
 
@@ -54,14 +54,21 @@ export default new Store({
 		isTextEdit: (state) => state.textMode === pageModes.MODE_EDIT,
 		isTextView: (state) => state.textMode === pageModes.MODE_VIEW,
 
-		editorApiVersionCheck() {
-			const requiredVersion = '1.0'
+		editorApiVersionCheck: () => (requiredVersion) => {
 			const apiVersion = window.OCA?.Text?.apiVersion || '0'
 			return apiVersion.localeCompare(requiredVersion, undefined, { numeric: true, sensitivity: 'base' }) >= 0
 		},
 
 		useEditorApi(_, get) {
-			return !!window.OCA?.Text?.createEditor && get.editorApiVersionCheck
+			return !!window.OCA?.Text?.createEditor && get.editorApiVersionCheck('1.0')
+		},
+
+		editorApiFlags(_, get) {
+			const flags = []
+			if (get.editorApiVersionCheck('1.1')) {
+				flags.push(editorApiReaderFileId)
+			}
+			return flags
 		},
 	},
 


### PR DESCRIPTION
Only do this if editor API is version 1.1 or newer to not break usage with older Text versions.

This builds on nextcloud/text#5042.

Fixes: #620 
Fixes: #964 

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required
