### PR TITLE
chore(build): Exclude rector.php when building the release tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ build: node-modules build-js-production composer-install-no-dev
 		--exclude="$(APP_NAME)/package-lock.json" \
 		--exclude="$(APP_NAME)/package.json" \
 		--exclude="$(APP_NAME)/psalm.xml" \
+		--exclude="$(APP_NAME)/rector.php" \
 		--exclude="$(APP_NAME)/renovate.json" \
 		--exclude="$(APP_NAME)/src" \
 		--exclude="$(APP_NAME)/stylelint.config.js" \


### PR DESCRIPTION
Fixes: #1541

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
