### PR TITLE
Further CSS fixes

### DIFF
--- a/src/components/Page.vue
+++ b/src/components/Page.vue
@@ -103,8 +103,10 @@
 					:is-template="isTemplatePage" />
 			</div>
 		</h2>
-		<LandingPageWidgets v-if="isLandingPage" />
-		<TextEditor :key="`text-editor-${currentPage.id}`" ref="texteditor" />
+		<div class="page-scroll-container">
+			<LandingPageWidgets v-if="isLandingPage" />
+			<TextEditor :key="`text-editor-${currentPage.id}`" ref="texteditor" />
+		</div>
 		<SearchDialog :show="shouldShowSearchDialog" />
 	</div>
 </template>
@@ -336,6 +338,11 @@ export default {
 // TODO: remove when we stop supporting NC < 30
 .page-title.pre-nc30 {
 	padding-top: 11px;
+}
+
+.page-scroll-container {
+	overflow-y: auto;
+	flex-grow: 1;
 }
 
 .titlebar-buttons {

--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -198,9 +198,9 @@ export default {
 
 <style lang="scss" scoped>
 .collectives-text-container {
-	// Required for search dialog to stick to the bottom
-	flex-grow: 1;
-	overflow: auto;
+	// Give editor some minimum scroll height on empty/short content
+	// Important on landing page when landing page widgets cover full height
+	min-height: 50vh;
 }
 
 .text-container-heading {

--- a/src/components/SearchDialog.vue
+++ b/src/components/SearchDialog.vue
@@ -170,6 +170,7 @@ $button-gap: calc(var(--default-grid-baseline) * 3);
 
 .search-dialog__buttons {
 	display: flex;
+	overflow: hidden;
 	align-items: center;
 	column-gap: $button-gap;
 }

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -34,13 +34,13 @@
 	.landing-page-widgets,
 	.page-heading-skeleton,
 	.page-content-skeleton {
-		width: var(--text-editor-max-width);
-		max-width: var(--text-editor-max-width);
+		width: min(var(--text-editor-max-width), 100%);
+		max-width: min(var(--text-editor-max-width), 100%);
 		margin-inline: auto;
 	}
 
 	.text-container-heading {
-		max-width: var(--text-editor-max-width);
+		max-width: min(var(--text-editor-max-width), 100%);
 		margin-inline: auto;
 	}
 
@@ -51,7 +51,7 @@
 
 	// Editor document status bar
 	.document-status {
-		max-width: var(--text-editor-max-width);
+		max-width: min(var(--text-editor-max-width), 100%);
 		padding: 0 2px;
 		margin: auto;
 	}
@@ -59,11 +59,11 @@
 	[data-collectives-el='editor'],
 	[data-collectives-el='reader'] {
 		max-width: unset;
-		min-width: var(--text-editor-max-width);
+		width: min(var(--text-editor-max-width), 100%);
 		margin: auto;
 
 		.text-menubar {
-			max-width: var(--text-editor-max-width);
+			max-width: min(var(--text-editor-max-width), 100%);
 			margin: auto;
 		}
 	}
@@ -85,6 +85,6 @@
 	.page-title, .document-status, .editor__content {
 		margin: unset !important;
 		max-width: unset !important;
-		min-width: var(--text-editor-max-width);
+		width: var(--text-editor-max-width);
 	}
 }


### PR DESCRIPTION
### 📝 Summary

* Resolves: #1577
* Resolves: #1578

Tested:
* [x] Scrolling with long content on landing page with large desktop screen with/without search bar
* [x] Scrolling with short content on landing page with large desktop screen with/without search bar
* [x] Scrolling with long content on landing page with small mobile screen with/without search bar
* [x] Scrolling with short content on landing page with small mobile screen with/without search bar

```
fix(css): New scroll container to fix page design

* Page title always sticky at the top
* Landing page widgets (optional) and page content in scroll container
* Search bar (if visible) always sticky at bottom

Also give the editor some minimum scroll height so that it's possible to
scroll down when the landing page widgets cover full page height (e.g.
on small mobile screens) and the page has no/short content.
```

```
fix(css): Fix maximum editor/page width on mobile
Maximum width should be the smaller value of either text editor width or
screen width.
```

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
