### PR TITLE
Chore(ci): fix pages workflow with upload-pages-artifacts@v3

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -70,7 +70,7 @@ jobs:
           mv build/pages public
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 


### PR DESCRIPTION
v4 does not even exist.

I was confusing `actions/artifact@v4` and `actions/upload-pages-artifact`.
