### PR TITLE
fix(landingpage): Do not show the Show Templates button on public share

### DIFF
--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -14,7 +14,7 @@
 				trailing-button-icon="close"
 				:show-trailing-button="isFilteredView"
 				@trailing-button-click="clearFilterString" />
-			<NcActions class="toggle toggle-push-to-right">
+			<NcActions v-if="!isPublic" class="toggle toggle-push-to-right">
 				<NcActionButton class="toggle-button"
 					:aria-label="labels.showTemplates"
 					@click="toggleTemplates()">


### PR DESCRIPTION
### 📝 Summary

* Resolves: #1709

The user is not going to do some edition at this point, do not allow them to list the templates.

### 🏁 Checklist

- [X] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [X] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [X] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [X] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
