### PR TITLE
Don't show an error in frontend if files_trashbin is disabled

### DIFF
--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -444,7 +444,7 @@ class PageService {
 
 		$this->initTrashBackend();
 		if (!$this->trashBackend) {
-			throw new NotPermittedException('Failed to list page trash. Trash is disabled.');
+			return [];
 		}
 
 		$trashNodes = $this->trashBackend->listTrashForCollective($this->userManager->get($userId), $collectiveId);

--- a/src/util/displayError.js
+++ b/src/util/displayError.js
@@ -7,7 +7,7 @@ import escapeHtml from 'escape-html'
  */
 function content(msg, details) {
 	return details
-		? `<div>${escapeHtml(msg)}</div><div>${escapeHtml(details)}</div>`
+		? `<div>${escapeHtml(msg)}:&nbsp;</div><div>${escapeHtml(details)}</div>`
 		: msg
 }
 


### PR DESCRIPTION
Also contains a small formatting fix when displaying error messages from the backend in the frontend.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
