### PR TITLE
fix(CollectiveStorage): adjust `getOwner` to NC31

### DIFF
--- a/lib/Mount/CollectiveStorage.php
+++ b/lib/Mount/CollectiveStorage.php
@@ -38,9 +38,9 @@ class CollectiveStorage extends Wrapper {
 	/**
 	 * @param string $path
 	 *
-	 * @return false|string
+	 * @return string|false
 	 */
-	public function getOwner($path) {
+	public function getOwner($path): string|false {
 		return $this->mountOwner !== null ? $this->mountOwner->getUID() : false;
 	}
 


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
