### PR TITLE
fix(CollectiveMapper): Don't call `andX()` without parameters

### DIFF
--- a/lib/Db/CollectiveMapper.php
+++ b/lib/Db/CollectiveMapper.php
@@ -63,14 +63,15 @@ class CollectiveMapper extends QBMapper {
 	 */
 	public function findByCircleId(string $circleId, bool $includeTrash = false): ?Collective {
 		$qb = $this->db->getQueryBuilder();
-		$where = $qb->expr()->andX();
-		$where->add($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleId, IQueryBuilder::PARAM_STR)));
+		$andX = [
+			$qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleId, IQueryBuilder::PARAM_STR)),
+		];
 		if (!$includeTrash) {
-			$where->add($qb->expr()->isNull('trash_timestamp'));
+			$andX[] = $qb->expr()->isNull('trash_timestamp');
 		}
 		$qb->select('*')
 			->from($this->tableName)
-			->where($where);
+			->where($qb->expr()->andX(...$andX));
 		try {
 			return $this->findEntity($qb);
 		} catch (DoesNotExistException|MultipleObjectsReturnedException) {
@@ -82,14 +83,15 @@ class CollectiveMapper extends QBMapper {
 
 	public function findByCircleIds(array $circleIds, bool $includeTrash = false): array {
 		$qb = $this->db->getQueryBuilder();
-		$where = $qb->expr()->andX();
-		$where->add($qb->expr()->in('circle_unique_id', $qb->createNamedParameter($circleIds, IQueryBuilder::PARAM_STR_ARRAY)));
+		$andX = [
+			$qb->expr()->in('circle_unique_id', $qb->createNamedParameter($circleIds, IQueryBuilder::PARAM_STR_ARRAY)),
+		];
 		if (!$includeTrash) {
-			$where->add($qb->expr()->isNull('trash_timestamp'));
+			$andX[] = $qb->expr()->isNull('trash_timestamp');
 		}
 		$qb->select('*')
 			->from($this->tableName)
-			->where($where);
+			->where($qb->expr()->andX(...$andX));
 		try {
 			return $this->findEntities($qb);
 		} catch (Exception $e) {
@@ -104,12 +106,13 @@ class CollectiveMapper extends QBMapper {
 	 */
 	public function findTrashByCircleIdsAndUser(array $circleIds, string $userId): array {
 		$qb = $this->db->getQueryBuilder();
-		$where = $qb->expr()->andX();
-		$where->add($qb->expr()->in('circle_unique_id', $qb->createNamedParameter($circleIds, IQueryBuilder::PARAM_STR_ARRAY)));
-		$where->add($qb->expr()->isNotNull('trash_timestamp'));
+		$andX = [
+			$qb->expr()->in('circle_unique_id', $qb->createNamedParameter($circleIds, IQueryBuilder::PARAM_STR_ARRAY)),
+			$qb->expr()->isNotNull('trash_timestamp'),
+		];
 		$qb->select('*')
 			->from($this->tableName)
-			->where($where);
+			->where($qb->expr()->andX(...$andX));
 		try {
 			$collectives = $this->findEntities($qb);
 		} catch (Exception $e) {
@@ -126,12 +129,13 @@ class CollectiveMapper extends QBMapper {
 	 */
 	public function findByIdAndUser(int $id, ?string $userId = null): ?Collective {
 		$qb = $this->db->getQueryBuilder();
-		$where = $qb->expr()->andX();
-		$where->add($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-		$where->add($qb->expr()->isNull('trash_timestamp'));
+		$andX = [
+			$qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)),
+			$qb->expr()->isNull('trash_timestamp'),
+		];
 		$qb->select('*')
 			->from($this->tableName)
-			->where($where);
+			->where($qb->expr()->andX(...$andX));
 		return $this->findBy($qb, $userId);
 	}
 
@@ -142,12 +146,13 @@ class CollectiveMapper extends QBMapper {
 	 */
 	public function findTrashByIdAndUser(int $id, string $userId): ?Collective {
 		$qb = $this->db->getQueryBuilder();
-		$where = $qb->expr()->andX();
-		$where->add($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-		$where->add($qb->expr()->isNotNull('trash_timestamp'));
+		$andX = [
+			$qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)),
+			$qb->expr()->isNotNull('trash_timestamp'),
+		];
 		$qb->select('*')
 			->from($this->tableName)
-			->where($where);
+			->where($qb->expr()->andX(...$andX));
 		return $this->findBy($qb, $userId, Member::LEVEL_ADMIN);
 	}
 

--- a/lib/Db/CollectiveShareMapper.php
+++ b/lib/Db/CollectiveShareMapper.php
@@ -43,12 +43,13 @@ class CollectiveShareMapper extends QBMapper {
 	 */
 	public function findByCollectiveIdAndUser(int $collectiveId, string $userId): array {
 		$qb = $this->db->getQueryBuilder();
-		$where = $qb->expr()->andX();
-		$where->add($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId, IQueryBuilder::PARAM_INT)));
-		$where->add($qb->expr()->eq('owner', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)));
+		$andX = [
+			$qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId, IQueryBuilder::PARAM_INT)),
+			$qb->expr()->eq('owner', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)),
+		];
 		$qb->select('*')
 			->from($this->tableName)
-			->where($where);
+			->where($qb->expr()->andX(...$andX));
 		return $this->findEntities($qb);
 	}
 
@@ -59,13 +60,14 @@ class CollectiveShareMapper extends QBMapper {
 	 */
 	public function findOneByCollectiveIdAndUser(int $collectiveId, int $pageId, string $userId): CollectiveShare {
 		$qb = $this->db->getQueryBuilder();
-		$where = $qb->expr()->andX();
-		$where->add($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId, IQueryBuilder::PARAM_INT)));
-		$where->add($qb->expr()->eq('page_id', $qb->createNamedParameter($pageId, IQueryBuilder::PARAM_INT)));
-		$where->add($qb->expr()->eq('owner', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)));
+		$andX = [
+			$qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId, IQueryBuilder::PARAM_INT)),
+			$qb->expr()->eq('page_id', $qb->createNamedParameter($pageId, IQueryBuilder::PARAM_INT)),
+			$qb->expr()->eq('owner', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)),
+		];
 		$qb->select('*')
 			->from($this->tableName)
