### PR TITLE
fix(backlinks): Detect links with title in markdown syntax

### DIFF
--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -1028,8 +1028,8 @@ class PageService {
 	}
 
 	public function matchBacklinks(PageInfo $pageInfo, string $content): bool {
-		$prefix = '/(\[[^\]]+\]\(|\<)';
-		$suffix = '[\)\>]/';
+		$prefix = '/(\[[^]]+]\(|<)';
+		$suffix = '(( \([^)]+\))?\)|>)/';
 
 		$protocol = 'https?:\/\/';
 		$trustedDomainArray = array_map(static fn (string $domain) => str_replace('\*', '\w*', preg_quote($domain, '/')), (array)$this->config->getSystemValue('trusted_domains', []));

--- a/tests/Unit/Service/PageServiceTest.php
+++ b/tests/Unit/Service/PageServiceTest.php
@@ -331,6 +331,9 @@ class PageServiceTest extends TestCase {
 		self::assertFalse($this->service->matchBacklinks($pageInfo, 'content with [a link to wrong host](https://anothercloud.com' . $urlPath . ') in it.'));
 		self::assertFalse($this->service->matchBacklinks($pageInfo, 'content with [a link to wrong host](anothercloud.com' . $urlPath . ') in it.'));
 
+		// Relative link with fileId in [text](link (preview)) syntax
+		self::assertTrue($this->service->matchBacklinks($pageInfo, 'content with [a link](https://nextcloud.local' . $urlPath . ' (preview)) in it.'));
+
 		OC::$WEBROOT = 'mycloud';
 
 		// Relative link with fileId with webroot in [text](link) syntax


### PR DESCRIPTION
This fixes detecting preview links, as they have `preview` set as title in the markdown link syntax.

Fixes: #1451

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
