### PR TITLE
Fix link handling with new link bubble from Nextcloud 29

### DIFF
--- a/cypress/e2e/pages-links.spec.js
+++ b/cypress/e2e/pages-links.spec.js
@@ -171,13 +171,13 @@ describe('Page Link Handling', function() {
 			const calledUrl = edit
 				? url.href
 				: href
-			/*
-			cy.get('@open')
-				.should('be.calledWith', calledUrl)
-				.then(() => {
-					openStub.restore()
-				})
-			 */
+			if (['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+				cy.get('@open')
+					.should('be.calledWith', calledUrl)
+					.then(() => {
+						openStub.restore()
+					})
+			}
 
 			const encodedCollectiveName = encodeURIComponent('Link Testing')
 			const pathname = isPublic

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -39,14 +39,20 @@ Cypress.Commands.add('loginAs', (user, password = null) => {
  */
 Cypress.Commands.add('getEditor', (timeout = null) => {
 	timeout = timeout ?? Cypress.config('defaultCommandTimeout')
-	cy.get('[data-collectives-el="editor"]', { timeout })
+	return cy.get('[data-collectives-el="editor"]', { timeout })
 })
 
 /**
  * Get the ReadOnlyEditor/RichTextReader component
  */
 Cypress.Commands.add('getReadOnlyEditor', () => {
-	cy.get('[data-collectives-el="reader"]')
+	return cy.get('[data-collectives-el="reader"]')
+})
+
+Cypress.Commands.add('getEditorContent', (edit = false) => {
+	return (edit ? cy.getEditor() : cy.getReadOnlyEditor())
+		.should('be.visible')
+		.find('.ProseMirror')
 })
 
 /**

--- a/lib/Mount/LazyFolder.php
+++ b/lib/Mount/LazyFolder.php
@@ -6,6 +6,7 @@ namespace OCA\Collectives\Mount;
 
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 
@@ -157,6 +158,10 @@ class LazyFolder implements Folder {
 	}
 
 	public function getById($id) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getFirstNodeById(int $id): ?Node {
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 

--- a/src/main.js
+++ b/src/main.js
@@ -31,6 +31,11 @@ import VTooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 import './shared-init.js'
 
+window.OCA.Collectives = {
+	...window.OCA.Collectives,
+	vueRouter: router,
+}
+
 // Register global directives
 Vue.directive('Tooltip', VTooltip)
 

--- a/src/views/PageReferenceWidget.vue
+++ b/src/views/PageReferenceWidget.vue
@@ -20,7 +20,11 @@
   -->
 
 <template>
-	<div v-if="richObject" class="collective-page">
+	<a v-if="richObject"
+		:href="richObject.link"
+		target="_blank"
+		class="collective-page"
+		@click="clickLink">
 		<div class="collective-page--image">
 			<span v-if="emoji"
 				class="page-emoji">
@@ -32,9 +36,7 @@
 		<div class="collective-page--info">
 			<div class="line">
 				<strong>
-					<a :href="richObject.link" target="_blank">
-						{{ richObject.page.title }}
-					</a>
+					{{ richObject.page.title }}
 				</strong>
 			</div>
 			<div class="description">
@@ -46,12 +48,13 @@
 					:display-name="richObject.page.lastUserDisplayName" />
 			</div>
 		</div>
-	</div>
+	</a>
 </template>
 
 <script>
 import PageIcon from '../components/Icon/PageIcon.vue'
 import NcUserBubble from '@nextcloud/vue/dist/Components/NcUserBubble.js'
+import { generateUrl } from '@nextcloud/router'
 
 export default {
 	name: 'PageReferenceWidget',
@@ -81,6 +84,20 @@ export default {
 			return this.richObject.page.emoji
 		},
 	},
+
+	methods: {
+		clickLink(event) {
+			const appUrl = '/apps/collectives'
+			const linkUrl = new URL(this.richObject.link, window.location)
+			// Only consider rerouting if we're inside the collectives app and for links to collectives app
+			if (OCA.Collectives?.vueRouter
+				&& linkUrl.pathname.toString().startsWith(generateUrl(appUrl))) {
+				event.preventDefault()
+				const collectivesUrl = linkUrl.href.substring(linkUrl.href.indexOf(appUrl) + appUrl.length)
+				OCA.Collectives.vueRouter.push(collectivesUrl)
+			}
+		},
+	},
 }
 </script>
 
@@ -88,15 +105,10 @@ export default {
 .collective-page {
 	width: 100%;
 	white-space: normal;
-	padding: 12px;
+	padding: 12px !important;
 	display: flex;
-
-	a {
-		padding: 0 !important;
-		&:not(:hover) {
-			text-decoration: unset !important;
-		}
-	}
+	text-decoration: unset !important;
+	color: var(--color-main-text) !important;
 
 	&--image {
 		margin-right: 12px;


### PR DESCRIPTION
### 📝 Summary

Starting with Nextcloud 29, clicking on a link opens the link bubble. This bubble contains a preview, clicking on it opens the link. It's no longer possible to pass a custom link handler into the Text app. Instead, all custom link handling needs to happen in the custom reference providers that provide the link preview.
 
Also starting with Nextcloud 29, all links to the collectives app open in the same tab, regardless whether in edit or view mode.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required
