### PR TITLE
fix: search dialog stick to bottom of page

### DIFF
--- a/src/components/SearchDialog.vue
+++ b/src/components/SearchDialog.vue
@@ -153,7 +153,7 @@ $button-gap: calc(var(--default-grid-baseline) * 3);
 .search-dialog__container {
 	width: 100%;
 	display: flex;
-	position: sticky;
+	position: absolute;
 	align-items: center;
 	bottom: 0;
 	background-color: var(--color-main-background);


### PR DESCRIPTION
### 📝 Summary

This PR changes the positioning of the search dialog so that it doesn't float up depending on the length of the page content. For pages with very little content, e.g. one word, it would float up; now, it will always stick to the bottom of the page.

#### 🖼️ Screenshots

<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/6c1b75bf-598f-44ec-a29b-59ed229f7028)
</details>

<details>
<summary>After</summary>

![image](https://github.com/user-attachments/assets/dee1caf9-bf1a-432a-a0af-96c082f5d337)
</details>

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
