### PR TITLE
Make permanently delete collective buttons readable

### DIFF
--- a/src/components/Nav/CollectivesTrash.vue
+++ b/src/components/Nav/CollectivesTrash.vue
@@ -55,22 +55,28 @@
 					{{ t('collectives', 'Delete corresponding team along with the collective?') }}
 				</div>
 				<div class="three_buttons">
-					<NcButton @click="closeDeleteModal">
-						{{ t('collectives', 'Cancel') }}
-					</NcButton>
-					<NcButton type="error" @click="deleteCollective(modalCollective, false)">
+					<NcButton type="error"
+						:wide="true"
+						@click="deleteCollective(modalCollective, false)">
 						{{ t('collectives', 'Only collective') }}
 					</NcButton>
 					<NcButton v-if="isCollectiveOwner(modalCollective)"
 						type="error"
+						:wide="true"
 						@click="deleteCollective(modalCollective, true)">
 						{{ t('collectives', 'Collective and team') }}
 					</NcButton>
 					<NcButton v-else
 						type="primary"
 						disabled
-						:title="t('collectives', 'Only team owners can delete a team')">
+						:title="t('collectives', 'Only team owners can delete a team')"
+						:wide="true">
 						{{ t('collectives', 'Collective and team') }}
+					</NcButton>
+					<NcButton v-click-outside
+						:wide="true"
+						@click="closeDeleteModal">
+						{{ t('collectives', 'Cancel') }}
 					</NcButton>
 				</div>
 			</div>
@@ -242,6 +248,7 @@ export default {
 
 .three_buttons {
 	display: flex;
+	flex-flow: column nowrap;
 	justify-content: space-between;
 	padding-top: 10px;
 	gap: 10px;


### PR DESCRIPTION
### 📝 Summary

* Resolves: #1250 

The button text is not readable, so this PR aligns the buttons in a column layout instead, and moves the "Cancel" button to the bottom.

#### 🖼️ Screenshots

<details>
<summary>Before</summary>

![Snapshot_2024-05-10_15-00-56](https://github.com/nextcloud/collectives/assets/23369449/83915967-c6f7-4316-80db-1507239cc32c)
</details>

<details>
<summary>After</summary>

![Snapshot_2024-05-10_15-01-55](https://github.com/nextcloud/collectives/assets/23369449/eedc6f1e-2fc3-498a-9b3a-cb269b798429)
</details>

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
