### PR TITLE
Allow export collectives only if you have edit permission

### DIFF
--- a/src/components/Collective/CollectiveActions.vue
+++ b/src/components/Collective/CollectiveActions.vue
@@ -17,7 +17,8 @@
 				<ShareVariantIcon :size="20" />
 			</template>
 		</NcActionButton>
-		<NcActionLink :close-after-click="true"
+		<NcActionLink v-if="collectiveCanEdit(collective)"
+			:close-after-click="true"
 			:href="printLink"
 			target="_blank">
 			{{ t('collectives', 'Export or print') }}
@@ -89,6 +90,7 @@ export default {
 
 	computed: {
 		...mapGetters([
+			'collectiveCanEdit',
 			'collectiveCanShare',
 			'isCollectiveAdmin',
 			'isPublic',

--- a/src/views/CollectivePrintView.vue
+++ b/src/views/CollectivePrintView.vue
@@ -1,6 +1,6 @@
 <template>
 	<NcAppContent>
-		<CollectivePrint v-if="currentCollective" />
+		<CollectivePrint v-if="currentCollective && collectiveCanEdit(currentCollective)" />
 		<NcEmptyContent v-else-if="loading('collectives')" />
 		<CollectiveNotFound v-else />
 	</NcAppContent>
@@ -25,6 +25,7 @@ export default {
 
 	computed: {
 		...mapGetters([
+			'collectiveCanEdit',
 			'currentCollective',
 			'loading',
 		]),


### PR DESCRIPTION
### 📝 Summary
Right now anybody can export Collectives. Would be nice to increase security and allow such export only for editors. In ideal world we would like to add an extra setting "allow exporting for"
![image](https://github.com/nextcloud/collectives/assets/191082/1aa30a5c-a093-47e8-8b24-ab8ab47b76b2)
. But this is not possible because of bitmask used for permissions, see `\OCA\Collectives\Db\Collective::editPermissions`.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/collectives/assets/191082/25420041-203f-4851-b050-831fa6cb0699) | ![image](https://github.com/nextcloud/collectives/assets/191082/d3a573e9-c846-4dcd-a780-26ab02d6528f)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
