### PR TITLE
fix(landingpage): Do not show the Team Overview button on public share

### DIFF
--- a/src/components/Page/LandingPageWidgets.vue
+++ b/src/components/Page/LandingPageWidgets.vue
@@ -6,8 +6,8 @@
 <template>
 	<div class="landing-page-widgets"
 		:class="[isFullWidth ? 'full-width-view' : 'sheet-view']">
-		<div class="first-row-widgets">
-			<MembersWidget v-if="!isPublic" />
+		<div v-if="!isPublic" class="first-row-widgets">
+			<MembersWidget />
 			<NcButton v-if="hasContactsApp" :href="teamUrl" target="_blank">
 				<template #icon>
 					<TeamsIcon :size="20" />


### PR DESCRIPTION
### 📝 Summary

Do not show the Team Overview button on public share

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
