### PR TITLE
Last edit user related fixes

### DIFF
--- a/src/components/LastUserBubble.vue
+++ b/src/components/LastUserBubble.vue
@@ -4,10 +4,7 @@
 			{{ t('collectives', 'Last changed by') }}
 		</template>
 		<NcUserBubble :display-name="lastUserDisplayName"
-			:user="lastUserId || ' '"
-			:show-user-status="false">
-			{{ lastEditedUserMessage }}
-		</NcUserBubble>
+			:user="lastUserId" />
 		<span class="timestamp">
 			{{ lastUpdate }}
 		</span>
@@ -45,10 +42,6 @@ export default {
 	},
 
 	computed: {
-		lastEditedUserMessage() {
-			return t('collectives', 'Last edited by {user}', { user: this.lastUserDisplayName })
-		},
-
 		lastUpdate() {
 			return moment.unix(this.timestamp).fromNow()
 		},


### PR DESCRIPTION
### 📝 Summary

* fix(LastUserBubble): Fix displaying user bubble
* fix(PageService): Don't update last edit user with subpageOrder
* Resolves: #1122 

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
