### PR TITLE
fix: Allow to mount the collectives user folder into a subfolder

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -53,10 +53,10 @@ class SettingsController extends OCSController {
 		}
 
 		if ($setting === 'user_folder') {
-			// No root folder, has to start with `/`, no subfolder
+			// No root folder, has to start with `/`, not allowed to end with `/`
 			if ($value === '/'
 				|| !(str_starts_with($value, '/'))
-				|| str_contains(substr($value, 1), '/')) {
+				|| str_ends_with($value, '/')) {
 				throw new InvalidArgumentException('Invalid collectives folder path');
 			}
 

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -61,10 +61,15 @@ class MountProvider implements IMountProvider {
 			return $folders;
 		}
 
+		$userFolderSetting = $this->userFolderHelper->getUserFolderSetting($user->getUID());
+		$internalPathPrefix = 'files';
+		$userFolderPath = substr($userFolder->getInternalPath(), 0, strlen($internalPathPrefix)) == $internalPathPrefix
+			? substr($userFolder->getInternalPath(), strlen('files')) . '/'
+			: $userFolder->getName() . '/';
+		$mountPointPath = ($userFolderSetting === '/')
+			? ''
+			: $userFolderPath;
 		foreach ($collectives as $c) {
-			$mountPointPath = ($this->userFolderHelper->getUserFolderSetting($user->getUID()) === '/')
-				? ''
-				: $userFolder->getName() . '/';
 			$mountPointName = $c->getName();
 			try {
 				$cacheEntry = $this->collectiveFolderManager->getFolderFileCache($c->getId(), $mountPointName);

--- a/src/components/Nav/CollectivesGlobalSettings.vue
+++ b/src/components/Nav/CollectivesGlobalSettings.vue
@@ -61,10 +61,10 @@ export default {
 				.build()
 			picker.pick()
 				.then((path) => {
-					// No root folder, has to start with `/`, no subfolder
+					// No root folder, has to start with `/`, not allowed to end with `/`
 					if (path === '/'
 						|| !path.startsWith('/')
-						|| path.includes('/', 1)) {
+						|| path.endsWith('/')) {
 						const error = t('collectives', 'Invalid path selected. Only folders on first level are supported.')
 						showError(error)
 						throw new Error(error)

--- a/tests/Integration/features/mountpoint.feature
+++ b/tests/Integration/features/mountpoint.feature
@@ -17,6 +17,14 @@ Feature: mountpoint
     And user "alice" has webdav access to "BehatMountPoint" with permissions "RMG"
     And user "bob" has webdav access to "BehatMountPoint" with permissions "MG"
 
+  Scenario: Change collectives user folder for user
+    When user "bob" sets setting "user_folder" to value "/some/folder"
+    Then user "jane" has webdav access to "BehatMountPoint" with permissions "RMGDNVCK"
+    And user "john" has webdav access to "BehatMountPoint" with permissions "RMGDNVCK"
+    And user "alice" has webdav access to "BehatMountPoint" with permissions "RMG"
+    And user "bob" has webdav access to "BehatMountPoint" with permissions "MG"
+    Then user "bob" sets setting "user_folder" to value "/Collectives"
+
   Scenario: Trash page via webdav
     When user "bob" fails to trash page "firstpage" via webdav in "BehatMountPoint"
     And user "jane" trashes page "firstpage" via webdav in "BehatMountPoint"

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -60,8 +60,8 @@ class SettingsControllerTest extends TestCase {
 	public function testSetUserSettingsNoSlashStart(): void {
 		$response = new DataResponse('Invalid collectives folder path', Http::STATUS_BAD_REQUEST);
 		self::assertEquals($response, $this->settingsController->setUserSetting('user_folder', 'test'));
-		self::assertEquals($response, $this->settingsController->setUserSetting('user_folder', '/test/'));
 		self::assertEquals($response, $this->settingsController->setUserSetting('user_folder', 'test/'));
+		self::assertEquals($response, $this->settingsController->setUserSetting('user_folder', 'test/abc'));
 	}
 
 	public function testSetUserSettingsRootFolder(): void {
@@ -69,13 +69,19 @@ class SettingsControllerTest extends TestCase {
 		self::assertEquals($response, $this->settingsController->setUserSetting('user_folder', '/'));
 	}
 
-	public function testSetUserSettingsMultipleSlashes(): void {
+	public function testSetUserSettingsSlashEnd(): void {
 		$response = new DataResponse('Invalid collectives folder path', Http::STATUS_BAD_REQUEST);
 		self::assertEquals($response, $this->settingsController->setUserSetting('user_folder', '/test/'));
+		self::assertEquals($response, $this->settingsController->setUserSetting('user_folder', '/test/abc/'));
 	}
 
 	public function testSetUserSettings(): void {
 		$response = new DataResponse('/test', Http::STATUS_OK);
 		self::assertEquals($response, $this->settingsController->setUserSetting('user_folder', '/test'));
+	}
+
+	public function testSetUserSettingsSubfolder(): void {
+		$response = new DataResponse('/test/abc', Http::STATUS_OK);
+		self::assertEquals($response, $this->settingsController->setUserSetting('user_folder', '/test/abc'));
 	}
 }


### PR DESCRIPTION
Fixes: #514

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
