### PR TITLE
Fix/page filter performance issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "vue": "^2.7.16",
         "vue-material-design-icons": "^5.3.0",
         "vue-router": "^3.6.5",
+        "vue-virtual-scroller": "^1.1.2",
         "vuedraggable": "^2.24.3",
         "vuex": "^3.6.2",
         "vuex-router-sync": "^5.0.0"
@@ -18015,6 +18016,11 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA=="
+    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -20817,6 +20823,11 @@
       "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.3.0.tgz",
       "integrity": "sha512-wnbRh+48RwX/Gt+iqwCSdWpm0hPBwwv9F7MSouUzZ2PsphYVMJB9KkG9iGs+tgBiT57ZiurFEK07Y/rFKx+Ekg=="
     },
+    "node_modules/vue-observe-visibility": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-0.4.6.tgz",
+      "integrity": "sha512-xo0CEVdkjSjhJoDdLSvoZoQrw/H2BlzB5jrCBKGZNXN2zdZgMuZ9BKrxXDjNP2AxlcCoKc8OahI3F3r3JGLv2Q=="
+    },
     "node_modules/vue-resize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-1.0.1.tgz",
@@ -20861,6 +20872,27 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/vue-virtual-scroller": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-1.1.2.tgz",
+      "integrity": "sha512-SkUyc7QHCJFB5h1Fya7LxVizlVzOZZuFVipBGHYoTK8dwLs08bIz/tclvRApYhksaJIm/nn51inzO2UjpGJPMQ==",
+      "dependencies": {
+        "scrollparent": "^2.0.1",
+        "vue-observe-visibility": "^0.4.4",
+        "vue-resize": "^0.4.5"
+      },
+      "peerDependencies": {
+        "vue": "^2.6.11"
+      }
+    },
+    "node_modules/vue-virtual-scroller/node_modules/vue-resize": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-0.4.5.tgz",
+      "integrity": "sha512-bhP7MlgJQ8TIkZJXAfDf78uJO+mEI3CaLABLjv0WNzr4CcGRGPIAItyWYnP6LsPA4Oq0WE+suidNs6dgpO4RHg==",
+      "peerDependencies": {
+        "vue": "^2.3.0"
+      }
     },
     "node_modules/vue2-datepicker": {
       "version": "3.11.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "vue": "^2.7.16",
     "vue-material-design-icons": "^5.3.0",
     "vue-router": "^3.6.5",
+    "vue-virtual-scroller": "^1.1.2",
     "vuedraggable": "^2.24.3",
     "vuex": "^3.6.2",
     "vuex-router-sync": "^5.0.0"

--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -99,13 +99,24 @@
 					:level="1"
 					:filter-string="filterString"
 					:is-template="true" />
-				<SubpageList v-for="page in subpages"
-					:key="page.id"
-					:data-page-id="page.id"
-					:page="page"
-					:level="1"
-					:filter-string="filterString"
-					class="page-list-drag-item" />
+				<div v-if="filterString !== ''">
+					<SubpageList v-for="page in filteredPages"
+						:key="page.id"
+						:data-page-id="page.id"
+						:page="page"
+						:level="1"
+						:filtered-view="true"
+						class="page-list-drag-item" />
+				</div>
+				<div v-else>
+					<SubpageList v-for="page in subpages"
+						:key="page.id"
+						:data-page-id="page.id"
+						:page="page"
+						:level="1"
+						:filtered-view="false"
+						class="page-list-drag-item" />
+				</div>
 			</Draggable>
 		</div>
 		<PageTrash v-if="displayTrash" />
@@ -174,7 +185,18 @@ export default {
 			'sortBy',
 			'showing',
 			'showTemplates',
+			'allPages',
 		]),
