### PR TITLE
fix(circles): Use `probeCircles()` instead of `getCircles()`

### DIFF
--- a/lib/Service/CollectiveHelper.php
+++ b/lib/Service/CollectiveHelper.php
@@ -28,7 +28,7 @@ class CollectiveHelper {
 	 */
 	public function getCollectivesForUser(string $userId, bool $getLevel = true, bool $getUserSettings = true): array {
 		$circles = $this->circleHelper->getCircles($userId);
-		$cids = array_map(fn ($circle) => $circle->getSingleId(), $circles);
+		$cids = array_map(static fn ($circle) => $circle->getSingleId(), $circles);
 		$circles = array_combine($cids, $circles);
 		/** @var Collective[] $collectives */
 		$collectives = $this->collectiveMapper->findByCircleIds($cids);
@@ -55,13 +55,14 @@ class CollectiveHelper {
 	 */
 	public function getCollectivesTrashForUser(string $userId): array {
 		$circles = $this->circleHelper->getCircles($userId);
-		$cids = array_map(fn ($circle) => $circle->getSingleId(), $circles);
+		$cids = array_map(static fn ($circle) => $circle->getSingleId(), $circles);
 		$circles = array_combine($cids, $circles);
 		$collectives = $this->collectiveMapper->findTrashByCircleIdsAndUser($cids, $userId);
 		foreach ($collectives as $c) {
 			$cid = $c->getCircleId();
-			$c->setName($circles[$cid]->getSanitizedName());
-			$c->setLevel($this->circleHelper->getLevel($cid, $userId));
+			$circle = $circles[$cid];
+			$c->setName($circle->getSanitizedName());
+			$c->setLevel($circle->getInitiator()->getLevel());
 		}
 		return $collectives;
 	}

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -651,6 +651,10 @@ namespace OCA\Circles\Model\Probes {
 	class CircleProbe {
 		public function mustBeMember(bool $must = true): self {}
 	}
+	class DataProbe {
+        public const INITIATOR = 'h';
+		public function add(string $key, array $path = []): self {}
+	}
 }
 
 namespace OCA\Circles\Events {
@@ -689,16 +693,18 @@ namespace OCA\Circles {
     use OCA\Circles\Model\Circle;
     use OCA\Circles\Model\FederatedUser;
     use OCA\Circles\Model\Probes\CircleProbe;
+    use OCA\Circles\Model\Probes\DataProbe;
     class CirclesManager {
-        public function startSuperSession(): void {}
-        public function startSession(?FederatedUser $federatedUser = null): void {}
-        public function getCircles(?CircleProbe $probe = null): array {}
-        public function getCircle(string $singleId, ?CircleProbe $probe = null): Circle {}
-        public function flagAsAppManaged(string $circleId, bool $enabled = true): void {}
         public function getFederatedUser(string $federatedId, int $type = Member::TYPE_SINGLE): FederatedUser {}
+        public function startSession(?FederatedUser $federatedUser = null): void {}
+        public function startSuperSession(): void {}
         public function stopSession(): void {}
 		public function createCircle(string $name, ?FederatedUser $owner = null, bool $personal = false, bool $local = false): Circle {}
         public function destroyCircle(string $singleId): void {}
+        public function getCircles(?CircleProbe $probe = null): array {}
+        public function getCircle(string $singleId, ?CircleProbe $probe = null): Circle {}
+        public function flagAsAppManaged(string $circleId, bool $enabled = true): void {}
+        public function probeCircles(?CircleProbe $circleProbe = null, ?DataProbe $dataProbe = null): array {}
     }
 }
 


### PR DESCRIPTION
`probeCircles()` is lighter and more performant.

Fixes: #498

Requires https://github.com/nextcloud/circles/pull/1758

### Todo

* [x] Wait until nextcloud/circles#1758 got published with upcoming server releases
* [x] Make usage of `probeCircles()` conditional and use only with Nextcloud >= 30.0.3, 29.0.10, 28.0.13

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
