### PR TITLE
fix(share): Add owner sharing permission for folder of public share

### DIFF
--- a/lib/Db/Collective.php
+++ b/lib/Db/Collective.php
@@ -211,9 +211,10 @@ class Collective extends Entity implements JsonSerializable {
 	}
 
 	public function getUserPermissions(bool $isShare = false): int {
-		// Public shares always get permissions of a simple member
+		// Public shares always get permissions of a simple member plus sharing permission of owner
 		if ($isShare) {
-			return $this->getMemberPermissions();
+			$sharePermissions = $this->canShare() ? Constants::PERMISSION_SHARE : 0;
+			return $this->getMemberPermissions() | $sharePermissions;
 		}
 
 		if ($this->level === Member::LEVEL_OWNER || $this->level === Member::LEVEL_ADMIN) {


### PR DESCRIPTION
Fixes: #1530

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
