### PR TITLE
Set default language for TNTSearch

### DIFF
--- a/lib/Search/FileSearch/FileSearcher.php
+++ b/lib/Search/FileSearch/FileSearcher.php
@@ -21,13 +21,31 @@ class FileSearcher extends TNTSearch {
 		'storage' => ''
 	];
 
-	protected FileIndexer $indexer;
+	public const SUPPORTED_LANGUAGES = [
+		'ar' => 'Arabic',
+		'cr' => 'Croatian',
+		'fr' => 'French',
+		'de' => 'German',
+		'en' => 'Porter',
+		'it' => 'Italian',
+		'lv' => 'Latvian',
+		'pl' => 'Polish',
+		'pt' => 'Portuguese',
+		'ru' => 'Russian',
+		'uk' => 'Ukrainian',
+	];
 
-	public function __construct() {
+	private const UNSUPPORTED_LANGUAGE = 'No';
+
+	protected FileIndexer $indexer;
+	private ?string $language;
+
+	public function __construct(?string $language = null) {
 		parent::__construct();
 		$this->loadConfig();
 		$this->asYouType(true);
 		$this->fuzziness(true);
+		$this->language = $language;
 	}
 
 	public function loadConfig(array $config = self::DEFAULT_CONFIG): void {
@@ -75,6 +93,8 @@ class FileSearcher extends TNTSearch {
 		$this->index->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 		$this->indexer->setIndex($this->index);
+		$this->indexer->setLanguage($this->language ?? self::UNSUPPORTED_LANGUAGE);
+
 		return $this->indexer;
 	}
 
@@ -84,6 +104,8 @@ class FileSearcher extends TNTSearch {
 	 */
 	public function createIndex($indexName = '', $disableOutput = false): FileIndexer {
 		$this->indexer->createIndex($indexName);
+		$this->indexer->setLanguage($this->language ?? self::UNSUPPORTED_LANGUAGE);
+
 		$this->index = $this->indexer->getIndex();
 		return $this->indexer;
 	}


### PR DESCRIPTION
### 📝 Summary
This change improves morphology in search functionality by providing correct Stemmer for TNTSearch

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/collectives/assets/191082/2f2ad7de-633e-4c48-be3a-a1987ffc0167)  | ![image](https://github.com/nextcloud/collectives/assets/191082/29cc8f10-1c5a-4828-8690-b88de47cc8d9) |

### 🚧 TODO

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
