### PR TITLE
fixes to display latest page content in reader

### DIFF
--- a/src/mixins/editorMixin.js
+++ b/src/mixins/editorMixin.js
@@ -151,6 +151,9 @@ export default {
 					readOnly: false,
 					shareToken: this.shareTokenParam || null,
 					autofocus: false,
+					onCreate: ({ markdown }) => {
+						this.updateEditorContentDebounced(markdown)
+					},
 					onLoaded: () => {
 						this.done('editor')
 					},

--- a/src/mixins/pageContentMixin.js
+++ b/src/mixins/pageContentMixin.js
@@ -22,13 +22,16 @@ export default {
 		 * @param {string} davUrl URL to fetch page via DAV
 		 */
 		async fetchPageContent(davUrl) {
+			// Add `timestamp` as cache buster param
+			const axiosConfig = {
+				params: {
+					timestamp: Math.floor(Date.now() / 1000),
+				},
+			}
 			// Authenticate via share token for public shares
-			let axiosConfig = {}
 			if (this.isPublic) {
-				axiosConfig = {
-					auth: {
-						username: this.shareTokenParam,
-					},
+				axiosConfig.auth = {
+					username: this.shareTokenParam,
 				}
 			}
 


### PR DESCRIPTION
### 📝 Summary

* fix(editor): Pass onCreate callback to editor API - Makes sure that reader content is updated with editor content on initial load.
* fix(pageContent): Add cache buster param to DAV request - Ensures that we always get the latest DAV content and nobody (neither browser nor server) cache anything in between.

Fixes: #1437

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
