### PR TITLE
feat: Implement a custom notification message for mentions

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -91,6 +91,14 @@ jobs:
           path: apps/files_pdfviewer
           ref: ${{ matrix.server-versions }}
 
+      - name: Checkout notifications app
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          repository: nextcloud/notifications
+          path: apps/notifications
+          ref: ${{ matrix.server-versions }}
+
       - name: Checkout password_policy app
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -218,6 +226,7 @@ jobs:
           ./occ config:system:set --value="http://localhost:8081" -- overwrite.cli.url
           ./occ app:enable --force contacts
           ./occ app:enable --force files_pdfviewer
+          ./occ app:enable --force notifications
           ./occ app:disable password_policy
           ./occ app:enable --force ${{ env.APP_NAME }}
 

--- a/cypress/e2e/page-mentions.spec.js
+++ b/cypress/e2e/page-mentions.spec.js
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+describe('Page mentions', function() {
+	if (!['stable29', 'stable30'].includes(Cypress.env('ncVersion'))) {
+		before(function() {
+			cy.loginAs('bob')
+			cy.deleteAndSeedCollective('Mention Collective')
+				.seedPage('Page 1', '', 'Readme.md')
+			cy.circleFind('Mention Collective')
+				.circleAddMember('alice')
+
+			cy.visit('/apps/collectives/Mention Collective/Page 1')
+			cy.getEditorContent(true)
+				.type('Bob mentions @alice')
+			cy.get('.tippy-content')
+				.contains('alice')
+				.click()
+			cy.getEditor()
+				.find('.save-status')
+				.click()
+		})
+
+		describe('Mentioning another member in a page', function() {
+			it('Notification is shown to mentioned member', function() {
+				cy.loginAs('alice')
+				cy.visit('/apps/collectives/Mention Collective')
+				cy.get('.notifications-button')
+					.click()
+
+				cy.get('#header-menu-notifications')
+					.find('.notification .rich-text--wrapper')
+					.invoke('text')
+					.should('match', /bob \s*has mentioned you in .*Mention Collective - .*Page 1/)
+			})
+		})
+	}
+})

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -20,6 +20,7 @@ use OCA\Collectives\Listeners\BeforeTemplateRenderedListener;
 use OCA\Collectives\Listeners\CircleDestroyedListener;
 use OCA\Collectives\Listeners\CollectivesReferenceListener;
 use OCA\Collectives\Listeners\ShareDeletedListener;
+use OCA\Collectives\Listeners\TextMentionListener;
 use OCA\Collectives\Mount\CollectiveFolderManager;
 use OCA\Collectives\Mount\MountProvider;
 use OCA\Collectives\Reference\SearchablePageReferenceProvider;
@@ -35,6 +36,7 @@ use OCA\Collectives\Trash\PageTrashBackend;
 use OCA\Collectives\Trash\PageTrashManager;
 use OCA\Collectives\Versions\VersionsBackend;
 use OCA\Files_Versions\Versions\IVersionBackend;
+use OCA\Text\Event\MentionEvent;
 use OCP\App\IAppManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -66,6 +68,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(CircleDestroyedEvent::class, CircleDestroyedListener::class);
 		$context->registerEventListener(ShareDeletedEvent::class, ShareDeletedListener::class);
 		$context->registerEventListener(RenderReferenceEvent::class, CollectivesReferenceListener::class);
+		$context->registerEventListener(MentionEvent::class, TextMentionListener::class);
 
 		$context->registerService(MountProvider::class, fn (ContainerInterface $c) => new MountProvider(
 			$c->get(CollectiveHelper::class),

--- a/lib/Listeners/TextMentionListener.php
+++ b/lib/Listeners/TextMentionListener.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Collectives\Listeners;
 
+use OCA\Collectives\Model\PageInfo;
 use OCA\Collectives\Mount\CollectiveMountPoint;
 use OCA\Collectives\Service\CollectiveService;
 use OCA\Collectives\Service\PageService;
@@ -42,7 +43,17 @@ class TextMentionListener implements IEventListener {
 		$pageInfo = $this->pageService->findByFile($mountPoint->getFolderId(), $event->getFile(), $this->userId);
 
 		$collectiveLink = $this->urlGenerator->linkToRouteAbsolute('collectives.start.index') . rawurlencode($collective->getName());
+		$collectiveName = $collective->getEmoji()
+			? $collective->getEmoji() . ' ' . $collective->getName()
+			: $collective->getName();
+
 		$pageLink = $this->urlGenerator->linkToRouteAbsolute('collectives.start.index') . $this->pageService->getPageLink($collective->getName(), $pageInfo);
+		$pageTitle = $pageInfo->getTitle() === PageInfo::INDEX_PAGE_TITLE
+			? $this->l10n->t('Landing page')
+			: $pageInfo->getTitle();
+		$pageName = $pageInfo->getEmoji()
+			? $pageInfo->getEmoji() . ' ' . $pageTitle
+			: $pageTitle;
 
 		$notification = $event->getNotification();
 		$notification->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('collectives', 'collectives-dark.svg')));
@@ -52,13 +63,13 @@ class TextMentionListener implements IEventListener {
 			'collective' => [
 				'id' => (string)$collective->getId(),
 				'type' => 'highlight',
-				'name' => $collective->getEmoji() . ' ' . $collective->getName(),
+				'name' => $collectiveName,
 				'link' => $collectiveLink,
 			],
 			'page' => [
 				'id' => (string)$pageInfo->getId(),
 				'type' => 'highlight',
-				'name' => $pageInfo->getEmoji() . ' ' . $pageInfo->getTitle(),
+				'name' => $pageName,
 				'link' => $pageLink,
 			],
 		]);

