### PR TITLE
fix(css): Use flexbox to align editor container and search dialog

### DIFF
--- a/src/components/Collective.vue
+++ b/src/components/Collective.vue
@@ -231,6 +231,10 @@ export default {
 	height: 100%;
 }
 
+.page-heading-skeleton {
+	width: 100%;
+}
+
 /* Format page title in Page.vue and Version.vue */
 .page-title {
 	position: sticky;
@@ -240,7 +244,7 @@ export default {
 	display: flex;
 	align-items: center;
 	background-color: var(--color-main-background);
-	height: 48px;
+	min-height: 48px;
 	// Overwrite `h2` defaults
 	margin: 0;
 

--- a/src/components/Page/PageInfoBar.vue
+++ b/src/components/Page/PageInfoBar.vue
@@ -39,7 +39,7 @@ export default {
 .text-menubar {
 	--background-blur: blur(10px);
 	position: sticky;
-	top: 48px;
+	top: 0;
 	z-index: 10021;
 	background-color: var(--color-main-background-translucent);
 	backdrop-filter: var(--background-blur);

--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -180,7 +180,8 @@ export default {
 <style lang="scss" scoped>
 .collectives-text-container {
 	// Required for search dialog to stick to the bottom
-	height: 100%;
+	flex-grow: 1;
+	overflow: scroll;
 }
 
 .text-container-heading {
@@ -189,19 +190,6 @@ export default {
 
 .page-content-skeleton {
 	padding-top: var(--default-clickable-area);
-}
-
-:deep([data-text-el='editor-container']) {
-	/* Remove scrolling mechanism from editor-container, required for menubar stickyness */
-	overflow: visible;
-
-	div.editor {
-		/* Adjust to page titlebar height */
-		div.text-menubar {
-			margin: auto;
-			top: 48px;
-		}
-	}
 }
 
 @media print {

--- a/src/components/SearchDialog.vue
+++ b/src/components/SearchDialog.vue
@@ -153,9 +153,7 @@ $button-gap: calc(var(--default-grid-baseline) * 3);
 .search-dialog__container {
 	width: 100%;
 	display: flex;
-	position: sticky;
 	align-items: center;
-	bottom: 0;
 	background-color: var(--color-main-background);
 }
 

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -10,6 +10,8 @@
 .full-width-view {
 	// Required for search dialog to stick to the bottom
 	height: 100%;
+	display: flex;
+	flex-direction: column;
 
 	--text-editor-max-width: false !important;
 	max-width: unset;
@@ -18,6 +20,8 @@
 .sheet-view {
 	// Required for search dialog to stick to the bottom
 	height: 100%;
+	display: flex;
+	flex-direction: column;
 
 	--text-editor-max-width: 670px !important;
 
@@ -26,7 +30,7 @@
 	.page-heading-skeleton,
 	.page-content-skeleton {
 		max-width: var(--text-editor-max-width);
-		margin: auto;
+		margin-inline: auto;
 	}
 
 	.page-title {


### PR DESCRIPTION
This fixes stickyness of the search dialog to the bottom with long documents.

We have 2 or 3 elements in `app-content-details`: the page title, the editor, and optionally the search dialog. Page title and editor should align to the top, search dialog shall align to the bottom. Scroll container shall be in the editor.

First, the editor didn't take all space, so with a short document, the search dialog didn't align to the bottom. This was tried to fix by e9180858f5545883149e91e90ca76245a33a0958, which had other unwanted side effects. So another attempt was bfb69b3fa1c0556e9e10fa1801fb1fe65dcebd54. But the scroll container was wrong, so the search dialog moved out of the viewport with this approach. Instead of playing around more with `position: sticky` I decided to migrate it to `flexbox` instead.

I tested view and edit mode with sheet and full page width and with short documents and long documents. I also checked the loading skeletons for page header and page content.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
