### PR TITLE
fix: Properly check for fileId parameter

### DIFF
--- a/lib/Reference/SearchablePageReferenceProvider.php
+++ b/lib/Reference/SearchablePageReferenceProvider.php
@@ -84,7 +84,7 @@ class SearchablePageReferenceProvider extends ADiscoverableReferenceProvider imp
 			$collectiveName = $pageReferenceInfo['collectiveName'];
 			try {
 				$collective = $this->collectiveService->findCollectiveByName($this->userId, $collectiveName);
-				if ($pageReferenceInfo['fileId']) {
+				if (isset($pageReferenceInfo['fileId'])) {
 					$page = $this->pageService->findByFileId($collective->getId(), $pageReferenceInfo['fileId'], $this->userId);
 				} else {
 					try {


### PR DESCRIPTION
Found while looking through sentry errors:

[PHP] Undefined array key "fileId" at /var/www/nextcloud/apps/collectives/lib/Reference/SearchablePageReferenceProvider.php#87