### PR TITLE
fix(CollectiveMapper): Always return trashed collectives as simple list

### DIFF
--- a/lib/Db/CollectiveMapper.php
+++ b/lib/Db/CollectiveMapper.php
@@ -108,7 +108,7 @@ class CollectiveMapper extends QBMapper {
 			throw new NotFoundException('Failed to run database query', 0, $e);
 		}
 
-		return array_filter($collectives, fn (Collective $c) => $this->circleHelper->hasLevel($c->getCircleId(), $userId, Member::LEVEL_ADMIN));
+		return array_values(array_filter($collectives, fn (Collective $c) => $this->circleHelper->hasLevel($c->getCircleId(), $userId, Member::LEVEL_ADMIN)));
 	}
 
 	/**


### PR DESCRIPTION
`array_filter()` returns an array with out-of-order keys when removing elements that are not the last one from an indexed array. This results in `json_encode()` returning an associative array, which is interpreted as dict by the javascript frontend.

Fixes: #1289

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
