### PR TITLE
fix(LandingPage): Several landing page widgets improvements

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -33,6 +33,8 @@ return [
 		// collectives userSettings API
 		['name' => 'collectiveUserSettings#pageOrder', 'url' => '/_api/{id}/_userSettings/pageOrder', 'verb' => 'PUT',
 			'requirements' => ['id' => '\d+']],
+		['name' => 'collectiveUserSettings#showMembers', 'url' => '/_api/{id}/_userSettings/showMembers', 'verb' => 'PUT',
+			'requirements' => ['id' => '\d+']],
 		['name' => 'collectiveUserSettings#showRecentPages', 'url' => '/_api/{id}/_userSettings/showRecentPages', 'verb' => 'PUT',
 			'requirements' => ['id' => '\d+']],
 		['name' => 'collectiveUserSettings#favoritePages', 'url' => '/_api/{id}/_userSettings/favoritePages', 'verb' => 'PUT',

--- a/cypress/e2e/page-landingpage.spec.js
+++ b/cypress/e2e/page-landingpage.spec.js
@@ -57,7 +57,24 @@ describe('Page landing page', function() {
 		})
 	})
 
-	describe('Displays recent members', function() {
+	describe.only('Displays recent members', function() {
+		it('Allows to toggle members widget', function() {
+			cy.get('.members-widget img[src*="/alice/"]')
+
+			cy.get('.members-widget .members-title')
+				.click()
+			cy.get('.members-widget img[src*="/alice/"]')
+				.should('not.be.visible')
+
+			cy.reload()
+
+			cy.get('.members-widget img[src*="/alice/"]')
+				.should('not.be.visible')
+			cy.get('.members-widget .members-title')
+				.click()
+			cy.get('.members-widget img[src*="/alice/"]')
+		})
+
 		it('Allows to open members modal as admin', function() {
 			cy.get('.members-widget img[src*="/alice/"]')
 			cy.get('.members-widget .button-vue[title="Manage members"]')

--- a/cypress/e2e/page-landingpage.spec.js
+++ b/cypress/e2e/page-landingpage.spec.js
@@ -60,7 +60,7 @@ describe('Page landing page', function() {
 	describe('Displays recent members', function() {
 		it('Allows to open members modal as admin', function() {
 			cy.get('.members-widget img[src*="/alice/"]')
-			cy.get('.members-widget .button-vue[title="Show members"]')
+			cy.get('.members-widget .button-vue[title="Manage members"]')
 				.click()
 
 			cy.get('.current-members').contains('.member-row', 'alice')

--- a/lib/Controller/CollectiveUserSettingsController.php
+++ b/lib/Controller/CollectiveUserSettingsController.php
@@ -53,6 +53,18 @@ class CollectiveUserSettingsController extends Controller {
 	}
 
 	#[NoAdminRequired]
+	public function showMembers(int $id, bool $showMembers): DataResponse {
+		return $this->prepareResponse(function () use ($id, $showMembers): array {
+			$this->service->setShowMembers(
+				$id,
+				$this->getUserId(),
+				$showMembers
+			);
+			return [];
+		});
+	}
+
+	#[NoAdminRequired]
 	public function showRecentPages(int $id, bool $showRecentPages): DataResponse {
 		return $this->prepareResponse(function () use ($id, $showRecentPages): array {
 			$this->service->setShowRecentPages(

--- a/lib/Db/Collective.php
+++ b/lib/Db/Collective.php
@@ -55,6 +55,8 @@ class Collective extends Entity implements JsonSerializable {
 	/** @var int */
 	public const defaultPageMode = 0;
 	/** @var bool */
+	public const defaultShowMembers = true;
+	/** @var bool */
 	public const defaultShowRecentPages = true;
 
 	protected ?string $circleUniqueId = null;
@@ -70,6 +72,7 @@ class Collective extends Entity implements JsonSerializable {
 	protected int $sharePageId = 0;
 	protected bool $shareEditable = false;
 	protected int $userPageOrder = Collective::defaultPageOrder;
+	protected bool $userShowMembers = Collective::defaultShowMembers;
 	protected bool $userShowRecentPages = Collective::defaultShowRecentPages;
 	protected array $userFavoritePages = [];
 	protected ?bool $canLeave = null;
@@ -185,6 +188,10 @@ class Collective extends Entity implements JsonSerializable {
 		return $this->userPageOrder;
 	}
 
+	public function getUserShowMembers(): bool {
+		return $this->userShowMembers;
+	}
+
 	public function getUserShowRecentPages(): bool {
 		return $this->userShowRecentPages;
 	}
@@ -209,6 +216,10 @@ class Collective extends Entity implements JsonSerializable {
 			throw new RuntimeException('Invalid userPageOrder value: ' . $userPageOrder);
 		}
 		$this->userPageOrder = $userPageOrder;
+	}
+
+	public function setUserShowMembers(bool $userShowMembers): void {
+		$this->userShowMembers = $userShowMembers;
 	}
 
 	public function setUserShowRecentPages(bool $userShowRecentPages): void {
@@ -283,6 +294,7 @@ class Collective extends Entity implements JsonSerializable {
 			'sharePageId' => $this->sharePageId,
 			'shareEditable' => $this->canEdit() && $this->shareEditable,
 			'userPageOrder' => $this->userPageOrder,
+			'userShowMembers' => $this->userShowMembers,
 			'userShowRecentPages' => $this->userShowRecentPages,
 			'userFavoritePages' => $this->userFavoritePages,
 			'canLeave' => $this->getCanLeave(),

--- a/lib/Db/CollectiveUserSettings.php
+++ b/lib/Db/CollectiveUserSettings.php
@@ -28,6 +28,7 @@ class CollectiveUserSettings extends Entity implements JsonSerializable {
 	/** @var array */
 	public const supportedSettings = [
 		'page_order',
+		'show_members',
 		'show_recent_pages',
 		'favorite_pages',
 	];
@@ -77,6 +78,14 @@ class CollectiveUserSettings extends Entity implements JsonSerializable {
 			throw new NotPermittedException('Invalid pageOrder value: ' . $pageOrder);
 		}
 		$this->setSetting('page_order', $pageOrder);
+	}
+
+	/**
+	 * @throws NotPermittedException
+	 * @throws JsonException
+	 */
+	public function setShowMembers(bool $showMembers): void {
+		$this->setSetting('show_members', $showMembers);
 	}
 
 	/**

--- a/lib/Service/CollectiveHelper.php
+++ b/lib/Service/CollectiveHelper.php
@@ -41,6 +41,7 @@ class CollectiveHelper {
 				// TODO: merge queries for collective and user settings into one?
 				$settings = $this->collectiveUserSettingsMapper->findByCollectiveAndUser($c->getId(), $userId);
 				$c->setUserPageOrder(($settings ? $settings->getSetting('page_order') : null) ?? Collective::defaultPageOrder);
+				$c->setUserShowMembers(($settings ? $settings->getSetting('show_members') : null) ?? Collective::defaultShowMembers);
 				$c->setUserShowRecentPages(($settings ? $settings->getSetting('show_recent_pages') : null) ?? Collective::defaultShowRecentPages);
 				$c->setUserFavoritePages(($settings ? $settings->getSetting('favorite_pages') : null) ?? []);
 			}

--- a/lib/Service/CollectiveUserSettingsService.php
+++ b/lib/Service/CollectiveUserSettingsService.php
@@ -58,6 +58,21 @@ class CollectiveUserSettingsService {
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 */
+	public function setShowMembers(int $collectiveId, string $userId, bool $showMembers): void {
+		$settings = $this->initSettings($collectiveId, $userId);
+		$settings->setShowMembers($showMembers);
+
+		try {
+			$this->collectiveUserSettingsMapper->insertOrUpdate($settings);
+		} catch (Exception $e) {
+			throw new NotPermittedException($e->getMessage(), 0, $e);
+		}
+	}
+
+	/**
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 */
 	public function setShowRecentPages(int $collectiveId, string $userId, bool $showRecentPages): void {
 		$settings = $this->initSettings($collectiveId, $userId);
 		$settings->setShowRecentPages($showRecentPages);

--- a/src/apis/collectives/userSettings.js
+++ b/src/apis/collectives/userSettings.js
@@ -20,6 +20,19 @@ export function setCollectiveUserSettingPageOrder(collectiveId, pageOrder) {
 }
 
 /**
+ * Set the `show members` toggle for the current user
+ *
+ * @param {number} collectiveId ID of the collective to be updated
+ * @param {boolean} showMembers the desired value
+ */
+export function setCollectiveUserSettingShowMembers(collectiveId, showMembers) {
+	return axios.put(
+		collectivesUrl(collectiveId, '_userSettings', 'showMembers'),
+		{ showMembers },
+	)
+}
+
+/**
  * Set the `show recent pages` toggle for the current user
  *
  * @param {number} collectiveId ID of the collective to be updated

--- a/src/components/Page/LandingPageWidgets.vue
+++ b/src/components/Page/LandingPageWidgets.vue
@@ -48,7 +48,7 @@ export default {
 <style scoped>
 .landing-page-widgets {
 	padding-inline: 14px 8px;
-	padding-bottom: 4px;
+	padding-bottom: 8px;
 	border-bottom: 1px solid var(--color-border);
 }
 

--- a/src/components/Page/LandingPageWidgets.vue
+++ b/src/components/Page/LandingPageWidgets.vue
@@ -48,7 +48,7 @@ export default {
 <style scoped>
 .landing-page-widgets {
 	padding-inline: 14px 8px;
-	padding-bottom: 8px;
+	padding-bottom: 12px;
 	border-bottom: 1px solid var(--color-border);
 }
 

--- a/src/components/Page/LandingPageWidgets.vue
+++ b/src/components/Page/LandingPageWidgets.vue
@@ -8,7 +8,7 @@
 		:class="[isFullWidth ? 'full-width-view' : 'sheet-view']">
 		<div v-if="!isPublic" class="first-row-widgets">
 			<MembersWidget />
-			<NcButton v-if="hasContactsApp" :href="teamUrl" target="_blank">
+			<NcButton v-if="showTeamOverviewButton" :href="teamUrl" target="_blank">
 				<template #icon>
 					<TeamsIcon :size="20" />
 				</template>
@@ -24,6 +24,7 @@
 <script>
 import { mapState } from 'pinia'
 import { useRootStore } from '../../stores/root.js'
+import { useCirclesStore } from '../../stores/circles.js'
 import { useCollectivesStore } from '../../stores/collectives.js'
 import { usePagesStore } from '../../stores/pages.js'
 
@@ -58,6 +59,7 @@ export default {
 
 	computed: {
 		...mapState(useRootStore, ['isPublic']),
+		...mapState(useCirclesStore, ['circleMembers']),
 		...mapState(useCollectivesStore, ['currentCollective']),
 		...mapState(usePagesStore, ['pages']),
 
@@ -67,6 +69,10 @@ export default {
 
 		hasContactsApp() {
 			return 'contacts' in this.OC.appswebroots
+		},
+
+		showTeamOverviewButton() {
+			return this.hasContactsApp && this.circleMembers(this.currentCollective.circleId).length > 1
 		},
 
 		showRecentPages() {

--- a/src/components/Page/LandingPageWidgets.vue
+++ b/src/components/Page/LandingPageWidgets.vue
@@ -17,7 +17,7 @@
 				</template>
 			</NcButton>
 		</div>
-		<RecentPagesWidget />
+		<RecentPagesWidget v-if="showRecentPages" />
 	</div>
 </template>
 
@@ -25,12 +25,15 @@
 import { mapState } from 'pinia'
 import { useRootStore } from '../../stores/root.js'
 import { useCollectivesStore } from '../../stores/collectives.js'
+import { usePagesStore } from '../../stores/pages.js'
+
+import { generateUrl } from '@nextcloud/router'
+import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
+
 import MembersWidget from './LandingPageWidgets/MembersWidget.vue'
 import RecentPagesWidget from './LandingPageWidgets/RecentPagesWidget.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import TeamsIcon from '../Icon/TeamsIcon.vue'
-import { generateUrl } from '@nextcloud/router'
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 
 export default {
 	name: 'LandingPageWidgets',
@@ -56,6 +59,7 @@ export default {
 	computed: {
 		...mapState(useRootStore, ['isPublic']),
 		...mapState(useCollectivesStore, ['currentCollective']),
+		...mapState(usePagesStore, ['pages']),
 
 		teamUrl() {
 			return generateUrl('/apps/contacts/circle/{teamId}', { teamId: this.currentCollective.circleId })
@@ -64,6 +68,10 @@ export default {
 		hasContactsApp() {
 			return 'contacts' in this.OC.appswebroots
 		},
+
+		showRecentPages() {
+			return this.pages.length > 3
+		},
 	},
 }
 </script>
@@ -71,6 +79,7 @@ export default {
 <style scoped>
 .landing-page-widgets {
 	padding-inline: 14px 8px;
+	padding-bottom: 4px;
 	border-bottom: 1px solid var(--color-border);
 }
 

--- a/src/components/Page/LandingPageWidgets.vue
+++ b/src/components/Page/LandingPageWidgets.vue
@@ -6,17 +6,7 @@
 <template>
 	<div class="landing-page-widgets"
 		:class="[isFullWidth ? 'full-width-view' : 'sheet-view']">
-		<div v-if="!isPublic" class="first-row-widgets">
-			<MembersWidget />
-			<NcButton v-if="showTeamOverviewButton" :href="teamUrl" target="_blank">
-				<template #icon>
-					<TeamsIcon :size="20" />
-				</template>
-				<template v-if="!isMobile" #default>
-					{{ t('collectives','Team overview') }}
-				</template>
-			</NcButton>
-		</div>
+		<MembersWidget v-if="!isPublic" />
 		<RecentPagesWidget v-if="showRecentPages" />
 	</div>
 </template>
@@ -24,17 +14,10 @@
 <script>
 import { mapState } from 'pinia'
 import { useRootStore } from '../../stores/root.js'
-import { useCirclesStore } from '../../stores/circles.js'
-import { useCollectivesStore } from '../../stores/collectives.js'
 import { usePagesStore } from '../../stores/pages.js'
-
-import { generateUrl } from '@nextcloud/router'
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 
 import MembersWidget from './LandingPageWidgets/MembersWidget.vue'
 import RecentPagesWidget from './LandingPageWidgets/RecentPagesWidget.vue'
-import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import TeamsIcon from '../Icon/TeamsIcon.vue'
 
 export default {
 	name: 'LandingPageWidgets',
@@ -42,13 +25,7 @@ export default {
 	components: {
 		MembersWidget,
 		RecentPagesWidget,
-		NcButton,
-		TeamsIcon,
 	},
-
-	mixins: [
-		isMobile,
-	],
 
 	props: {
 		isFullWidth: {
@@ -59,21 +36,7 @@ export default {
 
 	computed: {
 		...mapState(useRootStore, ['isPublic']),
-		...mapState(useCirclesStore, ['circleMembers']),
-		...mapState(useCollectivesStore, ['currentCollective']),
 		...mapState(usePagesStore, ['pages']),
-
-		teamUrl() {
-			return generateUrl('/apps/contacts/circle/{teamId}', { teamId: this.currentCollective.circleId })
-		},
-
-		hasContactsApp() {
-			return 'contacts' in this.OC.appswebroots
-		},
-
-		showTeamOverviewButton() {
-			return this.hasContactsApp && this.circleMembers(this.currentCollective.circleId).length > 1
-		},
 
 		showRecentPages() {
 			return this.pages.length > 3
@@ -87,13 +50,6 @@ export default {
 	padding-inline: 14px 8px;
 	padding-bottom: 4px;
 	border-bottom: 1px solid var(--color-border);
-}
-
-.first-row-widgets{
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	margin-top: 12px;
 }
 
 @media print {

--- a/src/components/Page/LandingPageWidgets/MembersWidget.vue
+++ b/src/components/Page/LandingPageWidgets/MembersWidget.vue
@@ -5,43 +5,17 @@
 
 <template>
 	<div class="members-widget">
-		<a class="members-title"
-			:aria-label="expandLabel"
-			@keydown.enter="toggleWidget"
-			@click="toggleWidget">
-			<WidgetHeading :title="t('collectives', 'Members')" />
-			<div class="toggle-icon">
-				<ChevronDownIcon :size="24"
-					:class="{ 'collapsed': !showMembers }" />
-			</div>
-		</a>
-		<div v-show="showMembers" class="members-container">
-			<div class="members-avatars">
-				<SkeletonLoading v-if="loading"
-					type="avatar"
-					:count="3"
-					class="members-skeleton" />
-				<div v-else ref="members" class="members-members">
-					<NcAvatar v-for="member in trimmedMembers"
-						:key="member.singleId"
-						:user="member.userId"
-						:display-name="member.displayName"
-						:is-no-user="isNoUser(member)"
-						:icon-class="iconClass(member)"
-						:disable-menu="true"
-						:tooltip-message="member.displayName"
-						:size="avatarSize" />
-					<NcButton type="secondary"
-						:title="showMembersTitle"
-						:aria-label="showMembersAriaLabel"
-						@click="openCollectiveMembers()">
-						<template #icon>
-							<AccountMultiplePlusIcon v-if="isAdmin" :size="16" />
-							<AccountMultipleIcon v-else :size="16" />
-						</template>
-					</NcButton>
+		<div class="members-title-container">
+			<a class="members-title"
+				:aria-label="expandLabel"
+				@keydown.enter="toggleWidget"
+				@click="toggleWidget">
+				<WidgetHeading :title="t('collectives', 'Members')" />
+				<div class="toggle-icon">
+					<ChevronDownIcon :size="24"
+						:class="{ 'collapsed': !showMembers }" />
 				</div>
-			</div>
+			</a>
 			<NcButton v-if="showTeamOverviewButton" :href="teamUrl" target="_blank">
 				<template #icon>
 					<TeamsIcon :size="20" />
@@ -50,6 +24,32 @@
 					{{ t('collectives','Team overview') }}
 				</template>
 			</NcButton>
+		</div>
+		<div v-show="showMembers" class="members-container">
+			<SkeletonLoading v-if="loading"
+				type="avatar"
+				:count="3"
+				class="members-skeleton" />
+			<div v-else ref="members" class="members-members">
+				<NcAvatar v-for="member in trimmedMembers"
+					:key="member.singleId"
+					:user="member.userId"
+					:display-name="member.displayName"
+					:is-no-user="isNoUser(member)"
+					:icon-class="iconClass(member)"
+					:disable-menu="true"
+					:tooltip-message="member.displayName"
+					:size="avatarSize" />
+				<NcButton type="secondary"
+					:title="showMembersTitle"
+					:aria-label="showMembersAriaLabel"
+					@click="openCollectiveMembers()">
+					<template #icon>
+						<AccountMultiplePlusIcon v-if="isAdmin" :size="16" />
+						<AccountMultipleIcon v-else :size="16" />
+					</template>
+				</NcButton>
+			</div>
 		</div>
 	</div>
 </template>
@@ -265,13 +265,14 @@ export default {
 	}
 }
 
-.members-container {
+.members-title-container {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 }
 
-.members-avatars {
+.members-container {
+	display: flex;
 	flex-grow: 1;
 }
 
@@ -283,5 +284,6 @@ export default {
 	display: flex;
 	flex-direction: row;
 	gap: 12px;
+	flex-grow: 1;
 }
 </style>

--- a/src/components/Page/LandingPageWidgets/MembersWidget.vue
+++ b/src/components/Page/LandingPageWidgets/MembersWidget.vue
@@ -20,11 +20,12 @@
 				:tooltip-message="member.displayName"
 				:size="avatarSize" />
 			<NcButton type="secondary"
-				:title="t('collectives', 'Show members')"
-				:aria-label="t('collectives', 'Show all members of the collective')"
+				:title="showMembersTitle"
+				:aria-label="showMembersAriaLabel"
 				@click="openCollectiveMembers()">
 				<template #icon>
-					<DotsHorizontalIcon :size="16" />
+					<AccountMultiplePlusIcon v-if="isAdmin" :size="16" />
+					<AccountMultipleIcon v-else :size="16" />
 				</template>
 			</NcButton>
 		</div>
@@ -38,7 +39,8 @@ import { useCirclesStore } from '../../../stores/circles.js'
 import { useCollectivesStore } from '../../../stores/collectives.js'
 import { usePagesStore } from '../../../stores/pages.js'
 import { NcAvatar, NcButton } from '@nextcloud/vue'
-import DotsHorizontalIcon from 'vue-material-design-icons/DotsHorizontal.vue'
+import AccountMultipleIcon from 'vue-material-design-icons/AccountMultiple.vue'
+import AccountMultiplePlusIcon from 'vue-material-design-icons/AccountMultiplePlus.vue'
 import SkeletonLoading from '../../SkeletonLoading.vue'
 import { circlesMemberTypes } from '../../../constants.js'
 
@@ -46,7 +48,8 @@ export default {
 	name: 'MembersWidget',
 
 	components: {
-		DotsHorizontalIcon,
+		AccountMultipleIcon,
+		AccountMultiplePlusIcon,
 		NcAvatar,
 		NcButton,
 		SkeletonLoading,
@@ -64,7 +67,10 @@ export default {
 			'circleMembersSorted',
 			'circleMemberType',
 		]),
-		...mapState(useCollectivesStore, ['currentCollective']),
+		...mapState(useCollectivesStore, [
+			'currentCollective',
+			'isCollectiveAdmin',
+		]),
 		...mapState(usePagesStore, ['recentPagesUserIds']),
 
 		sortedMembers() {
@@ -96,6 +102,22 @@ export default {
 			return function(member) {
 				return this.isNoUser(member) ? 'icon-group-white' : null
 			}
+		},
+
+		isAdmin() {
+			return this.isCollectiveAdmin(this.currentCollective)
+		},
+
+		showMembersTitle() {
+			return this.isAdmin
+				? t('collectives', 'Manage members')
+				: t('collectives', 'Show members')
+		},
+
+		showMembersAriaLabel() {
+			return this.isAdmin
+				? t('collectives', 'Manage members of the collective')
+				: t('collectives', 'Show all members of the collective')
 		},
 	},
 

--- a/src/components/Page/LandingPageWidgets/MembersWidget.vue
+++ b/src/components/Page/LandingPageWidgets/MembersWidget.vue
@@ -269,7 +269,6 @@ export default {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	padding-top: 12px;
 }
 
 .members-avatars {

--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -77,12 +77,12 @@ export default {
 
 	scroll-snap-align: start;
 	border-radius: var(--border-radius-large);
-	box-shadow: 0 0 4px 0 var(--color-box-shadow);
+	box-shadow: 0 0 8px 0 var(--color-box-shadow);
 
 	padding: 8px;
 
 	&:hover {
-		box-shadow: 0 0 8px 0 var(--color-box-shadow);
+		box-shadow: 0 0 4px 0 var(--color-box-shadow);
 	}
 
 	&__icon {
@@ -125,5 +125,12 @@ export default {
 			margin-left: 2px;
 		}
 	}
+}
+
+</style>
+
+<style lang="scss">
+body[data-themes="dark"] .recent-page-tile {
+		background: var(--color-background-darker);
 }
 </style>

--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -100,8 +100,7 @@ export default {
 	}
 
 	&__emoji {
-		font-size: 32px;
-		margin-top: -8px;
+		font-size: 29px;
 	}
 
 	&__title {

--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -9,7 +9,7 @@
 			<div v-if="page.emoji" class="recent-page-tile__emoji">
 				{{ page.emoji }}
 			</div>
-			<PageIcon v-else :size="36" fill-color="var(--color-text-maxcontrast)" />
+			<PageIcon v-else :size="36" fill-color="var(--color-background-darker)" />
 		</div>
 		<div class="recent-page-tile__text">
 			<div class="recent-page-tile__title">
@@ -18,7 +18,7 @@
 			<div class="recent-page-tile__subtitle">
 				<NcAvatar :user="page.lastUserId || ''"
 					:display-name="page.lastUserDisplayName || ''"
-					:size="20" />
+					:size="24" />
 				<span class="timestamp">
 					{{ lastUpdate }}
 				</span>
@@ -70,53 +70,60 @@ export default {
 .recent-page-tile {
 	display: flex;
 	flex-direction: column;
+	justify-content: center;
+	align-items: space-between;
 	height: 144px;
 	width: 144px;
-	margin-right: 12px;
 
 	scroll-snap-align: start;
-	background-color: var(--color-primary-element-light);
 	border-radius: var(--border-radius-large);
+	box-shadow: 0 0 4px 0 var(--color-box-shadow);
+
+	padding: 8px;
 
 	&:hover {
-		background-color: var(--color-background-hover);
+		box-shadow: 0 0 8px 0 var(--color-box-shadow);
 	}
 
 	&__icon {
 		display: flex;
 		height: 72px;
-		width: 144px;
 		align-items: center;
-		justify-content: center;
+		justify-content: flex-start;
+	}
+
+	&__text {
+		height: 100%;
+		display: flex;
+		margin-top: 8px;
+		flex-direction: column;
 	}
 
 	&__emoji {
 		font-size: 32px;
-	}
-
-	&__text {
-		padding: 12px;
+		margin-top: -8px;
 	}
 
 	&__title {
-		margin-top: 12px;
 		font-weight: bold;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
 		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
 	}
 
 	&__subtitle {
 		display: flex;
 		gap: 4px;
-		margin-top: 8px;
+		margin-top: auto;
 		align-items: center;
-		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 
 		.timestamp {
 			color: var(--color-text-maxcontrast);
+			margin-left: 2px;
 		}
 	}
 }

--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -4,7 +4,9 @@
 -->
 
 <template>
-	<router-link :to="pagePath(page)" class="recent-page-tile">
+	<router-link :to="pagePath(page)"
+		class="recent-page-tile"
+		:class="{ 'dark': isDarkTheme }">
 		<div class="recent-page-tile__icon">
 			<div v-if="page.emoji" class="recent-page-tile__emoji">
 				{{ page.emoji }}
@@ -32,6 +34,7 @@ import { mapState } from 'pinia'
 import { usePagesStore } from '../../../stores/pages.js'
 import { INDEX_PAGE } from '../../../constants.js'
 import moment from '@nextcloud/moment'
+import { isDarkTheme } from '@nextcloud/vue/functions/isDarkTheme'
 
 import PageIcon from '../../Icon/PageIcon.vue'
 import { NcAvatar } from '@nextcloud/vue'
@@ -52,6 +55,10 @@ export default {
 
 	computed: {
 		...mapState(usePagesStore, ['pagePath']),
+
+		isDarkTheme() {
+			return isDarkTheme
+		},
 
 		title() {
 			return this.page.title === INDEX_PAGE
@@ -83,6 +90,14 @@ export default {
 
 	&:hover {
 		box-shadow: 0 0 4px 0 var(--color-box-shadow);
+	}
+
+	&.dark {
+		background-color: var(--color-background-dark);
+
+		&:hover {
+			background-color: var(--color-background-hover);
+		}
 	}
 
 	&__icon {
@@ -126,11 +141,5 @@ export default {
 			margin-left: 2px;
 		}
 	}
-}
-</style>
-
-<style lang="scss">
-body[data-themes="dark"] .recent-page-tile {
-		background: var(--color-background-darker);
 }
 </style>

--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -88,6 +88,7 @@ export default {
 	&__icon {
 		display: flex;
 		height: 72px;
+		width: 144px;
 		align-items: center;
 		justify-content: flex-start;
 	}
@@ -126,7 +127,6 @@ export default {
 		}
 	}
 }
-
 </style>
 
 <style lang="scss">

--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -5,35 +5,41 @@
 
 <template>
 	<router-link :to="pagePath(page)" class="recent-page-tile">
-		<div class="recent-page-tile__rectangle">
-			<template v-if="page.emoji">
+		<div class="recent-page-tile__icon">
+			<div v-if="page.emoji" class="recent-page-tile__emoji">
 				{{ page.emoji }}
-			</template>
-			<template v-else>
-				<PageIcon :size="36" fill-color="var(--color-text-maxcontrast)" />
-			</template>
+			</div>
+			<PageIcon v-else :size="36" fill-color="var(--color-text-maxcontrast)" />
 		</div>
-		<div class="recent-page-tile__title">
-			{{ title }}
+		<div class="recent-page-tile__text">
+			<div class="recent-page-tile__title">
+				{{ title }}
+			</div>
+			<div class="recent-page-tile__subtitle">
+				<NcAvatar :user="page.lastUserId || ''"
+					:display-name="page.lastUserDisplayName || ''"
+					:size="20" />
+				<span class="timestamp">
+					{{ lastUpdate }}
+				</span>
+			</div>
 		</div>
-		<LastUserBubble :last-user-id="page.lastUserId || ''"
-			:last-user-display-name="page.lastUserDisplayName || ''"
-			:timestamp="page.timestamp"
-			class="recent-page-tile__last-user-bubble" />
 	</router-link>
 </template>
 
 <script>
 import { mapState } from 'pinia'
 import { usePagesStore } from '../../../stores/pages.js'
-import LastUserBubble from '../../LastUserBubble.vue'
-import PageIcon from '../../Icon/PageIcon.vue'
 import { INDEX_PAGE } from '../../../constants.js'
+import moment from '@nextcloud/moment'
+
+import PageIcon from '../../Icon/PageIcon.vue'
+import { NcAvatar } from '@nextcloud/vue'
 
 export default {
 	name: 'RecentPageTile',
 	components: {
-		LastUserBubble,
+		NcAvatar,
 		PageIcon,
 	},
 
@@ -52,54 +58,64 @@ export default {
 				? t('collectives', 'Landing page')
 				: this.page.title
 		},
+
+		lastUpdate() {
+			return moment.unix(this.page.timestamp).fromNow()
+		},
 	},
 }
 </script>
 
 <style lang="scss" scoped>
 .recent-page-tile {
+	display: flex;
+	flex-direction: column;
+	height: 144px;
+	width: 144px;
 	margin-right: 12px;
-	max-width: 150px;
-	box-sizing: content-box !important;
-	padding: 12px;
 
 	scroll-snap-align: start;
+	background-color: var(--color-primary-element-light);
 	border-radius: var(--border-radius-large);
 
 	&:hover {
 		background-color: var(--color-background-hover);
 	}
 
-	&__rectangle {
+	&__icon {
 		display: flex;
-		height: 150px;
-		width: 150px;
-
-		font-size: 36px;
+		height: 72px;
+		width: 144px;
 		align-items: center;
-		align-content: center;
 		justify-content: center;
-		background-color: var(--color-primary-element-light);
-		border-radius: var(--border-radius-large);
+	}
+
+	&__emoji {
+		font-size: 32px;
+	}
+
+	&__text {
+		padding: 12px;
 	}
 
 	&__title {
 		margin-top: 12px;
-		font-size: 20px;
+		font-weight: bold;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
 
-	&__last-user-bubble {
+	&__subtitle {
+		display: flex;
+		gap: 4px;
 		margin-top: 8px;
+		align-items: center;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-		display: flex;
-		flex-direction: column;
 
-		:deep(.timestamp) {
+		.timestamp {
 			color: var(--color-text-maxcontrast);
 		}
 	}

--- a/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
@@ -194,7 +194,6 @@ export default {
 		flex-direction: row;
 		gap: 12px;
 
-		overflow-x: auto;
 		scroll-snap-type: x mandatory;
 		// Hide scrollbar
 		scrollbar-width: none;

--- a/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
@@ -48,6 +48,7 @@ import { useRootStore } from '../../../stores/root.js'
 import { useCollectivesStore } from '../../../stores/collectives.js'
 import { usePagesStore } from '../../../stores/pages.js'
 import { showError } from '@nextcloud/dialogs'
+
 import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
 import ChevronLeftIcon from 'vue-material-design-icons/ChevronLeft.vue'
 import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'

--- a/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
@@ -193,7 +193,8 @@ export default {
 		display: flex;
 		flex-direction: row;
 		gap: 12px;
-
+		padding: 8px;
+		margin: -8px;
 		overflow-x: auto;
 		scroll-snap-type: x mandatory;
 		// Hide scrollbar

--- a/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
@@ -188,7 +188,6 @@ export default {
 
 .recent-pages-widget-container {
 	position: relative;
-	padding-top: 12px;
 
 	.recent-pages-widget-pages {
 		display: flex;

--- a/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
@@ -132,7 +132,7 @@ export default {
 			if (!pagesliderEl) {
 				return
 			}
-			if (pagesliderEl.scrollLeft <= 0) {
+			if (pagesliderEl.scrollLeft <= 8) {
 				this.$refs.buttonslideleft.classList.add('hidden')
 			} else {
 				this.$refs.buttonslideleft.classList.remove('hidden')
@@ -197,6 +197,7 @@ export default {
 		margin: -8px;
 		overflow-x: auto;
 		scroll-snap-type: x mandatory;
+		scroll-padding-inline-start: 8px;
 		// Hide scrollbar
 		scrollbar-width: none;
 		-ms-overflow-style: none;
@@ -211,13 +212,13 @@ export default {
 	width: fit-content;
 	height: 100%;
 	display: flex;
-	right: 0;
+	right: -8px;
 	top: 0;
 	padding: 0;
 	margin: 0 !important;
 
 	&__left {
-		left: 0;
+		left: -8px;
 		justify-content: left;
 		background: linear-gradient(to left, rgba(0, 0, 0, 0), var(--color-main-background));
 
@@ -227,7 +228,7 @@ export default {
 	}
 
 	&__right {
-		right: 0;
+		right: -8px;
 		justify-content: right;
 		background: linear-gradient(to right, rgba(0, 0, 0, 0), var(--color-main-background));
 

--- a/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPagesWidget.vue
@@ -194,6 +194,7 @@ export default {
 		flex-direction: row;
 		gap: 12px;
 
+		overflow-x: auto;
 		scroll-snap-type: x mandatory;
 		// Hide scrollbar
 		scrollbar-width: none;

--- a/src/components/Page/LandingPageWidgets/WidgetHeading.vue
+++ b/src/components/Page/LandingPageWidgets/WidgetHeading.vue
@@ -25,8 +25,7 @@ export default {
 <style lang="scss" scoped>
 .widget-heading {
 	padding: 24px 0 12px 0;
-	font-size: 20px;
 	font-weight: bold;
-	color: var(--color-text-maxcontrast);
+	color: var(--color-main-text);
 }
 </style>

--- a/src/stores/collectives.js
+++ b/src/stores/collectives.js
@@ -347,6 +347,11 @@ export const useCollectivesStore = defineStore('collectives', {
 			this.patchCollectiveWithProperty({ id, property: 'userPageOrder', value: pageOrder })
 		},
 
+		async setCollectiveUserSettingShowMembers({ id, showMembers }) {
+			this.patchCollectiveWithProperty({ id, property: 'userShowMembers', value: showMembers })
+			await api.setCollectiveUserSettingShowMembers(id, showMembers)
+		},
+
 		async setCollectiveUserSettingShowRecentPages({ id, showRecentPages }) {
 			this.patchCollectiveWithProperty({ id, property: 'userShowRecentPages', value: showRecentPages })
 			await api.setCollectiveUserSettingShowRecentPages(id, showRecentPages)

--- a/tests/Unit/Db/CollectiveUserSettingsTest.php
+++ b/tests/Unit/Db/CollectiveUserSettingsTest.php
@@ -68,6 +68,13 @@ class CollectiveUserSettingsTest extends TestCase {
 		$settings->setPageOrder(max($pageOrders) + 1);
 	}
 
+	public function testSetShowMembers(): void {
+		$settings = new CollectiveUserSettings();
+		self::assertEquals(null, $settings->getSetting('show_members'));
+		$settings->setShowMembers(true);
+		self::assertEquals(true, $settings->getSetting('show_members'));
+	}
+
 	public function testSetShowRecentPages(): void {
 		$settings = new CollectiveUserSettings();
 		self::assertEquals(null, $settings->getSetting('show_recent_pages'));

--- a/tests/Unit/Service/CollectiveServiceTest.php
+++ b/tests/Unit/Service/CollectiveServiceTest.php
@@ -220,6 +220,7 @@ class CollectiveServiceTest extends TestCase {
 			'sharePageId' => 0,
 			'shareEditable' => false,
 			'userPageOrder' => 0,
+			'userShowMembers' => true,
 			'userShowRecentPages' => true,
 			'userFavoritePages' => [],
 			'canLeave' => true,


### PR DESCRIPTION
* fix(LandingPage): Hide recent pages widget if less than four pages
* fix(LandingPageWidgets): Show team overview button only with >1 member
* fix(MembersWidget): Use clearer icons for the members list button
* refactor(LandingPage): Move team overview button into MembersWidget.vue
* feat(LandingPage): Add members widget caption and allow to toggle visibility
* fix(WidgetHeading): Use smaller font size and main text color
* fix(RecentPages): Use more condensed layout for tiles
* Fixes: #1698
* Fixes: #1745

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/user-attachments/assets/320e87ee-ba6a-41a9-8e01-4f4f4e770312) | ![image](https://github.com/user-attachments/assets/638c8c38-f2ae-491e-a964-3cd7e100be05)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
