### PR TITLE
Templates follow-up fixes

### DIFF
--- a/src/components/PageList/NewPageDialog.vue
+++ b/src/components/PageList/NewPageDialog.vue
@@ -54,7 +54,7 @@ export default {
 
 	computed: {
 		...mapState(usePagesStore, ['newPageParentId']),
-		...mapState(useTemplatesStore, ['templates']),
+		...mapState(useTemplatesStore, ['sortedTemplates']),
 
 		templateList() {
 			return [
@@ -63,7 +63,7 @@ export default {
 					id: null,
 					title: t('collectives', 'Blank page'),
 				},
-				...this.templates,
+				...this.sortedTemplates,
 			]
 		},
 

--- a/src/components/PageList/NewPageDialog.vue
+++ b/src/components/PageList/NewPageDialog.vue
@@ -137,6 +137,8 @@ export default {
 	justify-content: center;
 
 	.template-item {
+		// Leave enough space for long titles that take two lines
+		height: 220px;
 		display: flex;
 
 		&-link {
@@ -167,6 +169,13 @@ export default {
 		&-title {
 			max-width: calc(var(--icon-size) + 2 * var(--icon-border));
 			padding: calc(var(--icon-gap) / 2);
+
+			// Ellipsize long titles after two lines
+			overflow: hidden;
+			display: -webkit-box;
+			line-clamp: 2;
+			-webkit-line-clamp: 2;
+			-webkit-box-orient: vertical;
 		}
 	}
 }

--- a/src/stores/templates.js
+++ b/src/stores/templates.js
@@ -8,6 +8,7 @@ import { useRootStore } from './root.js'
 import { useCollectivesStore } from './collectives.js'
 import { usePagesStore } from './pages.js'
 import * as api from '../apis/collectives/index.js'
+import { byTitle } from '../util/sortOrders.js'
 import { TEMPLATE_PAGE } from '../constants.js'
 
 export const useTemplatesStore = defineStore('templates', {
@@ -27,6 +28,10 @@ export const useTemplatesStore = defineStore('templates', {
 			}
 		},
 
+		sortedTemplates(state) {
+			return state.templates.sort(byTitle)
+		},
+
 		hasTemplates(state) {
 			return state.templates.length > 0
 		},
@@ -44,14 +49,15 @@ export const useTemplatesStore = defineStore('templates', {
 		},
 
 		rootTemplates(state) {
-			return state.templates.filter(template => template.parentId === state.rootTemplateId)
+			return state.sortedTemplates
+				.filter(template => template.parentId === state.rootTemplateId)
 		},
 
 		currentPageFilePath(state) {
 			return state.pageFilePath(state.currentPage)
 		},
 
-		templateFilePath: (state) => (template) => {
+		templateFilePath: (_state) => (template) => {
 			const pagesStore = usePagesStore()
 			return pagesStore.pageFilePath(template)
 		},


### PR DESCRIPTION
### 📝 Summary

* fix(templates): Always sort templates alphabetically by title
* fix(NewPageDialog): Ellipsize long template titles after two lines
* Resolves: #1760 

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/user-attachments/assets/f921e355-63c9-4d51-a535-5093c31ac931) | ![grafik](https://github.com/user-attachments/assets/e87ae8ec-8556-4fae-8dcb-51a16f6882c6)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
