### PR TITLE
fix: Avoid reusing the collectives user folder for different users

### DIFF
--- a/lib/Fs/UserFolderHelper.php
+++ b/lib/Fs/UserFolderHelper.php
@@ -21,6 +21,7 @@ use UnexpectedValueException;
 
 class UserFolderHelper {
 	private ?Folder $userCollectivesFolder = null;
+	private ?string $initializedUser = null;
 
 	public function __construct(
 		private IRootFolder $rootFolder,
@@ -102,8 +103,9 @@ class UserFolderHelper {
 	 * @throws NotFoundException
 	 */
 	public function get(string $userId): Folder {
-		if (!$this->userCollectivesFolder) {
+		if (!$this->userCollectivesFolder || $userId !== $this->initializedUser) {
 			$this->userCollectivesFolder = $this->initialize($userId);
+			$this->initializedUser = $userId;
 		}
 
 		return $this->userCollectivesFolder;


### PR DESCRIPTION
When a file from a collective is shared to another user the mountpoint we are running into some frequent invalidation of the mount point cache. 

Steps to reproduce
1. admin and user1 have different languages
1. Have a collective that two users admin and user1 are part of
2. Share a file from this collective from from user1 to admin
3. Access the files list as admin, see that the path of the mountpoint that is requested for user1 actually uses the Collective folder name from admin (which is different due to the other language)

We basically reuse the collective user folder name from the first mount point in https://github.com/nextcloud/collectives/blob/1c7d1956cee227b2c1fa8df248249d3874927449/lib/Mount/MountProvider.php#L49-L59

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
