### PR TITLE
Revert "test(cypress): Fix flaky template test by disabling a check"

### DIFF
--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -100,8 +100,7 @@ describe('Pages', function() {
 			cy.wait(['@createPage', '@textCreateSession'])
 
 			cy.getEditor()
-				// TODO: Figure out why page doesn't load in edit mode in CI and enable next line
-				// .should('be.visible')
+				.should('be.visible')
 				.contains('This is going to be our template.')
 
 			cy.intercept('PUT', '**/_api/*/_pages/*').as('renamePage')


### PR DESCRIPTION
This reverts commit de20a9fb94331dce234102faec1cb904bbdd667e.

### 🚧 TODO

- [ ] Find out why in Cypress new pages don't open in edit mode when created from a template. Manually tests work as expected, but in CI this fails in the majority of test runs. I suspect a race condition that only happens because Cypress is faster than a human.

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
