### PR TITLE
fix(ci): same npm and node during init and run

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -171,13 +171,13 @@ jobs:
           key: cypress-context-${{ matrix.server-versions }}-${{ github.run_id }}
           path: ./
 
-      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+      - name: Set up node ${{ needs.init.outputs.nodeVersion }}
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: ${{ steps.versions.outputs.nodeVersion }}
+          node-version: ${{ needs.init.outputs.nodeVersion }}
 
-      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
-        run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
+      - name: Set up npm ${{ needs.init.outputs.npmVersion }}
+        run: npm i -g npm@"${{ needs.init.outputs.npmVersion }}"
 
       - name: Set up php ${{ matrix.php-versions }}
         uses: shivammathur/setup-php@efffd0e4f2504f936fcfe3b69293d31ce0e2fd7a # v2


### PR DESCRIPTION
* Fixes #1218.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests are made more reliable by this.
- Documentation is not required
