### PR TITLE
perf(dashboard): Use storage id for more performant index usage on dashboard query

### DIFF
--- a/tests/Unit/Service/RecentPagesServiceTest.php
+++ b/tests/Unit/Service/RecentPagesServiceTest.php
@@ -13,6 +13,7 @@ use OCA\Collectives\Service\CollectiveService;
 use OCA\Collectives\Service\NotFoundException;
 use OCA\Collectives\Service\RecentPagesService;
 use OCP\Files\IMimeTypeLoader;
+use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
@@ -32,6 +33,7 @@ class RecentPagesServiceTest extends TestCase {
 		$mimeTypeLoader = $this->createMock(IMimeTypeLoader::class);
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 		$l10n = $this->createMock(IL10N::class);
+		$rootFolder = $this->createMock(IRootFolder::class);
 
 		$this->service = new RecentPagesService(
 			$this->collectiveService,
@@ -39,7 +41,9 @@ class RecentPagesServiceTest extends TestCase {
 			$config,
 			$mimeTypeLoader,
 			$urlGenerator,
-			$l10n);
+			$l10n,
+			$rootFolder
+		);
 
 		$this->user = $this->createMock(IUser::class);
 		$this->user->method('getUID')->willReturn('user');


### PR DESCRIPTION
Signed-off-by: Julius Knorr <jus@bitgrid.net>

### 📝 Summary

Fix #1538 

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