-			->where($where);
+			->where($qb->expr()->andX(...$andX));
 		return $this->findEntity($qb);
 	}
 
@@ -91,14 +93,15 @@ class CollectiveShareMapper extends QBMapper {
 	 */
 	public function findOneByCollectiveIdAndTokenAndUser(int $collectiveId, int $pageId, string $token, string $userId): CollectiveShare {
 		$qb = $this->db->getQueryBuilder();
-		$where = $qb->expr()->andX();
-		$where->add($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId, IQueryBuilder::PARAM_INT)));
-		$where->add($qb->expr()->eq('page_id', $qb->createNamedParameter($pageId, IQueryBuilder::PARAM_INT)));
-		$where->add($qb->expr()->eq('token', $qb->createNamedParameter($token, IQueryBuilder::PARAM_STR)));
-		$where->add($qb->expr()->eq('owner', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)));
+		$andX = [
+			$qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId, IQueryBuilder::PARAM_INT)),
+			$qb->expr()->eq('page_id', $qb->createNamedParameter($pageId, IQueryBuilder::PARAM_INT)),
+			$qb->expr()->eq('token', $qb->createNamedParameter($token, IQueryBuilder::PARAM_STR)),
+			$qb->expr()->eq('owner', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)),
+		];
 		$qb->select('*')
 			->from($this->tableName)
-			->where($where);
+			->where($qb->expr()->andX(...$andX));
 		return $this->findEntity($qb);
 	}
 

--- a/lib/Db/CollectiveUserSettingsMapper.php
+++ b/lib/Db/CollectiveUserSettingsMapper.php
@@ -63,12 +63,13 @@ class CollectiveUserSettingsMapper extends QBMapper {
 	 */
 	public function findByCollectiveAndUser(int $collectiveId, string $userId): ?CollectiveUserSettings {
 		$qb = $this->db->getQueryBuilder();
-		$where = $qb->expr()->andX();
-		$where->add($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId, IQueryBuilder::PARAM_INT)));
-		$where->add($qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)));
+		$andX = [
+			$qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId, IQueryBuilder::PARAM_INT)),
+			$qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)),
+		];
 		$qb->select('*')
 			->from($this->tableName)
-			->where($where);
+			->where($qb->expr()->andX(...$andX));
 		try {
 			/** @var CollectiveUserSettings $this->findEntity($qb) */
 			return $this->findEntity($qb);

--- a/lib/Db/PageMapper.php
+++ b/lib/Db/PageMapper.php
@@ -63,16 +63,17 @@ class PageMapper extends QBMapper {
 
 	public function findByFileId(int $fileId, bool $trashed = false): ?Page {
 		$qb = $this->db->getQueryBuilder();
-		$where = $qb->expr()->andX();
-		$where->add($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+		$andX = [
+			$qb->expr()->eq('file_id', $qb->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)),
+		];
 		if ($trashed) {
-			$where->add($qb->expr()->isNotNull('trash_timestamp'));
+			$andX[] = $qb->expr()->isNotNull('trash_timestamp');
 		} else {
-			$where->add($qb->expr()->isNull('trash_timestamp'));
+			$andX[] = $qb->expr()->isNull('trash_timestamp');
 		}
 		$qb->select('*')
 			->from($this->tableName)
-			->where($where);
+			->where($qb->expr()->andX(...$andX));
 		try {
 			return $this->findEntity($qb);
 		} catch (DoesNotExistException|MultipleObjectsReturnedException) {


### PR DESCRIPTION
Fixes "Calling OCP\DB\QueryBuilder\IQueryBuilder::andX without parameters is deprecated and will throw soon."

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
