### PR TITLE
fix: Automatically open collective if only one exists

### DIFF
--- a/cypress/e2e/collective.spec.js
+++ b/cypress/e2e/collective.spec.js
@@ -153,7 +153,8 @@ describe('Collective', function() {
 	describe('in non-admin collective', function() {
 		it('can leave collective and undo', function() {
 			cy.loginAs('jane')
-			cy.visit('/apps/collectives')
+			cy.visit('/apps/collectives/Preexisting%20Collective')
+			cy.get('button.app-navigation-toggle').click()
 
 			// Leave collective
 			cy.openCollectiveMenu('Preexisting Collective')

--- a/cypress/e2e/settings.spec.js
+++ b/cypress/e2e/settings.spec.js
@@ -29,7 +29,6 @@ describe('Settings', function() {
 	describe('Collectives folder setting', function() {
 		it('Allows changing the collective user folder', function() {
 			const randomFolder = Math.random().toString(36).replace(/[^a-z]+/g, '').slice(0, 10)
-			const filePickerListSelector = '#picker-filestable tr, .file-picker__row'
 			const breadcrumbsSelector = '.files-controls .breadcrumb, [data-cy-files-content-breadcrumbs] a'
 			cy.loginAs('bob')
 			cy.visit('apps/collectives/A%20Collective')
@@ -54,10 +53,6 @@ describe('Settings', function() {
 			cy.get('nav.newFolderMenu > ul > li > form > input[type="text"], input[placeholder="New folder name"], input[placeholder="New folder"]')
 				.type(`${randomFolder}{enter}`)
 			cy.wait('@createFolder')
-			// TODO: new folder popover doesn't close automatically, so click somewhere
-			cy.get('.file-picker nav [title="Home"]')
-				.click()
-			cy.get(filePickerListSelector).contains(randomFolder).click()
 
 			// Select new created folder
 			cy.intercept('POST', '**/collectives/api/v1.0/settings/user').as('setCollectivesFolder')

--- a/cypress/e2e/settings.spec.js
+++ b/cypress/e2e/settings.spec.js
@@ -32,7 +32,8 @@ describe('Settings', function() {
 			const filePickerListSelector = '#picker-filestable tr, .file-picker__row'
 			const breadcrumbsSelector = '.files-controls .breadcrumb, [data-cy-files-content-breadcrumbs] a'
 			cy.loginAs('bob')
-			cy.visit('apps/collectives')
+			cy.visit('apps/collectives/A%20Collective')
+			cy.get('button.app-navigation-toggle').click()
 
 			cy.get('#app-settings')
 				.click()

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -52,7 +52,9 @@ export default {
 		// Open the navigation if we already have collectives.
 		// Only has an effect on mobile (where navigation is closed per default).
 		'collectives'(val, oldval) {
-			if (oldval.length === 0 && val.length > 0) {
+			if (oldval.length === 0 && val.length === 1) {
+				this.$router.push(`/${encodeURIComponent(val[0].name)}`)
+			} else if (oldval.length === 0 && val.length > 1) {
 				emit('toggle-navigation', { open: true })
 			}
 		},


### PR DESCRIPTION
Fixes: #1241

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
