### PR TITLE
chore: Drop Nextcloud 26 support (no longer supported)

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -21,16 +21,16 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Server details:**
-- Collectives app version: [e.g. 2.8.2; see Nextcloud apps page]
-- Nextcloud version: [e.g. 26.0.1]
-- PHP Version: [e.g. 8.2]
+- Collectives app version: [e.g. 2.10.1; see Nextcloud apps page]
+- Nextcloud version: [e.g. 29.0.1]
+- PHP Version: [e.g. 8.3]
 - Database: [e.g. MariaDB 10.6]
 
 **Client details:**
  - OS: [e.g. Windows/macOS/Ubuntu]
  - Browser: [e.g. Firefox, Chrome]
- - Browser version: [e.g. 22]
- - Device: [e.g. iPhone6, desktop]
+ - Browser version: [e.g. 112]
+ - Device: [e.g. iPhone13, desktop]
 
 <details>
 <summary>Logs</summary>

--- a/.github/workflows/behat-sqlite-encryption.yml
+++ b/.github/workflows/behat-sqlite-encryption.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.2']
-        server-versions: ['stable26', 'master']
+        server-versions: ['stable27', 'master']
 
     steps:
       - name: Set app env

--- a/.github/workflows/behat-sqlite.yml
+++ b/.github/workflows/behat-sqlite.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.2']
-        server-versions: ['stable26', 'master']
+        server-versions: ['stable27', 'master']
         include:
           - php-versions: '8.3'
             server-versions: 'master'

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.2']
-        server-versions: ['stable26', 'master']
+        server-versions: ['stable27', 'master']
 
     name: SQLite PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
 

--- a/.github/workflows/update-nextcloud-ocp-matrix.yml
+++ b/.github/workflows/update-nextcloud-ocp-matrix.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         branches: ['main']
-        target: ['stable26']
+        target: ['stable27']
 
     name: update-nextcloud-ocp-${{ matrix.branches }}
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -43,7 +43,7 @@ In your Nextcloud instance, simply navigate to **»Apps«**, find the
 		https://raw.githubusercontent.com/nextcloud/collectives/main/docs/static/images/screenshot.png
 	</screenshot>
 	<dependencies>
-		<nextcloud min-version="26" max-version="29" />
+		<nextcloud min-version="27" max-version="29" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\Collectives\BackgroundJob\CleanupSessions</job>

