### PR TITLE
chore(CI): Updating renovate-approve-merge.yml workflow from template

### DIFF
--- a/.github/workflows/renovate-approve-merge.yml
+++ b/.github/workflows/renovate-approve-merge.yml
@@ -45,7 +45,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # GitHub actions bot approve
-      - uses: hmarr/auto-approve-action@v3
+      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         if: startsWith(steps.branchname.outputs.branch, 'renovate/')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automated update of the renovate-approve-merge.yml workflow from https://github.com/nextcloud/.github