### PR TITLE
Optimize collectives fetching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
       "lint": "find . -name \\*.php -not -path './vendor/*' -exec php -l \"{}\" \\;",
       "cs:check": "php-cs-fixer fix --dry-run --diff",
       "cs:fix": "php-cs-fixer fix",
-      "psalm": "psalm --threads=$(nproc) --no-cache",
+      "psalm": "psalm --no-cache",
       "psalm:update-baseline": "psalm --threads=$(nproc) --no-cache --update-baseline --set-baseline=tests/psalm-baseline.xml",
       "test:unit": "phpunit -c tests/phpunit.xml",
       "post-install-cmd": [

--- a/lib/Service/CircleHelper.php
+++ b/lib/Service/CircleHelper.php
@@ -306,11 +306,12 @@ class CircleHelper {
 			if ($initiator->getUserType() !== Member::TYPE_USER) {
 				return false;
 			}
-			$members = $circle->getMembers();
+			$members = $circle->getMembers(2);
 		} catch (CircleNotFoundException $e) {
 			throw new NotFoundException($e->getMessage(), 0, $e);
 		}
 
+		// if there is at least 1 more user in this circle
 		foreach ($members as $member) {
 			if ($member->getSingleId() !== $initiator->getSingleId()) {
 				return true;


### PR DESCRIPTION
### 📝 Summary

In our organization we have circles with thousands of people. This leads api for fetching collectives list extremely slow, up to 30s. This happens because we loading all members of the circle for canLeave check. With suggested change we can reduce amount of loaded users

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] merge https://github.com/nextcloud/circles/pull/1913 first

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
