### PR TITLE
fix: use half icon size for subpage indention

### DIFF
--- a/src/components/PageList/SubpageList.vue
+++ b/src/components/PageList/SubpageList.vue
@@ -159,6 +159,6 @@ export default {
 
 <style>
 .page-list-indent {
-	padding-left: 28px;
+	padding-left: 20px;
 }
 </style>


### PR DESCRIPTION
Fixes: #1672

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/user-attachments/assets/2cb1bda7-346e-49ee-91ed-ccf8f74fb89b) | ![grafik](https://github.com/user-attachments/assets/49458ab0-4f42-4a6e-9bda-da16b7dedcca)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
