### PR TITLE
fix(PageList): Fix sort menu button

### DIFF
--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -17,8 +17,7 @@
 				</NcActionButton>
 			</NcActions>
 			<NcActions class="toggle"
-				:aria-label="t('collectives', 'Sort order')"
-				:menu-name="t('collectives', 'Sort order')">
+				:aria-label="t('collectives', 'Sort order')">
 				<template #icon>
 					<SortAscendingIcon v-if="sortedBy('byOrder')" :size="16" />
 					<SortAlphabeticalAscendingIcon v-else-if="sortedBy('byTitle')" :size="16" />


### PR DESCRIPTION
Remove `menuName` property to make it an icon-only button.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![2024-03-14T16:16:17,701803675+01:00](https://github.com/nextcloud/collectives/assets/3582805/e29cdc76-a1f4-42fc-857c-d40cf146c1de) | ![2024-03-14T16:15:32,246487243+01:00](https://github.com/nextcloud/collectives/assets/3582805/c4dd618c-38ce-4e8d-bf85-41755a3f6ca7)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
