### PR TITLE
fix(landingpage): replace editor heading with a thin line

### DIFF
--- a/src/components/Page/LandingPageWidgets.vue
+++ b/src/components/Page/LandingPageWidgets.vue
@@ -62,6 +62,7 @@ export default {
 <style scoped>
 .landing-page-widgets {
 	padding-inline: 14px 8px;
+	border-bottom: 1px solid var(--color-border);
 }
 .first-row-widgets{
 	display: flex;

--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -5,9 +5,6 @@
 
 <template>
 	<div ref="textContainer" class="collectives-text-container">
-		<WidgetHeading v-if="isLandingPage"
-			:title="t('collectives', 'Landing page')"
-			class="text-container-heading" />
 		<SkeletonLoading v-show="!contentLoaded"
 			type="text"
 			class="page-content-skeleton" />
@@ -26,7 +23,6 @@ import { ref, watch } from 'vue'
 import { useElementSize } from '@vueuse/core'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { showError } from '@nextcloud/dialogs'
-import WidgetHeading from './LandingPageWidgets/WidgetHeading.vue'
 import { mapActions, mapState } from 'pinia'
 import { useRootStore } from '../../stores/root.js'
 import { useCollectivesStore } from '../../stores/collectives.js'
@@ -42,7 +38,6 @@ export default {
 
 	components: {
 		SkeletonLoading,
-		WidgetHeading,
 	},
 
 	mixins: [
@@ -74,7 +69,6 @@ export default {
 		...mapState(usePagesStore, [
 			'currentPage',
 			'currentPageDavUrl',
-			'isLandingPage',
 			'isTemplatePage',
 		]),
 
@@ -214,20 +208,12 @@ export default {
 	min-height: 50vh;
 }
 
-.text-container-heading {
-	padding-inline: 14px 8px;
-}
-
 .page-content-skeleton {
 	padding-block-start: var(--default-clickable-area);
 }
 
 @media print {
 	/* Don't print unwanted elements */
-	.text-container-heading {
-		display: none !important;
-	}
-
 	.collectives-text-container {
 		overflow: visible;
 	}

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -39,11 +39,6 @@
 		margin-inline: auto;
 	}
 
-	.text-container-heading {
-		max-width: min(var(--text-editor-max-width), 100%);
-		margin-inline: auto;
-	}
-
 	.page-title {
 		max-width: 100%;
 		margin: 0 0 0 max(0px, calc(50% - (var(--text-editor-max-width) / 2)));


### PR DESCRIPTION
The heading "landing page" caused confusion, took unnecessary space and made the layout even more complex.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![image](https://github.com/user-attachments/assets/759e803a-ba81-40c9-bbf8-765461a1cf41) | ![image](https://github.com/user-attachments/assets/cc7127bf-4a29-451a-a9c5-bac1531c92a0)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