--- a/lib/Listeners/TextMentionListener.php
+++ b/lib/Listeners/TextMentionListener.php
@@ -19,6 +19,7 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
+/** @template-implements IEventListener<Event|MentionEvent> */
 class TextMentionListener implements IEventListener {
 	public function __construct(
 		private IL10N $l10n,
@@ -58,20 +59,22 @@ class TextMentionListener implements IEventListener {
 		$notification = $event->getNotification();
 		$notification->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('collectives', 'collectives-dark.svg')));
 		$notification->setLink($pageLink);
-		$notification->setRichSubject($this->l10n->t('{user} has mentioned you in {collective} - {page}'), [
-			...$notification->getRichSubjectParameters(),
-			'collective' => [
-				'id' => (string)$collective->getId(),
-				'type' => 'highlight',
-				'name' => $collectiveName,
-				'link' => $collectiveLink,
+		$notification->setRichSubject($this->l10n->t('{user} has mentioned you in {collective} - {page}'), array_merge(
+			$notification->getRichSubjectParameters(),
+			[
+				'collective' => [
+					'id' => (string)$collective->getId(),
+					'type' => 'highlight',
+					'name' => $collectiveName,
+					'link' => $collectiveLink,
+				],
+				'page' => [
+					'id' => (string)$pageInfo->getId(),
+					'type' => 'highlight',
+					'name' => $pageName,
+					'link' => $pageLink,
+				],
 			],
-			'page' => [
-				'id' => (string)$pageInfo->getId(),
-				'type' => 'highlight',
-				'name' => $pageName,
-				'link' => $pageLink,
-			],
-		]);
+		));
 	}
 }

