### PR TITLE
Fix anchcors scrolling

### DIFF
--- a/src/Collectives.vue
+++ b/src/Collectives.vue
@@ -183,4 +183,10 @@ export default {
 .app-navigation .app-navigation-toggle {
 	top: 0 !important;
 }
+
+/* Fix for anchor scroll and sticky header */
+.splitpanes__pane-details {
+	scroll-padding-top: 60px;
+	scroll-behavior: smooth;
+}
 </style>

--- a/src/mixins/editorMixin.js
+++ b/src/mixins/editorMixin.js
@@ -86,7 +86,15 @@ export default {
 				onOutlineToggle: (visible) => {
 					this.toggleOutlineFromEditor(visible)
 				},
+				onLoaded: () => {
+					if (document.location.hash) {
+						// scroll to the corresponding header if the page was loaded with a hash
+						const element = document.querySelector(`[href="${document.location.hash}"]`)
+						element?.click()
+					}
+				},
 			})
+
 			if (!this.loading('pageContent')) {
 				this.reader.setContent(this.pageContent)
 			}


### PR DESCRIPTION
### 📝 Summary
Steps to reproduce:
- Create long page with multiple headings
- Click on heading in the bottom of the page
- Copy url from address bar with anchor and open it in new tab

Expected result:
- Content scrolled to heading

Actual result:
- There are no scroll

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/collectives/assets/191082/de51f53e-36d3-45d8-bec5-6e389ec81c3d) | ![image](https://github.com/nextcloud/collectives/assets/191082/20591d37-4c26-4f23-9c06-42c75bf8fc8f)

### 🚧 TODO
- [x] For some reason `onLoaded` callback is not called in my case, so I'm using `setTimeout`. Any idea how to fix that?
- [x] ~~Merge https://github.com/nextcloud-libraries/nextcloud-vue/pull/5435~~

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
