### PR TITLE
Save full width of page on server

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -61,6 +61,8 @@ return [
 			'verb' => 'POST', 'requirements' => ['collectiveId' => '\d+', 'parentId' => '\d+']],
 		['name' => 'page#touch', 'url' => '/_api/{collectiveId}/_pages/{id}/touch',
 			'verb' => 'GET', 'requirements' => ['collectiveId' => '\d+', 'id' => '\d+']],
+		['name' => 'page#setFullWidth', 'url' => '/_api/{collectiveId}/_pages/{id}/fullWidth',
+			'verb' => 'PUT', 'requirements' => ['collectiveId' => '\d+', 'id' => '\d+']],
 		['name' => 'page#contentSearch', 'url' => '/_api/{collectiveId}/_pages/search',
 			'verb' => 'GET', 'requirements' => ['collectiveId' => '\d+', 'filterString' => '\s+']],
 		['name' => 'page#moveOrCopy', 'url' => '/_api/{collectiveId}/_pages/{id}',

--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -259,7 +259,7 @@ describe('Pages', function() {
 				.invoke('outerWidth')
 				.should('be.greaterThan', 700)
 
-			// Reload to check persistence with browser storage
+			// Reload to check persistence
 			cy.reload()
 			cy.get('#titleform').should('have.css', 'max-width', 'none')
 			cy.getReadOnlyEditor()

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -138,6 +138,17 @@ class PageController extends Controller {
 	}
 
 	#[NoAdminRequired]
+	public function setFullWidth(int $collectiveId, int $id, bool $fullWidth): DataResponse {
+		return $this->handleErrorResponse(function () use ($collectiveId, $id, $fullWidth): array {
+			$userId = $this->getUserId();
+			$pageInfo = $this->service->setFullWidth($collectiveId, $id, $userId, $fullWidth);
+			return [
+				"data" => $pageInfo,
+			];
+		}, $this->logger);
+	}
+
+	#[NoAdminRequired]
 	public function setSubpageOrder(int $collectiveId, int $id, ?string $subpageOrder = null): DataResponse {
 		return $this->handleErrorResponse(function () use ($collectiveId, $id, $subpageOrder): array {
 			$userId = $this->getUserId();

--- a/lib/Db/Page.php
+++ b/lib/Db/Page.php
@@ -24,6 +24,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setEmoji(?string $value)
  * @method string getSubpageOrder()
  * @method void setSubpageOrder(string $value)
+ * @method bool getFullWidth()
+ * @method void setFullWidth(bool $value)
  * @method int|null getTrashTimestamp()
  * @method void setTrashTimestamp(?int $trashTimestamp)
  */
@@ -32,7 +34,12 @@ class Page extends Entity implements JsonSerializable {
 	protected ?string $lastUserId = null;
 	protected ?string $emoji = null;
 	protected ?string $subpageOrder = null;
+	protected ?bool $fullWidth = null;
 	protected ?int $trashTimestamp = null;
+
+	public function __construct() {
+		$this->addType('fullWidth', 'bool');
+	}
 
 	public function jsonSerialize(): array {
 		return [
@@ -41,6 +48,7 @@ class Page extends Entity implements JsonSerializable {
 			'lastUserId' => $this->lastUserId,
 			'emoji' => $this->emoji,
 			'subpageOrder' => json_decode($this->getSubpageOrder() ?? '[]', true, 512, JSON_THROW_ON_ERROR),
+			'fullWidth' => $this->fullWidth,
 			'trashTimestamp' => $this->trashTimestamp,
 		];
 	}

--- a/lib/Migration/Version021200Date20240725154232.php
+++ b/lib/Migration/Version021200Date20240725154232.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version021200Date20240725154232 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('collectives_pages');
+		if (!$table->hasColumn('full_width')) {
+			$table->addColumn('full_width', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => false,
+			]);
+
+			return $schema;
+		}
+
+		return null;
+	}
+}

--- a/lib/Model/PageInfo.php
+++ b/lib/Model/PageInfo.php
@@ -24,6 +24,7 @@ class PageInfo implements JsonSerializable {
 	private ?string $lastUserId = null;
 	private ?string $lastUserDisplayName = null;
 	private ?string $emoji = null;
+	private bool $fullWidth = false;
 	private ?string $subpageOrder = null;
 	private ?int $trashTimestamp = null;
 	private string $title;
@@ -65,6 +66,14 @@ class PageInfo implements JsonSerializable {
 
 	public function setEmoji(?string $emoji): void {
 		$this->emoji = $emoji;
+	}
+
+	public function isFullWidth(): bool {
+		return $this->fullWidth;
+	}
+
+	public function setFullWidth(bool $fullWidth): void {
+		$this->fullWidth = $fullWidth;
 	}
 
 	public function getSubpageOrder(): ?string {
@@ -153,6 +162,7 @@ class PageInfo implements JsonSerializable {
 			'lastUserId' => $this->lastUserId,
 			'lastUserDisplayName' => $this->lastUserDisplayName,
 			'emoji' => $this->emoji,
+			'isFullWidth' => $this->fullWidth,
 			'subpageOrder' => json_decode($this->subpageOrder ?? '[]', true, 512, JSON_THROW_ON_ERROR),
 			'trashTimestamp' => $this->trashTimestamp,
 			'title' => $this->title,
@@ -170,7 +180,7 @@ class PageInfo implements JsonSerializable {
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */
-	public function fromFile(File $file, int $parentId, ?string $lastUserId = null, ?string $lastUserDisplayName = null, ?string $emoji = null, ?string $subpageOrder = null): void {
+	public function fromFile(File $file, int $parentId, ?string $lastUserId = null, ?string $lastUserDisplayName = null, ?string $emoji = null, ?string $subpageOrder = null, bool $fullWidth = false): void {
 		$this->setId($file->getId());
 		// Set folder name as title for all index pages except the collective landing page
 		$dirName = dirname($file->getInternalPath());
@@ -196,6 +206,9 @@ class PageInfo implements JsonSerializable {
 		}
 		if ($emoji !== null) {
 			$this->setEmoji($emoji);
+		}
+		if ($fullWidth !== null) {
+			$this->setFullWidth($fullWidth);
 		}
 		if ($subpageOrder !== null) {
 			$this->setSubpageOrder($subpageOrder);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",
         "@nextcloud/axios": "^2.5.0",
-        "@nextcloud/browser-storage": "^0.4.0",
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/dialogs": "^5.3.5",
         "@nextcloud/event-bus": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@nextcloud/auth": "^2.4.0",
     "@nextcloud/axios": "^2.5.0",
-    "@nextcloud/browser-storage": "^0.4.0",
     "@nextcloud/capabilities": "^1.2.0",
     "@nextcloud/dialogs": "^5.3.5",
     "@nextcloud/event-bus": "^3.3.1",

--- a/src/apis/collectives/pages.js
+++ b/src/apis/collectives/pages.js
@@ -158,6 +158,20 @@ export function setPageEmoji(context, pageId, emoji) {
 }
 
 /**
+ * Set full width for a page
+ *
+ * @param {object} context - either the current collective or a share context
+ * @param {number} pageId - Id of the page to update
+ * @param {boolean} fullWidth - Full width for the page
+ */
+export function setFullWidth(context, pageId, fullWidth) {
+	return axios.put(
+		pagesUrl(context, pageId, 'fullWidth'),
+		{ fullWidth },
+	)
+}
+
+/**
  * Set subpageOrder for a page
  *
  * @param {object} context - either the current collective or a share context

--- a/src/components/Page.vue
+++ b/src/components/Page.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<div :class="[isFullWidthView ? 'full-width-view' : 'sheet-view']">
+	<div :class="[currentPage.isFullWidth ? 'full-width-view' : 'sheet-view']">
 		<h2 id="titleform" class="page-title">
 			<!-- Page emoji or icon -->
 			<div class="page-title-icon"
@@ -247,7 +247,6 @@ export default {
 	},
 
 	mounted() {
-		this.initFullWidthPageIds()
 		document.title = this.documentTitle
 		this.initTitleEntry()
 	},
@@ -261,7 +260,6 @@ export default {
 		...mapActions(usePagesStore, [
 			'getPages',
 			'renamePage',
-			'initFullWidthPageIds',
 		]),
 
 		initTitleEntry() {

--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -41,7 +41,8 @@
 
 			<!-- Page view options: only displayed in page title menu -->
 			<NcActionCheckbox v-if="!inPageList && !isMobile"
-				:checked="isFullWidthView"
+				:checked="currentPage.isFullWidth"
+				:disabled="!currentCollectiveCanEdit"
 				@check="onCheckFullWidthView"
 				@uncheck="onUncheckFullWidthView">
 				{{ t('collectives', 'Full width') }}
@@ -230,7 +231,6 @@ export default {
 		]),
 		...mapState(usePagesStore, [
 			'hasSubpages',
-			'isFullWidthView',
 			'pagesTreeWalk',
 			'showTemplates',
 			'visibleSubpages',
@@ -313,11 +313,11 @@ export default {
 		...mapActions(usePagesStore, ['setFullWidthView']),
 
 		onCheckFullWidthView() {
-			this.setFullWidthView(true)
+			this.setFullWidthView({ pageId: this.currentPage.id, fullWidthView: true })
 		},
 
 		onUncheckFullWidthView() {
-			this.setFullWidthView(false)
+			this.setFullWidthView({ pageId: this.currentPage.id, fullWidthView: false })
 		},
 
 		openShareTab() {

--- a/src/components/Page/Version.vue
+++ b/src/components/Page/Version.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<div :class="[isFullWidthView ? 'full-width-view' : 'sheet-view']">
+	<div :class="[currentPage.isFullWidth ? 'full-width-view' : 'sheet-view']">
 		<h2 id="titleform" class="page-title">
 			<div class="page-title-icon">
 				<div v-if="currentPage.emoji">

--- a/tests/Integration/features/bootstrap/FeatureContext.php
+++ b/tests/Integration/features/bootstrap/FeatureContext.php
@@ -535,6 +535,27 @@ class FeatureContext implements Context {
 	}
 
 	/**
+	 * @When user :user sets full width for page :page to :fullWidth in :collective
+	 * @When user :user :fails to set full width for page :page to :fullWidth in :collective
+	 *
+	 * @throws GuzzleException
+	 */
+	public function userSetsFullWidth(string $user, string $page, string $fullWidth, string $collective, ?string $fail = null): void {
+		$this->setCurrentUser($user);
+		$collectiveId = $this->collectiveIdByName($collective);
+		$pageId = $this->pageIdByName($collectiveId, $page);
+		$isFullWidth = $fullWidth === "true";
+		$formData = new TableNode([['fullWidth', $isFullWidth]]);
+		$this->sendRequest('PUT', '/apps/collectives/_api/' . $collectiveId . '/_pages/' . $pageId . '/fullWidth', $formData);
+		if ($fail === "fails") {
+			$this->assertStatusCode(403);
+		} else {
+			$this->assertStatusCode(200);
+			$this->assertPageKeyValue($pageId, 'isFullWidth', $isFullWidth);
+		}
+	}
+
+	/**
 	 * @When user :user sets subpageOrder for page :page to :subpageOrder in :collective
 	 * @When user :user :fails to set subpageOrder for page :page to :subpageOrder in :collective
 	 *

--- a/tests/Integration/features/pages.feature
+++ b/tests/Integration/features/pages.feature
@@ -50,6 +50,10 @@ Feature: pages
     When user "jane" sets emoji for page "firstpage" to "🍏" in "BehatPagesCollective"
     And user "jane" sets emoji for page "firstpage" to "" in "BehatPagesCollective"
 
+  Scenario: Change page full width
+    When user "jane" sets full width for page "firstpage" to "true" in "BehatPagesCollective"
+    And user "jane" sets full width for page "firstpage" to "false" in "BehatPagesCollective"
+
   Scenario: Change page subpageOrder
     When user "jane" sets subpageOrder for page "firstpage" to "[]" in "BehatPagesCollective"
     And user "jane" sets subpageOrder for page "firstpage" to "[1,2]" in "BehatPagesCollective"
@@ -110,6 +114,7 @@ Feature: pages
     And user "john" fails to touch page "secondpage" in "BehatPagesCollective"
     And user "john" fails to move page "secondpage" to "newnamepage" with parentPath "Readme.md" in "BehatPagesCollective"
     And user "john" fails to set emoji for page "secondpage" to "🍏" in "BehatPagesCollective"
+    And user "john" fails to set full width for page "secondpage" to "🍏" in "BehatPagesCollective"
     And user "john" fails to set subpageOrder for page "secondpage" to "[]" in "BehatPagesCollective"
     And user "john" fails to trash page "secondpage" in "BehatPagesCollective"
 


### PR DESCRIPTION
### 📝 Summary
Currently we are storing "Full width" inside local storage. This means, that this setting not shares between users and browsers. Would be nice to make this setting persistent on db level like in Confluence.

#### 🖼️ Screenshots
https://github.com/user-attachments/assets/8b7372fe-807c-4a69-8db3-6d359a76ac0b

### 🚧 TODO
- [x] add tests after code review

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
