### PR TITLE
docs: Remove app store link for shipped apps and mention both circles/teams

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -10,7 +10,7 @@ The following tools are required for app development:
 * php `dom` and `sqlite` extension
 * composer for installing php dependencies
 * nextcloud server for running php tests
-* teams app for passing some php tests that depend on it
+* teams/circles app for passing some php tests that depend on it
 * gh, the Github console command, for releasing to Github
 
 ## Developer installation
@@ -18,7 +18,7 @@ The following tools are required for app development:
 To install the app manually:
 
 0. Install a [development setup](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#setup) of nextcloud.
-1. Install the teams, text and viewer apps by cloning them to the `apps` folder
+1. Install the teams/circles, text and viewer apps by cloning them to the `apps` folder
 2. Clone this repository into the `apps` folder of your Nextcloud
 3. Install build tools and dependencies by running `make setup-dev`
 4. Compile NodeJS assets by running `make build`

--- a/docs/content/administration/_index.md
+++ b/docs/content/administration/_index.md
@@ -7,10 +7,10 @@ alwaysopen = false
 
 ## Runtime Dependencies
 
-This app requires the following apps to be enabled:
+Collectives requires the following apps to be enabled, all being shipped and enabled by default with recent Nextcloud releases:
 
-* [**Teams**](https://apps.nextcloud.com/apps/circles)
-* [**Text**](https://apps.nextcloud.com/apps/text)
+* **Teams** (with Nextcloud >= 29) or **Circles** (with Nextcloud <= 28)
+* **Text**
 * **Viewer**
 * **files_versions**
 


### PR DESCRIPTION
Fixes: #1220

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
