### PR TITLE
test(cypress): Fix typing into editor

### DIFF
--- a/cypress/e2e/collective-share.spec.js
+++ b/cypress/e2e/collective-share.spec.js
@@ -112,7 +112,7 @@ describe('Collective Share', function() {
 				.should('have.value', '')
 			cy.get('#titleform input.title')
 				.type('New page')
-			cy.getEditor()
+			cy.getEditorContent(true)
 				.type('New content')
 			cy.get('button.titleform-button')
 				.click()

--- a/cypress/e2e/page-list.spec.js
+++ b/cypress/e2e/page-list.spec.js
@@ -248,8 +248,7 @@ describe('Page list', function() {
 			cy.wait('@attachmentUpload')
 
 			cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
-			cy.getEditor()
-				.should('be.visible')
+			cy.getEditorContent(true)
 				.type('text')
 			cy.switchToViewMode()
 

--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -174,15 +174,13 @@ describe('Pages', function() {
 			cy.log('Inserting a heading')
 			// Wait 1 second to prevent race condition with previous insertion
 			cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
-			cy.getEditor()
-				.should('be.visible')
+			cy.getEditorContent(true)
 				.type('## Heading{enter}')
 
 			cy.log('Inserting a user mention')
 			// Wait 1 second to prevent race condition with previous insertion
 			cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
-			cy.getEditor()
-				.should('be.visible')
+			cy.getEditorContent(true)
 				.type('@admi')
 			cy.get('.tippy-content')
 				.contains('admin')
@@ -242,8 +240,7 @@ describe('Pages', function() {
 		it('Supports selecting a page from a collective', function() {
 			cy.openPage('Page Title')
 
-			cy.getEditor()
-				.should('be.visible')
+			cy.getEditorContent(true)
 				.type('/Coll')
 			cy.get('.tippy-content .link-picker__item')
 				.contains('Collective pages')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -102,10 +102,17 @@ Cypress.Commands.add('setAppEnabled', (appName, value = true) => {
  */
 Cypress.Commands.add('enableDashboardWidget', (widgetName) => {
 	Cypress.log()
-	const url = `${Cypress.env('baseUrl')}/index.php/apps/dashboard/layout`
-	return axios.post(url,
-		{ layout: widgetName },
-	)
+	if (['stable26', 'stable27', 'stable28', 'stable29'].includes(Cypress.env('ncVersion'))) {
+		const url = `${Cypress.env('baseUrl')}/index.php/apps/dashboard/layout`
+		return axios.post(url,
+			{ layout: widgetName },
+		)
+	} else {
+		const url = `${Cypress.env('baseUrl')}/ocs/v2.php/apps/dashboard/api/v3/layout`
+		return axios.post(url,
+			{ layout: [widgetName] },
+		)
+	}
 })
 
 Cypress.Commands.add('store', (selector, options = {}) => {


### PR DESCRIPTION
`cy.type()` requires a typable element. `cy.getEditor()` returns the wrapper which is not writable, so use `cy.getEditorContent(true)` to get the contenteditable element.
