### PR TITLE
ci(renovate): pin vueuse to version 11 until we migrate to vue3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,10 @@
     {
       "matchPackageNames": ["vue-router"],
       "allowedVersions": "<4"
+    },
+    {
+      "matchPackageNames": ["vueuse"],
+      "allowedVersions": "<12"
     }
   ]
 }


### PR DESCRIPTION
Vueuse 12 dropped Vue 2 support.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