+
+		allpages() {
+			return this.allPages(this.rootPage.collectivePath)
+		},
+
+		filteredPages() {
+			return this.allpages.filter(p => {
+				return p.title.toLowerCase().includes(this.filterString.toLowerCase())
+			})
+		},
 
 		subpages() {
 			if (this.rootPage) {

--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -77,7 +77,7 @@
 			<Draggable v-if="subpages || keptSortable(currentPage.id)"
 				:list="subpages"
 				:parent-id="rootPage.id"
-				:disable-sorting="disableSorting">
+				:disable-sorting="isFilteredview">
 				<template #header>
 					<div v-if="!sortedBy('byOrder')" class="sort-order-container">
 						<span class="sort-order-chip">
@@ -97,9 +97,9 @@
 					:key="templateView.id"
 					:page="templateView"
 					:level="1"
-					:filtered-view="disableSorting"
+					:filtered-view="isFilteredview"
 					:is-template="true" />
-				<div v-if="disableSorting">
+				<div v-if="isFilteredview">
 					<RecycleScroller v-slot="{item}"
 						class="scroller"
 						:items="filteredPages"
@@ -113,7 +113,7 @@
 							class="page-list-drag-item" />
 					</RecycleScroller>
 				</div>
-				<div v-if="!disableSorting">
+				<div v-if="!isFilteredview">
 					<SubpageList v-for="page in subpages"
 						:key="page.id"
 						:data-page-id="page.id"
@@ -237,7 +237,7 @@ export default {
 			return (sortOrder) => this.sortBy === sortOrder
 		},
 
-		disableSorting() {
+		isFilteredview() {
 			return this.filterString !== ''
 		},
 

--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -285,8 +285,9 @@ export default {
 
 <style lang="scss" scoped>
 
-.scroller{
-	height: 100vh;
+.scroller {
+	// NC header bar 50px; page list header bar 52px; landing page 48px; page trash 76px
+	height: calc(100vh - 50px - 52px - 48px - 76px);
 }
 
 .app-content-list {
@@ -307,7 +308,8 @@ export default {
 	margin-right: 4px;
 
 	.page-filter {
-		margin-left: 50px !important;
+		margin-left: 52px !important;
+		padding-bottom: 2px;
 	}
 }
 
@@ -335,7 +337,7 @@ li.toggle-button.selected {
 
 .page-list-root-page {
 	position: sticky;
-	top: 44px;
+	top: 52px;
 	z-index: 1;
 	background-color: var(--color-main-background);
 }

--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -198,7 +198,7 @@ export default {
 		]),
 
 		allpages() {
-			return this.allPages(this.rootPage.collectivePath)
+			return this.allPages(this.rootPage.id)
 		},
 
 		filteredPages() {

--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -97,9 +97,9 @@
 					:key="templateView.id"
 					:page="templateView"
 					:level="1"
-					:filtered-view="filterString !== ''"
+					:filtered-view="disableSorting"
 					:is-template="true" />
-				<div v-if="filterString.length>0">
+				<div v-if="disableSorting">
 					<RecycleScroller v-slot="{item}"
 						class="scroller"
 						:items="filteredPages"
@@ -113,7 +113,7 @@
 							class="page-list-drag-item" />
 					</RecycleScroller>
 				</div>
-				<div v-if="filterString.length === 0">
+				<div v-if="!disableSorting">
 					<SubpageList v-for="page in subpages"
 						:key="page.id"
 						:data-page-id="page.id"

--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -194,15 +194,15 @@ export default {
 			'sortBy',
 			'showing',
 			'showTemplates',
-			'allPages',
+			'allPagesSorted',
 		]),
 
-		allpages() {
-			return this.allPages(this.rootPage.id)
+		allPagesSortedCached() {
+			return this.allPagesSorted(this.rootPage.id)
 		},
 
 		filteredPages() {
-			return this.allpages.filter(p => {
+			return this.allPagesSortedCached.filter(p => {
 				return p.title.toLowerCase().includes(this.filterString.toLowerCase())
 			})
 		},
@@ -286,7 +286,7 @@ export default {
 <style lang="scss" scoped>
 
 .scroller{
-	height:100vh;
+	height: 100vh;
 }
 
 .app-content-list {

--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -97,18 +97,23 @@
 					:key="templateView.id"
 					:page="templateView"
 					:level="1"
-					:filter-string="filterString"
+					:filtered-view="filterString !== ''"
 					:is-template="true" />
-				<div v-if="filterString !== ''">
-					<SubpageList v-for="page in filteredPages"
-						:key="page.id"
-						:data-page-id="page.id"
-						:page="page"
-						:level="1"
-						:filtered-view="true"
-						class="page-list-drag-item" />
+				<div v-if="filterString.length>0">
+					<RecycleScroller v-slot="{item}"
+						class="scroller"
+						:items="filteredPages"
+						:item-size="44"
+						key-field="id">
+						<SubpageList :key="item.id"
+							:data-page-id="item.id"
+							:page="item"
+							:level="1"
+							:filtered-view="true"
+							class="page-list-drag-item" />
+					</RecycleScroller>
 				</div>
-				<div v-else>
+				<div v-if="filterString.length === 0">
 					<SubpageList v-for="page in subpages"
 						:key="page.id"
 						:data-page-id="page.id"
@@ -141,6 +146,9 @@ import { SET_COLLECTIVE_USER_SETTING_PAGE_ORDER } from '../store/actions.js'
 import { scrollToPage } from '../util/scrollToElement.js'
 import { pageOrders } from '../util/sortOrders.js'
 import SkeletonLoading from './SkeletonLoading.vue'
+import { RecycleScroller } from 'vue-virtual-scroller'
+
+import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
 
 export default {
 	name: 'PageList',
@@ -161,6 +169,7 @@ export default {
 		SortAlphabeticalAscendingIcon,
 		SortAscendingIcon,
 		SortClockAscendingOutlineIcon,
+		RecycleScroller,
 	},
 
 	data() {
@@ -275,6 +284,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+
+.scroller{
+	height:100vh;
+}
+
 .app-content-list {
 	// nextcloud-vue component sets `max-height: unset` on mobile.
 	// Overwrite this to fix stickyness of header and rootpage.

--- a/src/components/PageList/SubpageList.vue
+++ b/src/components/PageList/SubpageList.vue
@@ -1,7 +1,6 @@
 <template>
 	<div>
-		<Item v-show="pageInFilterString"
-			key="page.title"
+		<Item :key="page.title"
 			:to="pagePath(page)"
 			:page-id="page.id"
 			:parent-id="page.parentId"
@@ -14,7 +13,7 @@
 			:can-edit="currentCollectiveCanEdit"
 			:is-template="isTemplate"
 			:has-visible-subpages="hasVisibleSubpages"
-			:filtered-view="filterString !== ''"
+			:filtered-view="filteredView"
 			@toggleCollapsed="toggleCollapsed(page.id)"
 			@click.native="show('details')" />
 		<div class="page-list-indent">
@@ -22,7 +21,6 @@
 				:key="templateView.id"
 				:page="templateView"
 				:level="level+1"
-				:filter-string="filterString"
 				:is-template="true" />
 			<Draggable v-if="subpagesView.length > 0 || keptSortable(page.id)"
 				:list="subpagesView"
@@ -34,7 +32,6 @@
 					:data-page-id="subpage.id"
 					:page="subpage"
 					:level="level+1"
-					:filter-string="filterString"
 					:is-template="isTemplate"
 					class="page-list-drag-item" />
 			</Draggable>
@@ -64,9 +61,9 @@ export default {
 			type: Number,
 			required: true,
 		},
-		filterString: {
-			type: String,
-			default: '',
+		filteredView: {
+			type: Boolean,
+			default: false,
 		},
 		isTemplate: {
 			type: Boolean,
@@ -87,13 +84,9 @@ export default {
 			'showTemplates',
 		]),
 
-		pageInFilterString() {
-			return this.page.title.toLowerCase().includes(this.filterString.toLowerCase())
-		},
-
 		showSubpages() {
-			// Display subpages if either in filtered view or not collapsed
-			return this.filterString !== '' || !this.collapsed(this.page.id)
+			// Display subpages only when not in filtered view and when not collapsed
+			return !this.filteredView && !this.collapsed(this.page.id)
 		},
 
 		subpagesView() {
@@ -124,7 +117,7 @@ export default {
 		},
 
 		disableSorting() {
-			return this.filterString !== ''
+			return this.filteredView
 		},
 	},
 

--- a/src/store/pages.js
+++ b/src/store/pages.js
@@ -194,12 +194,17 @@ export default {
 			}
 		},
 
-		allPages(state) {
-			return function(collectivePath) {
-				const pages = state.pages.filter(p => p.collectivePath === collectivePath).map((p) => {
-					return p
+		allPages(state, getters) {
+			const allSubPagesSorted = (pageId) => {
+				const res = []
+				sortedSubpages(state, getters)(pageId).forEach(element => {
+					res.push(element)
+					res.push(...sortedSubpages(state, getters)(element.id))
 				})
-				return pages
+				return res
+			}
+			return function(rootPageId) {
+				return allSubPagesSorted(rootPageId)
 			}
 		},
 

--- a/src/store/pages.js
+++ b/src/store/pages.js
@@ -186,15 +186,7 @@ export default {
 			}
 		},
 
-		filteredPages(state) {
-			return (filterString) => {
-				return state.pages.filter(p => {
-					return p.title.toLowerCase().includes(filterString.toLowerCase())
-				})
-			}
-		},
-
-		allPages(state, getters) {
+		allPagesSorted(state, getters) {
 			const allSubPagesSorted = (pageId) => {
 				const res = []
 				sortedSubpages(state, getters)(pageId).forEach(element => {
@@ -203,9 +195,7 @@ export default {
 				})
 				return res
 			}
-			return function(rootPageId) {
-				return allSubPagesSorted(rootPageId)
-			}
+			return allSubPagesSorted
 		},
 
 		sortedSubpages,

--- a/src/store/pages.js
+++ b/src/store/pages.js
@@ -186,6 +186,23 @@ export default {
 			}
 		},
 
+		filteredPages(state) {
+			return (filterString) => {
+				return state.pages.filter(p => {
+					return p.title.toLowerCase().includes(filterString.toLowerCase())
+				})
+			}
+		},
+
+		allPages(state) {
+			return function(collectivePath) {
+				const pages = state.pages.filter(p => p.collectivePath === collectivePath).map((p) => {
+					return p
+				})
+				return pages
+			}
+		},
+
 		sortedSubpages,
 
 		pagesTreeWalk: (_state, getters) => (parentId = 0) => {


### PR DESCRIPTION
### 📝 Summary

* Resolves: #1090 

Logic for filtering Search results in collectives was done in the search results' component itself mainly, this was extracted to be done at once in the parent component. To Improve performance even more and make the search responsive a virtual-scroller was added to only render visible search results.

⚠️ Filtered Results are now in a flat list. That improves performance, and also makes the list more intuitive, as having indented search results without the parent page can be confusing.


🏚️ Before | 🏡 After
---|---
Entering something in the search bar was very unresponsive, sometimes waiting multiple seconds until the first keystroke is handled | Entering something is very responsive, waiting very little to virtually no time until keystrokes are recognized


### 🚧 TODO
While developing, a bug was discovered. The subpages list is actually bigger than the content it displays (search bar is written above it).
Therefore when the virtual scroller comes in, there are two scrollbars. It's planned to work on this in a seperate bug ticket as it's not completely related/caused by the performance improvement.

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required

![image](https://github.com/nextcloud/collectives/assets/56235737/a5cf1d9e-9beb-4fa7-8970-07fd0e67ff9a)