--- a/lib/Listeners/TextMentionListener.php
+++ b/lib/Listeners/TextMentionListener.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Listeners;
+
+use OCA\Collectives\Mount\CollectiveMountPoint;
+use OCA\Collectives\Service\CollectiveService;
+use OCA\Collectives\Service\PageService;
+use OCA\Text\Event\MentionEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+
+class TextMentionListener implements IEventListener {
+	public function __construct(
+		private IL10N $l10n,
+		private IURLGenerator $urlGenerator,
+		private CollectiveService $collectiveService,
+		private PageService $pageService,
+		private ?string $userId,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof MentionEvent) {
+			return;
+		}
+
+		$mountPoint = $event->getFile()->getMountPoint();
+		if (!$mountPoint instanceof CollectiveMountPoint) {
+			return;
+		}
+
+		$collective = $this->collectiveService->getCollective($mountPoint->getFolderId(), $this->userId);
+		$pageInfo = $this->pageService->findByFile($mountPoint->getFolderId(), $event->getFile(), $this->userId);
+
+		$collectiveLink = $this->urlGenerator->linkToRouteAbsolute('collectives.start.index') . rawurlencode($collective->getName());
+		$pageLink = $this->urlGenerator->linkToRouteAbsolute('collectives.start.index') . $this->pageService->getPageLink($collective->getName(), $pageInfo);
+
+		$notification = $event->getNotification();
+		$notification->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('collectives', 'collectives-dark.svg')));
+		$notification->setLink($pageLink);
+		$notification->setRichSubject($this->l10n->t('{user} has mentioned you in {collective} - {page}'), [
+			...$notification->getRichSubjectParameters(),
+			'collective' => [
+				'id' => (string)$collective->getId(),
+				'type' => 'highlight',
+				'name' => $collective->getEmoji() . ' ' . $collective->getName(),
+				'link' => $collectiveLink,
+			],
+			'page' => [
+				'id' => (string)$pageInfo->getId(),
+				'type' => 'highlight',
+				'name' => $pageInfo->getEmoji() . ' ' . $pageInfo->getTitle(),
+				'link' => $pageLink,
+			],
+		]);
+	}
+}

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -8,36 +8,36 @@ declare(strict_types=1);
  */
 
 namespace {
-    use OCP\IServerContainer;
+	use OCP\IServerContainer;
 
-    class OC {
-        static $CLI = false;
-        /** @var string */
-        static $WEBROOT;
-        /** @var IServerContainer */
-        static $server;
-    }
+	class OC {
+	    static $CLI = false;
+	    /** @var string */
+	    static $WEBROOT;
+	    /** @var IServerContainer */
+	    static $server;
+	}
 }
 
 namespace OC\Files\Node {
-    use OCP\Files\FileInfo;
-    abstract class Node implements \OCP\Files\Node {
+	use OCP\Files\FileInfo;
+	abstract class Node implements \OCP\Files\Node {
 		/** @return FileInfo|\ArrayAccess */
 		public function getFileInfo() {}
 
-        /** @return \OCP\Files\Mount\IMountPoint */
-        public function getMountPoint() {}
-    }
+	    /** @return \OCP\Files\Mount\IMountPoint */
+	    public function getMountPoint() {}
+	}
 }
 
 namespace OC\Hooks {
-    class Emitter {
-        public function emit(string $class, string $value, array $option) {}
-        /** Closure $closure */
-        public function listen(string $class, string $value, $closure) {}
-    }
-    class BasicEmitter extends Emitter {
-    }
+	class Emitter {
+	    public function emit(string $class, string $value, array $option) {}
+	    /** Closure $closure */
+	    public function listen(string $class, string $value, $closure) {}
+	}
+	class BasicEmitter extends Emitter {
+	}
 }
 
 namespace OC\Cache {
@@ -57,25 +57,25 @@ namespace OC\Cache {
 }
 
 namespace OC\Core\Command {
-    use Symfony\Component\Console\Input\InputInterface;
-    use Symfony\Component\Console\Output\OutputInterface;
-    class Base {
-        public const OUTPUT_FORMAT_PLAIN = 'plain';
-        public const OUTPUT_FORMAT_JSON = 'json';
-        public const OUTPUT_FORMAT_JSON_PRETTY = 'json_pretty';
+	use Symfony\Component\Console\Input\InputInterface;
+	use Symfony\Component\Console\Output\OutputInterface;
+	class Base {
+	    public const OUTPUT_FORMAT_PLAIN = 'plain';
+	    public const OUTPUT_FORMAT_JSON = 'json';
+	    public const OUTPUT_FORMAT_JSON_PRETTY = 'json_pretty';
 
-        public function __construct() {}
-        protected function configure() {}
-        public function run(InputInterface $input, OutputInterface $output) {}
-        public function setName(string $name) {}
-        public function getHelper(string $name) {}
-        protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, $items, $prefix = '  - ') {
-        }
-    }
+	    public function __construct() {}
+	    protected function configure() {}
+	    public function run(InputInterface $input, OutputInterface $output) {}
+	    public function setName(string $name) {}
+	    public function getHelper(string $name) {}
+	    protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, $items, $prefix = '  - ') {
+	    }
+	}
 }
 
 namespace OC\Files\ObjectStore {
-    class NoopScanner {}
+	class NoopScanner {}
 }
 
 namespace Symfony\Component\Console\Helper {
@@ -113,118 +113,118 @@ namespace Symfony\Component\Console\Question {
 }
 
 namespace Symfony\Component\Console\Output {
-    class OutputInterface {
-        public const VERBOSITY_VERBOSE = 1;
-        public function writeln(string $text, int $flat = 0) {}
-        public function write($messages, $newline = false, $options = 0) {}
-    }
+	class OutputInterface {
+	    public const VERBOSITY_VERBOSE = 1;
+	    public function writeln(string $text, int $flat = 0) {}
+	    public function write($messages, $newline = false, $options = 0) {}
+	}
 }
 
 namespace Symfony\Component\EventDispatcher {
-    class EventDispatcherInterface {}
+	class EventDispatcherInterface {}
 }
 
 namespace OC\Collaboration\Reference {
-    use OCP\Collaboration\Reference\IReferenceManager;
+	use OCP\Collaboration\Reference\IReferenceManager;
 
-    class LinkReferenceProvider {
-        public function resolveReference(string $referenceText) {}
-    }
+	class LinkReferenceProvider {
+	    public function resolveReference(string $referenceText) {}
+	}
 
-    class ReferenceManager implements IReferenceManager {
-        public function invalidateCache(string $cachePrefix, ?string $cacheKey = null): void;
-    }
+	class ReferenceManager implements IReferenceManager {
+	    public function invalidateCache(string $cachePrefix, ?string $cacheKey = null): void;
+	}
 }
 
 namespace OC\Files\Cache {
-    use OCP\Files\Cache\ICache;
-    use OCP\Files\Cache\ICacheEntry;
-    use OCP\Files\Search\ISearchQuery;
+	use OCP\Files\Cache\ICache;
+	use OCP\Files\Cache\ICacheEntry;
+	use OCP\Files\Search\ISearchQuery;
 	use OCP\Files\Search\ISearchOperator;
 	use OCP\Files\Search\ISearchQuery;
-    use OCP\Files\IMimeTypeLoader;
+	use OCP\Files\IMimeTypeLoader;
 
-    class Cache implements ICache {
-        /**
-         * @param \OCP\Files\Cache\ICache $cache
-         */
-        public function __construct($cache) {
-            $this->cache = $cache;
-        }
-        public function getNumericStorageId() { }
-        public function get() { }
-        public function getIncomplete() {}
-        public function getPathById($id) {}
-        public function getAll() {}
-        public function get($file) {}
-        public function getFolderContents($folder) {}
-        public function getFolderContentsById($fileId) {}
-        public function put($file, array $data) {}
-        public function insert($file, array $data) {}
-        public function update($id, array $data) {}
-        public function getId($file) {}
-        public function getParentId($file) {}
-        public function inCache($file) {}
-        public function remove($file) {}
-        public function move($source, $target) {}
-        public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath) {}
-        public function clear() {}
-        public function getStatus($file) {}
-        public function search($pattern) {}
-        public function searchByMime($mimetype) {}
-        public function searchQuery(ISearchQuery $query) {}
-        public function correctFolderSize($path, $data = null, $isBackgroundScan = false) {}
-        public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int {}
-        public function normalize($path) {}
-        public function getQueryFilterForStorage(): ISearchOperator {}
-        public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry {}
-        public static function cacheEntryFromData($data, IMimeTypeLoader $mimetypeLoader): ICacheEntry {}
-    }
+	class Cache implements ICache {
+	    /**
+	     * @param \OCP\Files\Cache\ICache $cache
+	     */
+	    public function __construct($cache) {
+	        $this->cache = $cache;
+	    }
+	    public function getNumericStorageId() { }
+	    public function get() { }
+	    public function getIncomplete() {}
+	    public function getPathById($id) {}
+	    public function getAll() {}
+	    public function get($file) {}
+	    public function getFolderContents($folder) {}
+	    public function getFolderContentsById($fileId) {}
+	    public function put($file, array $data) {}
+	    public function insert($file, array $data) {}
+	    public function update($id, array $data) {}
+	    public function getId($file) {}
+	    public function getParentId($file) {}
+	    public function inCache($file) {}
+	    public function remove($file) {}
+	    public function move($source, $target) {}
+	    public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath) {}
+	    public function clear() {}
+	    public function getStatus($file) {}
+	    public function search($pattern) {}
+	    public function searchByMime($mimetype) {}
+	    public function searchQuery(ISearchQuery $query) {}
+	    public function correctFolderSize($path, $data = null, $isBackgroundScan = false) {}
+	    public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int {}
+	    public function normalize($path) {}
+	    public function getQueryFilterForStorage(): ISearchOperator {}
+	    public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry {}
+	    public static function cacheEntryFromData($data, IMimeTypeLoader $mimetypeLoader): ICacheEntry {}
+	}
 }
 
 namespace OC\Files\Cache\Wrapper {
-    use OC\Files\Cache\Cache;
-    class CacheWrapper extends Cache {}
+	use OC\Files\Cache\Cache;
+	class CacheWrapper extends Cache {}
 }
 
 namespace OC\Files {
-    use OCP\Files\Cache\ICacheEntry;
-    use OCP\Files\Mount\IMountPoint;
-    use OCP\IUser;
+	use OCP\Files\Cache\ICacheEntry;
+	use OCP\Files\Mount\IMountPoint;
+	use OCP\IUser;
 
-    class Filesystem {
-        public static function addStorageWrapper(string $wrapperName, callable $wrapper, int $priority = 50) {
-        }
-    }
+	class Filesystem {
+	    public static function addStorageWrapper(string $wrapperName, callable $wrapper, int $priority = 50) {
+	    }
+	}
 
-    class FileInfo implements \OCP\Files\FileInfo {
-        /**
-         * @param string|boolean $path
-         * @param \OCP\Files\Storage\IStorage $storage
-         * @param string $internalPath
-         * @param array|ICacheEntry $data
-         * @param \OCP\Files\Mount\IMountPoint $mount
-         * @param \OCP\IUser|null $owner
-         */
-        public function __construct($path, $storage, $internalPath, $data, $mount, $owner = null) {}
-    }
-    class View {
-        public function __construct(string $path) {}
-        public function unlink($path) {}
+	class FileInfo implements \OCP\Files\FileInfo {
+	    /**
+	     * @param string|boolean $path
+	     * @param \OCP\Files\Storage\IStorage $storage
+	     * @param string $internalPath
+	     * @param array|ICacheEntry $data
+	     * @param \OCP\Files\Mount\IMountPoint $mount
+	     * @param \OCP\IUser|null $owner
+	     */
+	    public function __construct($path, $storage, $internalPath, $data, $mount, $owner = null) {}
+	}
+	class View {
+	    public function __construct(string $path) {}
+	    public function unlink($path) {}
 		public function is_dir($path): bool {}
 		public function mkdir($path) {}
 		public function getRoot(): string {}
 		public function getOwner(string $path): string {}
-    }
+	}
 }
 
 namespace OC\User {
-    use OCP\EventDispatcher\IEventDispatcher;
-    use OCP\IUser;
-    use OCP\UserInterface;
-    class User implements IUser {
-        public function __construct(string $uid, ?UserInterface $backend, IEventDispatcher $dispatcher, $emitter = null, IConfig $config = null, $urlGenerator = null) {}
-    }
+	use OCP\EventDispatcher\IEventDispatcher;
+	use OCP\IUser;
+	use OCP\UserInterface;
+	class User implements IUser {
+	    public function __construct(string $uid, ?UserInterface $backend, IEventDispatcher $dispatcher, $emitter = null, IConfig $config = null, $urlGenerator = null) {}
+	}
 }
 
 namespace OCA\DAV\Upload {
@@ -247,369 +247,369 @@ namespace OCA\DAV\Connector\Sabre {
 
 namespace OC\BackgroundJob {
 
-    use OCP\BackgroundJob\IJob;
-    use OCP\BackgroundJob\IJobList;
-    use OCP\ILogger;
+	use OCP\BackgroundJob\IJob;
+	use OCP\BackgroundJob\IJobList;
+	use OCP\ILogger;
 
-    abstract class TimedJob implements IJob {
-        public function execute(IJobList $jobList, ILogger $logger = null) {
-        }
+	abstract class TimedJob implements IJob {
+	    public function execute(IJobList $jobList, ILogger $logger = null) {
+	    }
 
-        abstract protected function run($argument);
+	    abstract protected function run($argument);
 
-        public function setId(int $id) {
-        }
+	    public function setId(int $id) {
+	    }
 
-        public function setLastRun(int $lastRun) {
-        }
+	    public function setLastRun(int $lastRun) {
+	    }
 
-        public function setArgument($argument) {
-        }
+	    public function setArgument($argument) {
+	    }
 
-        public function getId() {
-        }
+	    public function getId() {
+	    }
 
-        public function getLastRun() {
-        }
+	    public function getLastRun() {
+	    }
 
-        public function getArgument() {
-        }
-    }
+	    public function getArgument() {
+	    }
+	}
 }
 
 namespace OC\Files\Mount {
-    use OC\Files\Filesystem;
-    use OC\Files\Storage\Storage;
-    use OC\Files\Storage\StorageFactory;
-    use OCP\Files\Mount\IMountPoint;
+	use OC\Files\Filesystem;
+	use OC\Files\Storage\Storage;
+	use OC\Files\Storage\StorageFactory;
+	use OCP\Files\Mount\IMountPoint;
 
-    class MountPoint implements IMountPoint {
-        /**
-         * @var \OC\Files\Storage\Storage $storage
-         */
-        protected $storage = null;
-        protected $class;
-        protected $storageId;
-        protected $rootId = null;
+	class MountPoint implements IMountPoint {
+	    /**
+	     * @var \OC\Files\Storage\Storage $storage
+	     */
+	    protected $storage = null;
+	    protected $class;
+	    protected $storageId;
+	    protected $rootId = null;
 
-        /** @var int|null */
-        protected $mountId;
+	    /** @var int|null */
+	    protected $mountId;
 
-        /**
-         * @param string|\OCP\Files\Storage\IStorage $storage
-         * @param string $mountpoint
-         * @param array $arguments (optional) configuration for the storage backend
-         * @param \OCP\Files\Storage\IStorageFactory $loader
-         * @param array $mountOptions mount specific options
-         * @param int|null $mountId
-         * @throws \Exception
-         */
-        public function __construct($storage, $mountpoint, $arguments = null, $loader = null, $mountOptions = null, $mountId = null) {
-            throw new \Exception('stub');
-        }
+	    /**
+	     * @param string|\OCP\Files\Storage\IStorage $storage
+	     * @param string $mountpoint
+	     * @param array $arguments (optional) configuration for the storage backend
+	     * @param \OCP\Files\Storage\IStorageFactory $loader
+	     * @param array $mountOptions mount specific options
+	     * @param int|null $mountId
+	     * @throws \Exception
+	     */
+	    public function __construct($storage, $mountpoint, $arguments = null, $loader = null, $mountOptions = null, $mountId = null) {
+	        throw new \Exception('stub');
+	    }
 
-        /**
-         * get complete path to the mount point, relative to data/
-         *
-         * @return string
-         */
-        public function getMountPoint() {
-            throw new \Exception('stub');
-        }
+	    /**
+	     * get complete path to the mount point, relative to data/
+	     *
+	     * @return string
+	     */
+	    public function getMountPoint() {
+	        throw new \Exception('stub');
+	    }
 
-        /**
-         * Sets the mount point path, relative to data/
-         *
-         * @param string $mountPoint new mount point
-         */
-        public function setMountPoint($mountPoint) {
-            throw new \Exception('stub');
-        }
+	    /**
+	     * Sets the mount point path, relative to data/
+	     *
+	     * @param string $mountPoint new mount point
+	     */
+	    public function setMountPoint($mountPoint) {
+	        throw new \Exception('stub');
+	    }
 
-        /**
-         * @return \OCP\Files\Storage\IStorage
-         */
-        public function getStorage() {
-            throw new \Exception('stub');
-        }
+	    /**
+	     * @return \OCP\Files\Storage\IStorage
+	     */
+	    public function getStorage() {
+	        throw new \Exception('stub');
+	    }
 
-        /**
-         * @return string
-         */
-        public function getStorageId() {
-            throw new \Exception('stub');
-        }
+	    /**
+	     * @return string
+	     */
+	    public function getStorageId() {
+	        throw new \Exception('stub');
+	    }
 
-        /**
-         * @return int
-         */
-        public function getNumericStorageId() {
-            throw new \Exception('stub');
-        }
+	    /**
+	     * @return int
+	     */
+	    public function getNumericStorageId() {
+	        throw new \Exception('stub');
+	    }
 
-        /**
-         * @param string $path
-         * @return string
-         */
-        public function getInternalPath($path) {
-            throw new \Exception('stub');
-        }
+	    /**
+	     * @param string $path
+	     * @return string
+	     */
+	    public function getInternalPath($path) {
+	        throw new \Exception('stub');
+	    }
 
-        /**
-         * @param callable $wrapper
-         */
-        public function wrapStorage($wrapper) {
-            throw new \Exception('stub');
-        }
+	    /**
+	     * @param callable $wrapper
+	     */
+	    public function wrapStorage($wrapper) {
+	        throw new \Exception('stub');
+	    }
 
-        /**
-         * Get a mount option
-         *
-         * @param string $name Name of the mount option to get
-         * @param mixed $default Default value for the mount option
-         * @return mixed
-         */
-        public function getOption($name, $default) {
-            throw new \Exception('stub');
-        }
+	    /**
+	     * Get a mount option
+	     *
+	     * @param string $name Name of the mount option to get
+	     * @param mixed $default Default value for the mount option
+	     * @return mixed
+	     */
+	    public function getOption($name, $default) {
+	        throw new \Exception('stub');
+	    }
 
-        /**
-         * Get all options for the mount
-         *
-         * @return array
-         */
-        public function getOptions() {
-            throw new \Exception('stub');
-        }
+	    /**
+	     * Get all options for the mount
+	     *
+	     * @return array
+	     */
+	    public function getOptions() {
+	        throw new \Exception('stub');
+	    }
 
-        /**
-         * @return int
-         */
-        public function getStorageRootId() {
-            throw new \Exception('stub');
-        }
+	    /**
+	     * @return int
+	     */
+	    public function getStorageRootId() {
+	        throw new \Exception('stub');
+	    }
 
-        public function getMountId() {
-            throw new \Exception('stub');
-        }
+	    public function getMountId() {
+	        throw new \Exception('stub');
+	    }
 
-        public function getMountType() {
-            throw new \Exception('stub');
-        }
+	    public function getMountType() {
+	        throw new \Exception('stub');
+	    }
 
-        public function getMountProvider(): string {
-            throw new \Exception('stub');
-        }
-    }
+	    public function getMountProvider(): string {
+	        throw new \Exception('stub');
+	    }
+	}
 }
 
 namespace OC\Files\Storage\Wrapper{
 
-    use OCP\Files\Cache\ICache;
-    use OCP\Files\Cache\ICacheEntry;
-    use OCP\Files\Search\ISearchQuery;
-    use OCP\Files\Storage\IStorage;
+	use OCP\Files\Cache\ICache;
+	use OCP\Files\Cache\ICacheEntry;
+	use OCP\Files\Search\ISearchQuery;
+	use OCP\Files\Storage\IStorage;
 
-    class Wrapper implements IStorage {
-        public function __construct(array $parameters) {
-        }
+	class Wrapper implements IStorage {
+	    public function __construct(array $parameters) {
+	    }
 
-        public function getWrapperStorage(): ?IStorage {}
+	    public function getWrapperStorage(): ?IStorage {}
 
-        public function getId() {}
+	    public function getId() {}
 
-        public function mkdir($path) {}
+	    public function mkdir($path) {}
 
-        public function rmdir($path) {}
+	    public function rmdir($path) {}
 
-        public function opendir($path) {
-            throw new \Exception('stub');
-        }
+	    public function opendir($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function is_dir($path) {
-            throw new \Exception('stub');
-        }
+	    public function is_dir($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function is_file($path) {
-            throw new \Exception('stub');
-        }
+	    public function is_file($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function stat($path) {
-            throw new \Exception('stub');
-        }
+	    public function stat($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function filetype($path) {
-            throw new \Exception('stub');
-        }
+	    public function filetype($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function filesize($path) {
-            throw new \Exception('stub');
-        }
+	    public function filesize($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function isCreatable($path) {
-            throw new \Exception('stub');
-        }
+	    public function isCreatable($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function isReadable($path) {
-            throw new \Exception('stub');
-        }
+	    public function isReadable($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function isUpdatable($path) {
-            throw new \Exception('stub');
-        }
+	    public function isUpdatable($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function isDeletable($path) {
-            throw new \Exception('stub');
-        }
+	    public function isDeletable($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function isSharable($path) {
-            throw new \Exception('stub');
-        }
+	    public function isSharable($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function getPermissions($path) {
-            throw new \Exception('stub');
-        }
+	    public function getPermissions($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function file_exists($path) {
-            throw new \Exception('stub');
-        }
+	    public function file_exists($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function filemtime($path) {
-            throw new \Exception('stub');
-        }
+	    public function filemtime($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function file_get_contents($path) {
-            throw new \Exception('stub');
-        }
+	    public function file_get_contents($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function file_put_contents($path, $data) {
-            throw new \Exception('stub');
-        }
+	    public function file_put_contents($path, $data) {
+	        throw new \Exception('stub');
+	    }
 
-        public function unlink($path) {
-            throw new \Exception('stub');
-        }
+	    public function unlink($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function rename($path1, $path2) {
-            throw new \Exception('stub');
-        }
+	    public function rename($path1, $path2) {
+	        throw new \Exception('stub');
+	    }
 
-        public function copy($path1, $path2) {
-            throw new \Exception('stub');
-        }
+	    public function copy($path1, $path2) {
+	        throw new \Exception('stub');
+	    }
 
-        public function fopen($path, $mode) {
-            throw new \Exception('stub');
-        }
+	    public function fopen($path, $mode) {
+	        throw new \Exception('stub');
+	    }
 
-        public function getMimeType($path) {
-            throw new \Exception('stub');
-        }
+	    public function getMimeType($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function hash($type, $path, $raw = false) {
-            throw new \Exception('stub');
-        }
+	    public function hash($type, $path, $raw = false) {
+	        throw new \Exception('stub');
+	    }
 
-        public function free_space($path) {
-            throw new \Exception('stub');
-        }
+	    public function free_space($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function touch($path, $mtime = null) {
-            throw new \Exception('stub');
-        }
+	    public function touch($path, $mtime = null) {
+	        throw new \Exception('stub');
+	    }
 
-        public function getLocalFile($path) {
-            throw new \Exception('stub');
-        }
+	    public function getLocalFile($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function hasUpdated($path, $time) {
-            throw new \Exception('stub');
-        }
+	    public function hasUpdated($path, $time) {
+	        throw new \Exception('stub');
+	    }
 
-        public function getETag($path) {
-            throw new \Exception('stub');
-        }
+	    public function getETag($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function isLocal() {
-            throw new \Exception('stub');
-        }
+	    public function isLocal() {
+	        throw new \Exception('stub');
+	    }
 
-        public function instanceOfStorage($class) {
-            throw new \Exception('stub');
-        }
+	    public function instanceOfStorage($class) {
+	        throw new \Exception('stub');
+	    }
 
-        public function getDirectDownload($path) {
-            throw new \Exception('stub');
-        }
+	    public function getDirectDownload($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function verifyPath($path, $fileName) {
-            throw new \Exception('stub');
-        }
+	    public function verifyPath($path, $fileName) {
+	        throw new \Exception('stub');
+	    }
 
-        public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-            throw new \Exception('stub');
-        }
+	    public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	        throw new \Exception('stub');
+	    }
 
-        public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-            throw new \Exception('stub');
-        }
+	    public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	        throw new \Exception('stub');
+	    }
 
-        public function test() {
-            throw new \Exception('stub');
-        }
+	    public function test() {
+	        throw new \Exception('stub');
+	    }
 
-        public function getAvailability() {
-            throw new \Exception('stub');
-        }
+	    public function getAvailability() {
+	        throw new \Exception('stub');
+	    }
 
-        public function setAvailability($isAvailable) {
-            throw new \Exception('stub');
-        }
+	    public function setAvailability($isAvailable) {
+	        throw new \Exception('stub');
+	    }
 
-        public function getOwner($path) {
-            throw new \Exception('stub');
-        }
+	    public function getOwner($path) {
+	        throw new \Exception('stub');
+	    }
 
-        public function getCache() {
-            throw new \Exception('stub');
-        }
+	    public function getCache() {
+	        throw new \Exception('stub');
+	    }
 
-        public function getPropagator() {
-            throw new \Exception('stub');
-        }
+	    public function getPropagator() {
+	        throw new \Exception('stub');
+	    }
 
-        public function getScanner() {
-            throw new \Exception('stub');
-        }
+	    public function getScanner() {
+	        throw new \Exception('stub');
+	    }
 
-        public function getUpdater() {
-            throw new \Exception('stub');
-        }
+	    public function getUpdater() {
+	        throw new \Exception('stub');
+	    }
 
-        public function getWatcher() {
-            throw new \Exception('stub');
-        }
+	    public function getWatcher() {
+	        throw new \Exception('stub');
+	    }
 
 		public function needsPartFile(): bool {
-            throw new \Exception('stub');
+	        throw new \Exception('stub');
 		}
 
 		public function setOwner(?string $user): void {
-            throw new \Exception('stub');
+	        throw new \Exception('stub');
 		}
-    }
+	}
 
-    class Jail extends Wrapper {
-        public function getUnjailedPath(string $path): string {}
-    }
+	class Jail extends Wrapper {
+	    public function getUnjailedPath(string $path): string {}
+	}
 
-    class Quota extends Wrapper {
-        public function getQuota() {}
-    }
+	class Quota extends Wrapper {
+	    public function getQuota() {}
+	}
 
-    class PermissionsMask extends Wrapper {
-        public function getQuota() {}
-    }
+	class PermissionsMask extends Wrapper {
+	    public function getQuota() {}
+	}
 }
 
 namespace OCA\Viewer\Event {
@@ -617,42 +617,42 @@ namespace OCA\Viewer\Event {
 }
 
 namespace OCA\Circles\Model {
-    class Member {
-        public const LEVEL_NONE = 0;
-        public const LEVEL_MEMBER = 1;
-        public const LEVEL_MODERATOR = 4;
-        public const LEVEL_ADMIN = 8;
-        public const LEVEL_OWNER = 9;
+	class Member {
+	    public const LEVEL_NONE = 0;
+	    public const LEVEL_MEMBER = 1;
+	    public const LEVEL_MODERATOR = 4;
+	    public const LEVEL_ADMIN = 8;
+	    public const LEVEL_OWNER = 9;
 
-        public const TYPE_SINGLE = 0;
-        public const TYPE_USER = 1;
-        public const TYPE_GROUP = 2;
-        public const TYPE_MAIL = 4;
-        public const TYPE_CONTACT = 8;
-        public const TYPE_CIRCLE = 16;
-        public const TYPE_APP = 10000;
+	    public const TYPE_SINGLE = 0;
+	    public const TYPE_USER = 1;
+	    public const TYPE_GROUP = 2;
+	    public const TYPE_MAIL = 4;
+	    public const TYPE_CONTACT = 8;
+	    public const TYPE_CIRCLE = 16;
+	    public const TYPE_APP = 10000;
 
-        public const ALLOWING_ALL_TYPES = 31;
+	    public const ALLOWING_ALL_TYPES = 31;
 
-        public const APP_CIRCLES = 10001;
-        public const APP_OCC = 10002;
-        public const APP_DEFAULT = 11000;
+	    public const APP_CIRCLES = 10001;
+	    public const APP_OCC = 10002;
+	    public const APP_DEFAULT = 11000;
 
-        public function getSingleId(): string {}
-        public function getUserType(): int {}
-        public function getLevel(): int {}
-    }
+	    public function getSingleId(): string {}
+	    public function getUserType(): int {}
+	    public function getLevel(): int {}
+	}
 
-    class Circle {
-        public function getName(): string {}
-        public function getSingleId(): string {}
-        public function getSanitizedName(): string {}
-        public function getMembers(): array {}
-        public function getInitiator(): Member {}
-    }
+	class Circle {
+	    public function getName(): string {}
+	    public function getSingleId(): string {}
+	    public function getSanitizedName(): string {}
+	    public function getMembers(): array {}
+	    public function getInitiator(): Member {}
+	}
 
-    class FederatedUser {
-    }
+	class FederatedUser {
+	}
 }
 
 namespace OCA\Circles\Model\Probes {
@@ -660,7 +660,7 @@ namespace OCA\Circles\Model\Probes {
 		public function mustBeMember(bool $must = true): self {}
 	}
 	class DataProbe {
-        public const INITIATOR = 'h';
+	    public const INITIATOR = 'h';
 		public function add(string $key, array $path = []): self {}
 	}
 }
@@ -698,152 +698,152 @@ namespace OCA\Circles\Tools\Exceptions {
 }
 
 namespace OCA\Circles {
-    use OCA\Circles\Model\Circle;
-    use OCA\Circles\Model\FederatedUser;
-    use OCA\Circles\Model\Probes\CircleProbe;
-    use OCA\Circles\Model\Probes\DataProbe;
-    class CirclesManager {
-        public function getFederatedUser(string $federatedId, int $type = Member::TYPE_SINGLE): FederatedUser {}
-        public function startSession(?FederatedUser $federatedUser = null): void {}
-        public function startSuperSession(): void {}
-        public function stopSession(): void {}
+	use OCA\Circles\Model\Circle;
+	use OCA\Circles\Model\FederatedUser;
+	use OCA\Circles\Model\Probes\CircleProbe;
+	use OCA\Circles\Model\Probes\DataProbe;
+	class CirclesManager {
+	    public function getFederatedUser(string $federatedId, int $type = Member::TYPE_SINGLE): FederatedUser {}
+	    public function startSession(?FederatedUser $federatedUser = null): void {}
+	    public function startSuperSession(): void {}
+	    public function stopSession(): void {}
 		public function createCircle(string $name, ?FederatedUser $owner = null, bool $personal = false, bool $local = false): Circle {}
-        public function destroyCircle(string $singleId): void {}
-        public function getCircles(?CircleProbe $probe = null): array {}
-        public function getCircle(string $singleId, ?CircleProbe $probe = null): Circle {}
-        public function flagAsAppManaged(string $circleId, bool $enabled = true): void {}
-        public function probeCircles(?CircleProbe $circleProbe = null, ?DataProbe $dataProbe = null): array {}
-    }
+	    public function destroyCircle(string $singleId): void {}
+	    public function getCircles(?CircleProbe $probe = null): array {}
+	    public function getCircle(string $singleId, ?CircleProbe $probe = null): Circle {}
+	    public function flagAsAppManaged(string $circleId, bool $enabled = true): void {}
+	    public function probeCircles(?CircleProbe $circleProbe = null, ?DataProbe $dataProbe = null): array {}
+	}
 }
 
 namespace OCA\Files_Versions\Versions {
-    use OCP\Files\File;
-    use OCP\Files\FileInfo;
-    use OCP\Files\NotFoundException;
-    use OCP\Files\Storage\IStorage;
-    use OCP\IUser;
+	use OCP\Files\File;
+	use OCP\Files\FileInfo;
+	use OCP\Files\NotFoundException;
+	use OCP\Files\Storage\IStorage;
+	use OCP\IUser;
 
-    interface IVersionBackend {
-        public function useBackendForStorage(IStorage $storage): bool;
+	interface IVersionBackend {
+	    public function useBackendForStorage(IStorage $storage): bool;
 
-        /**
-         * @return IVersion[]
-         */
-        public function getVersionsForFile(IUser $user, FileInfo $file): array;
+	    /**
+	     * @return IVersion[]
+	     */
+	    public function getVersionsForFile(IUser $user, FileInfo $file): array;
 
-        public function createVersion(IUser $user, FileInfo $file);
+	    public function createVersion(IUser $user, FileInfo $file);
 
-        public function rollback(IVersion $version);
+	    public function rollback(IVersion $version);
 
-        /**
-         * @return resource|false
-         * @throws NotFoundException
-         */
-        public function read(IVersion $version);
+	    /**
+	     * @return resource|false
+	     * @throws NotFoundException
+	     */
+	    public function read(IVersion $version);
 
-        /**
-         * @param int|string $revision
-         */
-        public function getVersionFile(IUser $user, FileInfo $sourceFile, $revision): ?File;
-    }
+	    /**
+	     * @param int|string $revision
+	     */
+	    public function getVersionFile(IUser $user, FileInfo $sourceFile, $revision): ?File;
+	}
 
-    interface IVersion {
-        public function getBackend(): IVersionBackend;
+	interface IVersion {
+	    public function getBackend(): IVersionBackend;
 
-        public function getSourceFile(): FileInfo;
+	    public function getSourceFile(): FileInfo;
 
-        /**
-         * @return int|string
-         */
-        public function getRevisionId();
+	    /**
+	     * @return int|string
+	     */
+	    public function getRevisionId();
 
-        public function getTimestamp(): int;
+	    public function getTimestamp(): int;
 
-        public function getSize(): int;
+	    public function getSize(): int;
 
-        public function getSourceFileName(): string;
+	    public function getSourceFileName(): string;
 
-        public function getMimeType(): string;
+	    public function getMimeType(): string;
 
-        public function getVersionPath(): string;
+	    public function getVersionPath(): string;
 
-        public function getUser(): IUser;
-    }
+	    public function getUser(): IUser;
+	}
 
-    class Version implements IVersion {
-        public function __construct(
-            int $timestamp,
-            $revisionId,
-            string $name,
-            int $size,
-            string $mimetype,
-            string $path,
-            FileInfo $sourceFileInfo,
-            IVersionBackend $backend,
-            IUser $user
-        ) {
-        }
+	class Version implements IVersion {
+	    public function __construct(
+	        int $timestamp,
+	        $revisionId,
+	        string $name,
+	        int $size,
+	        string $mimetype,
+	        string $path,
+	        FileInfo $sourceFileInfo,
+	        IVersionBackend $backend,
+	        IUser $user
+	    ) {
+	    }
 
-        public function getBackend(): IVersionBackend {
-            throw new \Exception('stub');
-        }
+	    public function getBackend(): IVersionBackend {
+	        throw new \Exception('stub');
+	    }
 
-        public function getSourceFile(): FileInfo {
-            throw new \Exception('stub');
-        }
+	    public function getSourceFile(): FileInfo {
+	        throw new \Exception('stub');
+	    }
 
-        public function getRevisionId() {
-            throw new \Exception('stub');
-        }
+	    public function getRevisionId() {
+	        throw new \Exception('stub');
+	    }
 
-        public function getTimestamp(): int {
-            throw new \Exception('stub');
-        }
+	    public function getTimestamp(): int {
+	        throw new \Exception('stub');
+	    }
 
-        public function getSize(): int {
-            throw new \Exception('stub');
-        }
+	    public function getSize(): int {
+	        throw new \Exception('stub');
+	    }
 
-        public function getSourceFileName(): string {
-            throw new \Exception('stub');
-        }
+	    public function getSourceFileName(): string {
+	        throw new \Exception('stub');
+	    }
 
-        public function getMimeType(): string {
-            throw new \Exception('stub');
-        }
+	    public function getMimeType(): string {
+	        throw new \Exception('stub');
+	    }
 
-        public function getVersionPath(): string {
-            throw new \Exception('stub');
-        }
+	    public function getVersionPath(): string {
+	        throw new \Exception('stub');
+	    }
 
-        public function getUser(): IUser {
-            throw new \Exception('stub');
-        }
-    }
+	    public function getUser(): IUser {
+	        throw new \Exception('stub');
+	    }
+	}
 }
 
 namespace OCA\Files_Versions {
-    class Expiration {
-        public function shouldAutoExpire() { }
+	class Expiration {
+	    public function shouldAutoExpire() { }
 
-        /**
-         * @param int $timestamp
-         * @param bool $quotaExceeded
-         * @return bool
-         */
-        public function isExpired($timestamp, $quotaExceeded = false) {}
-    }
+	    /**
+	     * @param int $timestamp
+	     * @param bool $quotaExceeded
+	     * @return bool
+	     */
+	    public function isExpired($timestamp, $quotaExceeded = false) {}
+	}
 }
 
 namespace OCA\Files_Trashbin {
-    class Expiration {
-        /**
-         * @param int $timestamp
-         * @param bool $quotaExceeded
-         * @return bool
-         */
-        public function isExpired($timestamp, $quotaExceeded = false) {}
-    }
+	class Expiration {
+	    /**
+	     * @param int $timestamp
+	     * @param bool $quotaExceeded
+	     * @return bool
+	     */
+	    public function isExpired($timestamp, $quotaExceeded = false) {}
+	}
 }
 
 namespace OCA\Files_Trashbin\Trash {
@@ -898,5 +898,13 @@ namespace OCP\Files\Mount {
 }
 
 namespace OCA\Text\Event {
-	class LoadEditor extends \OCP\EventDispatcher\Event {}
+	use OCP\EventDispatcher\Event;
+	class LoadEditor extends Event {}
+
+	use OCP\Files\File;
+	use OCP\Notification\INotification;
+	class MentionEvent extends Event {
+		public function getFile(): File
+		public function getNotification(): INotification
+	}
 }


### PR DESCRIPTION
Requires https://github.com/nextcloud/text/pull/6923

Fixes https://github.com/nextcloud/collectives/issues/1469

This makes sure that for mentions in collectives we have a proper notification message and redirect the user to the collective page instead of the file.

<img width="543" alt="Screenshot 2025-02-27 at 17 00 41" src="https://github.com/user-attachments/assets/da757745-ac24-48c5-a8a6-a2ed3c0f3b51" />


### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
