### PR TITLE
chore: Add PHP-CS-Fixer cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ js/*
 # PHPunit cache
 .phpunit.result.cache
 
+# PHP-CS-Fixer cache
+.php-cs-fixer.cache
+
 # Cypress test artifacts
 cypress/screenshots/
 cypress/videos/


### PR DESCRIPTION
### 📝 Summary

When running php-cs-fixer locally the file is created, but it wasn't ignored until now.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
