### PR TITLE
enh(store): store pages, shares and templates for all collectives

### DIFF
--- a/src/components/Collective.vue
+++ b/src/components/Collective.vue
@@ -84,7 +84,6 @@ export default {
 			this.load('collective')
 			this.unsetPages()
 			this.unsetTrashPages()
-			this.unsetShares()
 			this.unsetTemplates()
 			this.clearListenPush()
 			if (val) {
@@ -119,7 +118,7 @@ export default {
 
 	methods: {
 		...mapActions(useRootStore, ['hide', 'load', 'show']),
-		...mapActions(useSharesStore, ['getShares', 'unsetShares']),
+		...mapActions(useSharesStore, ['getShares']),
 		...mapActions(useTemplatesStore, ['getTemplates', 'unsetTemplates']),
 		...mapActions(usePagesStore, ['getPages', 'getTrashPages', 'unsetPages', 'unsetTrashPages']),
 		...mapActions(useVersionsStore, ['selectVersion']),


### PR DESCRIPTION
### 📝 Summary

* Resolves: #1791 

This will allow switching back to a previously opened collective instantaneously.


### 🚧 TODO

- [x] shares
- [ ] pages
- [ ] templates
- [ ] use setup stores 

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
