### PR TITLE
fix: Only load files scripts for the files app

### DIFF
--- a/lib/Listeners/BeforeTemplateRenderedListener.php
+++ b/lib/Listeners/BeforeTemplateRenderedListener.php
@@ -53,7 +53,9 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			Util::addInitScript('collectives', 'collectives-init');
 		}
 
-		Util::addScript('collectives', 'collectives-files');
+		if ($event->getResponse()->getApp() === 'files') {
+			Util::addScript('collectives', 'collectives-files');
+		}
 
 		$isCollectivesResponse = $event->getResponse()->getApp() === Application::APP_NAME;
 		if ($isCollectivesResponse && class_exists(LoadEditor::class)) {


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>

### 📝 Summary

* Resolves: # <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
