### PR TITLE
fix: Alignment of landing page widgets

### DIFF
--- a/src/components/Page/LandingPageWidgets.vue
+++ b/src/components/Page/LandingPageWidgets.vue
@@ -61,7 +61,7 @@ export default {
 
 <style scoped>
 .landing-page-widgets {
-	padding-inline: 12px;
+	padding-inline: 14px 8px;
 }
 .first-row-widgets{
 	display: flex;

--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -185,11 +185,11 @@ export default {
 }
 
 .text-container-heading {
-	padding-left: 14px;
+	padding-inline: 14px 8px;
 }
 
 .page-content-skeleton {
-	padding-top: var(--default-clickable-area);
+	padding-block-start: var(--default-clickable-area);
 }
 
 @media print {

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -32,9 +32,14 @@
 	--text-editor-max-width: 670px !important;
 
 	.landing-page-widgets,
-	.text-container-heading,
 	.page-heading-skeleton,
 	.page-content-skeleton {
+		width: var(--text-editor-max-width);
+		max-width: var(--text-editor-max-width);
+		margin-inline: auto;
+	}
+
+	.text-container-heading {
 		max-width: var(--text-editor-max-width);
 		margin-inline: auto;
 	}


### PR DESCRIPTION
#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/28428c2f-c35a-4088-9a17-f067ff186954) | ![image](https://github.com/user-attachments/assets/10fcab31-29a9-451c-ad57-8d97461064dd)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
