### PR TITLE
fix(Makefile): evaluate composer prerequisits during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ all: setup-dev lint build test
 setup-dev: composer-install node-modules
 
 # Install build tools
-composer:
-ifeq (, $(wildcard $(BUILD_TOOLS_DIR)/composer.phar))
+composer: $(BUILD_TOOLS_DIR)/composer.phar
+
+$(BUILD_TOOLS_DIR)/composer.phar:
 	mkdir -p $(BUILD_TOOLS_DIR)
 	cd $(BUILD_TOOLS_DIR) && curl -sS https://getcomposer.org/installer | php
-endif
 
 $(BUILD_TOOLS_DIR)/info.xsd:
 	mkdir -p $(BUILD_TOOLS_DIR)


### PR DESCRIPTION
### 📝 Summary

`ifeq (, $(wildcard $(BUILD_TOOLS_DIR)/composer.phar))`
is evaluated before any targets are build.
Therefore the file still exists.
It is only removed later when the `dist-clean` target is build.

Use a file prerequisit instead.
This is evaluated when the target is build.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/user-attachments/assets/c6eeaddd-ee35-41d5-b649-4ee46ef25614) | ![grafik](https://github.com/user-attachments/assets/ae40e031-b263-4361-bda2-5063fdaef657)



### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation is not required
