### PR TITLE
perf: Optimize getPagesFromFolder to avoid requests for files that already get obtained through directory listing

### DIFF
--- a/tests/Unit/Service/PageServiceTest.php
+++ b/tests/Unit/Service/PageServiceTest.php
@@ -201,8 +201,8 @@ class PageServiceTest extends TestCase {
 		$indexPageInfo->setParentId(101);
 		$indexPageInfo->setTitle('testfolder');
 
-		$filesJustMd[] = $indexPageInfo;
-		$filesNotJustMd[] = $indexPageInfo;
+		$filesJustMd[] = $indexFile;
+		$filesNotJustMd[] = $indexFile;
 		$pageInfos[] = $indexPageInfo;
 
 		$fileNameList = [ 'page1.md', 'page2.md', 'page3.md', 'another.jpg', 'whatever.txt' ];


### PR DESCRIPTION
I'm cleaning up some local stashed changes, opening a PR to not forget about this one, still needs proper testing and performance measurements

This one targets optimizing the initial page load on `PageController::index` (currently quite slow with P95 of 5.80s on our instance) where a list of all pages are loaded. The current logic:

- get index file (checks for a file that we could reuse the results from the getDirectoryListing to obtain it)
- check if folder has subpages (calls getDirectoryListing)
- get directory content (calls getDirectoryListing again)

New logic would be to only get the directory listing once and reuse it for other checks


<img width="1238" alt="Screenshot 2024-08-05 at 21 55 57" src="https://github.com/user-attachments/assets/1156d37e-4f8f-4f9f-9d07-01caf57cef3a">


### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
