### PR TITLE
Build(deps): Bump actions/upload-pages-artifact from 2 to 4

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -70,7 +70,7 @@ jobs:
           mv build/pages public
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./public
 


### PR DESCRIPTION
Required by upload/artifacts v4.

Failed run:
https://github.com/nextcloud/collectives/actions/runs/7321770406/job/19942569756
