### PR TITLE
Revert `immediate: true` in debounced `updateEditorContent()`

### DIFF
--- a/src/components/LastUserBubble.vue
+++ b/src/components/LastUserBubble.vue
@@ -4,7 +4,7 @@
 			{{ t('collectives', 'Last changed by') }}
 		</template>
 		<NcUserBubble :display-name="lastUserDisplayName"
-			:user="lastUserId"
+			:user="lastUserId || ' '"
 			:show-user-status="false">
 			{{ lastEditedUserMessage }}
 		</NcUserBubble>

--- a/src/mixins/editorMixin.js
+++ b/src/mixins/editorMixin.js
@@ -132,7 +132,7 @@ export default {
 		updateEditorContent: debounce(function(markdown) {
 			this.editorContent = markdown
 			this.reader?.setContent(this.editorContent)
-		}, 200, { immediate: true }),
+		}, 200),
 
 		focusEditor() {
 			this.editor?.focus()


### PR DESCRIPTION
Revert "fix(editor): start immediately in debounced updateEditorContent function"
    
This reverts commit ab651d87b0a2eb0852f701da3fd866e254f8eaa7.
    
Fixes: #1194