### PR TITLE
Page list sorting fixes

### DIFF
--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -386,13 +386,22 @@ class PageService {
 				continue;
 			}
 
-			// Get page infos of subfolders
-			if ($recurse && $node instanceof Folder) {
-				try {
-					array_push($subPageInfos, ...$this->getPagesFromFolder($collectiveId, $node, $userId, true));
-				} catch (NotFoundException) {
-					// If parent folder doesn't have an index page, `getPagesFromFolder()` throws NotFoundException even though having subpages.
-					$hasPages = true;
+			if ($node instanceof Folder) {
+				if ($recurse) {
+					// Recursive: get subpage infos from folder
+					try {
+						array_push($subPageInfos, ...$this->getPagesFromFolder($collectiveId, $node, $userId, true));
+					} catch (NotFoundException) {
+						// If parent folder doesn't have an index page, `getPagesFromFolder()` throws NotFoundException even though having subpages.
+						$hasPages = true;
+					}
+				} else {
+					// Not recursive: get index page of folder, as the folder is not to be processed
+					try {
+						$subPageInfos[] = $this->getPageByFile(self::getIndexPageFile($node), $node);
+					} catch (NotFoundException) {
+						// Ignore subfolders without index page
+					}
 				}
 			} elseif ($node instanceof File && NodeHelper::isPage($node)) {
 				$hasPages = true;

--- a/src/mixins/pageMixin.js
+++ b/src/mixins/pageMixin.js
@@ -62,19 +62,17 @@ export default {
 			}
 			try {
 				await this.createPage(page)
-				this.$router.push(this.newPagePath)
-				this.expand(parentId)
-				this.$nextTick(() => scrollToPage(this.newPageId))
-
-				// Parents location changes when the first subpage is created.
-				this.getPages(false)
 			} catch (e) {
 				console.error(e)
 				showError(t('collectives', 'Could not create the page'))
 			}
 
-			// Append new page to parent page subpageOrder
-			this.addToSubpageOrder({ parentId, pageId: this.newPageId })
+			this.$router.push(this.newPagePath)
+			this.expand(parentId)
+			this.$nextTick(() => scrollToPage(this.newPageId))
+
+			// Parents location changes when the first subpage is created.
+			this.getPages(false)
 		},
 
 		/**

--- a/src/stores/pages.js
+++ b/src/stores/pages.js
@@ -339,7 +339,7 @@ export const usePagesStore = defineStore('pages', {
 		 * @param {object} object parameters object
 		 * @param {number} object.parentId ID of the parent page
 		 * @param {number} object.pageId ID of the page to remove
-		 * @param {number} object.newIndex New index for pageId (prepend by default)
+		 * @param {number|undefined} object.newIndex New index for pageId (prepend by default)
 		 */
 		addToSubpageOrder({ parentId, pageId, newIndex = 0 }) {
 			// Get current subpage order of parentId
@@ -462,7 +462,9 @@ export const usePagesStore = defineStore('pages', {
 
 			const response = await api.createPage(this.context, page)
 			// Add new page to the beginning of pages array
-			this.pages.unshift(response.data.data)
+			const newPage = response.data.data
+			this.pages.unshift(newPage)
+			this.addToSubpageOrder({ parentId: newPage.parentId, pageId: newPage.id })
 			this.newPage = response.data.data
 		},
 

--- a/src/stores/pages.js
+++ b/src/stores/pages.js
@@ -329,6 +329,42 @@ export const usePagesStore = defineStore('pages', {
 			}
 		},
 
+		/**
+		 * Add pageId to subpageOrder of parent page at specified index (only in frontend store)
+		 * If no index is provided, add to the beginning of the list.
+		 *
+		 * Build subpageOrder of parent page to maintain the displayed order. If no subpageOrder
+		 * was stored before or it missed pages, pages would jump around otherwise.
+		 *
+		 * @param {object} object parameters object
+		 * @param {number} object.parentId ID of the parent page
+		 * @param {number} object.pageId ID of the page to remove
+		 * @param {number} object.newIndex New index for pageId (prepend by default)
+		 */
+		addToSubpageOrder({ parentId, pageId, newIndex = 0 }) {
+			// Get current subpage order of parentId
+			const subpageOrder = this.sortedSubpages(parentId, 'byOrder')
+				.map(p => p.id)
+				.filter(id => (id !== pageId))
+
+			// Add pageId to index position
+			subpageOrder.splice(newIndex, 0, pageId)
+
+			this.updateSubpageOrder({ parentId, subpageOrder })
+		},
+
+		/**
+		 * Delete pageId from subpageOrder of parent page (only in frontend store)
+		 *
+		 * @param {object} object parameters object
+		 * @param {number} object.parentId ID of the parent page
+		 * @param {number} object.pageId ID of the page to remove
+		 */
+		deleteFromSubpageOrder({ parentId, pageId }) {
+			const parentPage = this.pages.find(p => (p.id === parentId))
+			this.updateSubpageOrder({ parentId, subpageOrder: parentPage.subpageOrder.filter(id => (id !== pageId)) })
+		},
+
 		setPageOrder(order) {
 			this.sortBy = order
 		},


### PR DESCRIPTION
### 📝 Summary

* Page order was jumping in UI when a new page got created (frontend)
* Page order of pages with subpages was broken after creating a new subpage of their parent
* Resolves: #1360 

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