--- a/cypress/e2e/collective-share.spec.js
+++ b/cypress/e2e/collective-share.spec.js
@@ -95,7 +95,7 @@ describe('Collective Share', function() {
 			cy.visit(shareUrl)
 			// Do some handstands to ensure that new page with editor is loaded before we edit the title
 			cy.intercept('POST', '**/_api/p/*/_pages/*').as('createPage')
-			if (['stable26', 'stable27'].includes(Cypress.env('ncVersion'))) {
+			if (['stable27'].includes(Cypress.env('ncVersion'))) {
 				cy.intercept('PUT', '**/apps/text/public/session/create').as('textCreateSession')
 			} else {
 				cy.intercept('PUT', '**/apps/text/public/session/*/create').as('textCreateSession')

--- a/cypress/e2e/page-details.spec.js
+++ b/cypress/e2e/page-details.spec.js
@@ -71,7 +71,7 @@ describe('Page details', function() {
 
 	describe('Displaying backlinks', function() {
 		it('Lists backlinks for a page', function() {
-			if (['stable26', 'stable27'].includes(Cypress.env('ncVersion'))) {
+			if (['stable27'].includes(Cypress.env('ncVersion'))) {
 				cy.intercept('PUT', '**/apps/text/session/create').as('textCreateSession')
 			} else {
 				cy.intercept('PUT', '**/apps/text/session/*/create').as('textCreateSession')

--- a/cypress/e2e/pages-links.spec.js
+++ b/cypress/e2e/pages-links.spec.js
@@ -112,7 +112,7 @@ describe('Page link handling', function() {
 			.click()
 
 		// Starting with Nextcloud 29, clicking on a link opens the link bubble
-		if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+		if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 			cy.get('.link-view-bubble .widgets--list')
 				.find('a.widget-file, a.collective-page, a.widget-default')
 				.click()
@@ -167,7 +167,7 @@ describe('Page link handling', function() {
 			const calledUrl = edit
 				? url.href
 				: href
-			if (['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				cy.get('@open')
 					.should('be.calledWith', calledUrl)
 					.then(() => {
@@ -189,7 +189,7 @@ describe('Page link handling', function() {
 	describe('Link handling to viewer in view mode', function() {
 		it('Opens link with absolute path to image in Nextcloud in viewer', function() {
 			let href = null
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				href = `/index.php/f/${imageId}`
 			} else {
 				href = `/index.php/apps/files/?dir=/&openfile=${imageId}#relPath=//test.png`
@@ -198,7 +198,7 @@ describe('Page link handling', function() {
 		})
 		it('Opens link with absolute path to text file in Nextcloud in viewer', function() {
 			let href = null
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				href = `/index.php/f/${textId}`
 			} else {
 				href = `/index.php/apps/files/?dir=/&openfile=${textId}#relPath=//test.md`
@@ -207,7 +207,7 @@ describe('Page link handling', function() {
 		})
 		it('Opens link with relative path to pdf in Nextcloud in viewer', function() {
 			let href = null
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				href = `/index.php/f/${pdfId}`
 			} else {
 				href = `/index.php/apps/files/?dir=/&openfile=${pdfId}#relPath=test.pdf`
@@ -219,7 +219,7 @@ describe('Page link handling', function() {
 	describe('Link handling to viewer in edit mode', function() {
 		it('Opens link with absolute path to image in Nextcloud in viewer', function() {
 			let href = null
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				href = `/index.php/f/${imageId}`
 			} else {
 				href = `/index.php/apps/files/?dir=/&openfile=${imageId}#relPath=//test.png`
@@ -229,7 +229,7 @@ describe('Page link handling', function() {
 		})
 		it('Opens link with absolute path to text file in Nextcloud in viewer', function() {
 			let href = null
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				href = `/index.php/f/${textId}`
 			} else {
 				href = `/index.php/apps/files/?dir=/&openfile=${textId}#relPath=//test.md`
@@ -243,7 +243,7 @@ describe('Page link handling', function() {
 		})
 		it('Opens link with relative path to pdf in Nextcloud in viewer', function() {
 			let href = null
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				href = `/index.php/f/${pdfId}`
 			} else {
 				href = `/index.php/apps/files/?dir=/Collectives/Link Testing&openfile=${pdfId}#relPath=test.pdf`
@@ -256,7 +256,7 @@ describe('Page link handling', function() {
 	describe('Link handling to collectives in view mode', function() {
 		it('Opens link with URL to page in this collective in same tab', function() {
 			const href = `${baseUrl}/index.php/apps/collectives/Link%20Testing/Link%20Target`
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				testLinkToSameTab(href, {
 					expectedSearch: `?fileId=${linkTargetPageId}`,
 				})
@@ -266,7 +266,7 @@ describe('Page link handling', function() {
 		})
 		it('Opens link with absolute path to page in this collective in same tab', function() {
 			const href = '/index.php/apps/collectives/Link%20Testing/Link%20Target'
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				testLinkToSameTab(href, {
 					expectedSearch: `?fileId=${linkTargetPageId}`,
 				})
@@ -276,7 +276,7 @@ describe('Page link handling', function() {
 		})
 		it('Opens link with relative path to page in this collective with fileId in same tab', function() {
 			// Starting with Nextcloud 29, internal links will always open in same tab (also in edit mode)
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				const href = `./Link%20Target?fileId=${linkTargetPageId}`
 				testLinkToSameTab(href)
 			} else {
@@ -291,7 +291,7 @@ describe('Page link handling', function() {
 		})
 		it('Opens link with relative path to page in this collective with fileId and outdated path in same tab', function() {
 			// Starting with Nextcloud 29, internal links will always open in same tab (also in edit mode)
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				const href = `./Link%20Target%20Outdated?fileId=${linkTargetPageId}`
 				testLinkToSameTab(href, {
 					expectedPathname: '/index.php/apps/collectives/Link%20Testing/Link%20Target',
@@ -309,7 +309,7 @@ describe('Page link handling', function() {
 		})
 		it('Opens link with relative path to page in this collective without fileId in same tab', function() {
 			const href = './Link%20Target'
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				testLinkToSameTab(href, {
 					expectedPathname: '/index.php/apps/collectives/Link%20Testing/Link%20Target',
 					expectedSearch: `?fileId=${linkTargetPageId}`,
@@ -321,7 +321,7 @@ describe('Page link handling', function() {
 		it('Opens link with relative path to markdown file in this collective without fileId in same tab', function() {
 			// TODO: We want '.md' to be stripped when opening the link
 			const href = './Link%20Target.md'
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				testLinkToSameTab(href, {
 					expectedPathname: '/index.php/apps/collectives/Link%20Testing/Link%20Target',
 					expectedSearch: `?fileId=${linkTargetPageId}`,
@@ -337,7 +337,7 @@ describe('Page link handling', function() {
 		})
 		it('Opens link with absolute path to page in other collective without fileId in same tab', function() {
 			const href = '/index.php/apps/collectives/Another%20Collective/First%20Page'
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				testLinkToSameTab(href, {
 					expectedSearch: `?fileId=${anotherCollectiveFirstPageId}`,
 				})
@@ -347,7 +347,7 @@ describe('Page link handling', function() {
 		})
 		it('Opens link with relative path from index page to page in this collective with fileId in same tab', function() {
 			// Starting with Nextcloud 29, internal links will always open in same tab (also in edit mode)
-			if (['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				cy.openPage('Parent')
 				// Link without origin and containing `fileId` param gets rewritten by editor rendering
 				// const href = `../Link%20Target.md?fileId=${linkTargetPageId}`
@@ -360,7 +360,7 @@ describe('Page link handling', function() {
 		})
 		it('Opens link with relative path from landing page to page in this collective with fileId in same tab', function() {
 			// Starting with Nextcloud 29, internal links will always open in same tab (also in edit mode)
-			if (['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				cy.openPage('Link Testing')
 				// Link without origin and containing `fileId` param gets rewritten by editor rendering
 				// const href = `./Link%20Target?fileId=${linkTargetPageId}`
@@ -378,7 +378,7 @@ describe('Page link handling', function() {
 			const href = `${baseUrl}/index.php/apps/collectives/Link%20Testing/Link%20Target`
 			cy.switchToEditMode()
 			// Starting with Nextcloud 29, internal links will always open in same tab (also in edit mode)
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				testLinkToSameTab(href, {
 					edit: true,
 					expectedSearch: `?fileId=${linkTargetPageId}`,
@@ -391,7 +391,7 @@ describe('Page link handling', function() {
 			const href = '/index.php/apps/collectives/Link%20Testing/Link%20Target'
 			cy.switchToEditMode()
 			// Starting with Nextcloud 29, internal links will always open in same tab (also in edit mode)
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				testLinkToSameTab(href, {
 					edit: true,
 					expectedSearch: `?fileId=${linkTargetPageId}`,
@@ -404,7 +404,7 @@ describe('Page link handling', function() {
 			const href = `./Link%20Target?fileId=${linkTargetPageId}`
 			cy.switchToEditMode()
 			// Starting with Nextcloud 29, internal links will always open in same tab (also in edit mode)
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				testLinkToSameTab(href, { edit: true })
 			} else {
 				// Link without origin and containing `fileId` param gets rewritten by editor rendering
@@ -414,7 +414,7 @@ describe('Page link handling', function() {
 			const href = `./Link%20Target%20Outdated?fileId=${linkTargetPageId}`
 			cy.switchToEditMode()
 			// Starting with Nextcloud 29, internal links will always open in same tab (also in edit mode)
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				testLinkToSameTab(href, {
 					edit: true,
 					expectedPathname: '/index.php/apps/collectives/Link%20Testing/Link%20Target',
@@ -428,7 +428,7 @@ describe('Page link handling', function() {
 			const href = './Link%20Target'
 			cy.switchToEditMode()
 			// Starting with Nextcloud 29, internal links will always open in same tab (also in edit mode)
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				testLinkToSameTab(href, {
 					edit: true,
 					expectedSearch: `?fileId=${linkTargetPageId}`,
@@ -442,7 +442,7 @@ describe('Page link handling', function() {
 			const href = './Link%20Target.md'
 			cy.switchToEditMode()
 			// Starting with Nextcloud 29, internal links will always open in same tab (also in edit mode)
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				testLinkToSameTab(href, {
 					edit: true,
 					expectedPathname: '/index.php/apps/collectives/Link%20Testing/Link%20Target',
@@ -457,7 +457,7 @@ describe('Page link handling', function() {
 			const href = `${baseUrl}/index.php/apps/collectives/Another%20Collective/First%20Page?fileId=${anotherCollectiveFirstPageId}`
 			cy.switchToEditMode()
 			// Starting with Nextcloud 29, internal links will always open in same tab (also in edit mode)
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				testLinkToSameTab(href, { edit: true })
 			} else {
 				testLinkToNewTab(href, { edit: true })
@@ -467,7 +467,7 @@ describe('Page link handling', function() {
 			const href = '/index.php/apps/collectives/Another%20Collective/First%20Page'
 			cy.switchToEditMode()
 			// Starting with Nextcloud 29, internal links will always open in same tab (also in edit mode)
-			if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+			if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 				testLinkToSameTab(href, {
 					edit: true,
 					expectedSearch: `?fileId=${anotherCollectiveFirstPageId}`,
@@ -527,7 +527,7 @@ describe('Page link handling', function() {
 	})
 
 	describe('Link handling public share', function() {
-		if (['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+		if (['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 			let shareUrl
 
 			it('Share the collective', function() {
@@ -576,7 +576,7 @@ describe('Page link handling', function() {
 				cy.visit(`${shareUrl}/Link Source`)
 				const href = '/index.php/apps/collectives/Link%20Testing/Link%20Target'
 				cy.switchToEditMode()
-				if (!['stable26', 'stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
+				if (!['stable27', 'stable28'].includes(Cypress.env('ncVersion'))) {
 					testLinkToSameTab(href, { edit: true, isPublic: true })
 				} else {
 					testLinkToNewTab(href, { edit: true, isPublic: true })

--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -106,7 +106,7 @@ describe('Pages', function() {
 		it('New page has template content', function() {
 			// Do some handstands to ensure that new page with editor is loaded before we edit the title
 			cy.intercept('POST', '**/_api/*/_pages/*').as('createPage')
-			if (['stable26', 'stable27'].includes(Cypress.env('ncVersion'))) {
+			if (['stable27'].includes(Cypress.env('ncVersion'))) {
 				cy.intercept('PUT', '**/apps/text/session/create').as('textCreateSession')
 			} else {
 				cy.intercept('PUT', '**/apps/text/session/*/create').as('textCreateSession')
@@ -133,7 +133,7 @@ describe('Pages', function() {
 		it('Shows the title in the enabled titleform and full path in browser title', function() {
 			// Do some handstands to ensure that new page with editor is loaded before we edit the title
 			cy.intercept('POST', '**/_api/*/_pages/*').as('createPage')
-			if (['stable26', 'stable27'].includes(Cypress.env('ncVersion'))) {
+			if (['stable27'].includes(Cypress.env('ncVersion'))) {
 				cy.intercept('PUT', '**/apps/text/session/create').as('textCreateSession')
 			} else {
 				cy.intercept('PUT', '**/apps/text/session/*/create').as('textCreateSession')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -105,7 +105,7 @@ Cypress.Commands.add('setAppEnabled', (appName, value = true) => {
  */
 Cypress.Commands.add('enableDashboardWidget', (widgetName) => {
 	Cypress.log()
-	if (['stable26', 'stable27', 'stable28', 'stable29'].includes(Cypress.env('ncVersion'))) {
+	if (['stable27', 'stable28', 'stable29'].includes(Cypress.env('ncVersion'))) {
 		const url = `${Cypress.env('baseUrl')}/index.php/apps/dashboard/layout`
 		return axios.post(url,
 			{ layout: widgetName },


### PR DESCRIPTION
`.github/ISSUE_TEMPLATE/Bug_report.md` was migrated from DOS to Unix line breaks, that's why the diff shows the whole file being rewritten.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
