### PR TITLE
fix(editor): Restore accidently removed editor API `onLinkClick` callback

### DIFF
--- a/src/mixins/editorMixin.js
+++ b/src/mixins/editorMixin.js
@@ -118,6 +118,10 @@ export default {
 						currentPage: this.pageInfoBarPage || this.pageToUse,
 					},
 				},
+				// Required for link handling on Nextcloud 27+28
+				onLinkClick: (_event, attrs) => {
+					this.followLink(_event, attrs)
+				},
 				onOutlineToggle: (visible) => {
 					this.toggleOutlineFromEditor(visible)
 				},


### PR DESCRIPTION
This is still required for link handling in Nextcloud 27 and 28.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
