### PR TITLE
fix: Do not load editor on unrelated pages

### DIFF
--- a/lib/Listeners/BeforeTemplateRenderedListener.php
+++ b/lib/Listeners/BeforeTemplateRenderedListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace OCA\Collectives\Listeners;
 
+use OCA\Collectives\AppInfo\Application;
 use OCA\Collectives\Fs\UserFolderHelper;
 use OCA\Collectives\Service\NotPermittedException;
 use OCA\Text\Event\LoadEditor;
@@ -61,7 +62,8 @@ class BeforeTemplateRenderedListener implements IEventListener {
 
 		Util::addScript('collectives', 'collectives-files');
 
-		if (class_exists(LoadEditor::class)) {
+		$isCollectivesResponse = $event->getResponse()->getApp() === Application::APP_NAME;
+		if ($isCollectivesResponse && class_exists(LoadEditor::class)) {
 			$this->eventDispatcher->dispatchTyped(new LoadEditor());
 		}
 

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -855,3 +855,7 @@ namespace OCA\Files_Trashbin\Trash {
 namespace OCP\Files\Mount {
 	interface ISystemMountPoint {}
 }
+
+namespace OCA\Text\Event {
+	class LoadEditor extends \OCP\EventDispatcher\Event {}
+}


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>

### 📝 Summary

Make sure that unrelated pages do not load the editor as we don't need it there.

To reproduce open an unrelated page and see editor scripts as well as the reference provider scripts loaded though not needed e.g. https://nextcloud.local/index.php/s/ for a 404 page

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
