### PR TITLE
fix(ci): Cache appstore repository in Github workflow

### DIFF
--- a/.github/workflows/app-upgrade-mysql.yml
+++ b/.github/workflows/app-upgrade-mysql.yml
@@ -96,6 +96,37 @@ jobs:
           path: apps/viewer
           ref: ${{ matrix.server-versions }}
 
+      - name: Save current date and hour for the cache key
+        run: echo "DATE_HOUR=$(date +"%Y-%m-%d-%H")" >> $GITHUB_ENV
+
+      - name: Restore appstore apps.json
+        id: cache_appstore_apps
+        uses: actions/cache@v4
+        with:
+          path: 'apps.json'
+          key: 'appstore_apps_${{ env.DATE_HOUR }}'
+
+      - name: Fetch appstore repository
+        if: ${{ steps.cache_appstore_apps.outputs.cache-hit != 'true' }}
+        id: appstore_apps
+        run: curl -fL -o 'apps.json' https://apps.nextcloud.com/api/v1/apps.json
+
+      - name: Get collectives app from app store
+        id: collectives-app
+        uses: mejo-/nextcloud-appstore-action@1873692fd1b3c198b3c57280462ed6ac7d6dde0a # v1.0.0
+        with:
+          appid: collectives
+
+      - name: Fetch collectives release tarball
+        run: |
+          curl -fL -o '${{ runner.temp }}/collectives.tar.gz' '${{ steps.collectives-app.outputs.download }}'
+
+      - name: Unpack collectives release tarball
+        run: |
+          cd apps
+          tar -xzf '${{ runner.temp }}/collectives.tar.gz'
+          cd ..
+
       - name: Set up php ${{ matrix.php-versions }}
         uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a # v2
         with:
@@ -112,7 +143,7 @@ jobs:
           echo "SET GLOBAL sql_mode=(SELECT CONCAT(@@sql_mode,',ONLY_FULL_GROUP_BY'));" | mysql -h 127.0.0.1 -P 4444 -u root -prootpassword
           echo "SELECT @@sql_mode;" | mysql -h 127.0.0.1 -P 4444 -u root -prootpassword
 
-      - name: Set up Nextcloud, enable collectives from app store and remove collectives
+      - name: Set up Nextcloud, enable downloaded collectives and remove collectives
         env:
           DB_PORT: 4444
         run: |

--- a/.github/workflows/app-upgrade-postgres.yml
+++ b/.github/workflows/app-upgrade-postgres.yml
@@ -98,6 +98,37 @@ jobs:
           path: apps/viewer
           ref: ${{ matrix.server-versions }}
 
+      - name: Save current date and hour for the cache key
+        run: echo "DATE_HOUR=$(date +"%Y-%m-%d-%H")" >> $GITHUB_ENV
+
+      - name: Restore appstore apps.json
+        id: cache_appstore_apps
+        uses: actions/cache@v4
+        with:
+          path: 'apps.json'
+          key: 'appstore_apps_${{ env.DATE_HOUR }}'
+
+      - name: Fetch appstore repository
+        if: ${{ steps.cache_appstore_apps.outputs.cache-hit != 'true' }}
+        id: appstore_apps
+        run: curl -fL -o 'apps.json' https://apps.nextcloud.com/api/v1/apps.json
+
+      - name: Get collectives app from app store
+        id: collectives-app
+        uses: mejo-/nextcloud-appstore-action@1873692fd1b3c198b3c57280462ed6ac7d6dde0a # v1.0.0
+        with:
+          appid: collectives
+
+      - name: Fetch collectives release tarball
+        run: |
+          curl -fL -o '${{ runner.temp }}/collectives.tar.gz' '${{ steps.collectives-app.outputs.download }}'
+
+      - name: Unpack collectives release tarball
+        run: |
+          cd apps
+          tar -xzf '${{ runner.temp }}/collectives.tar.gz'
+          cd ..
+
       - name: Set up php ${{ matrix.php-versions }}
         uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a # v2
         with:
@@ -109,7 +140,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Nextcloud, enable collectives from app store and remove collectives
+      - name: Set up Nextcloud, enable downloaded collectives and remove collectives
         env:
           DB_PORT: 4444
         run: |

--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -62,6 +62,11 @@ jobs:
     strategy:
       matrix:
         server-versions: ['stable29', 'master']
+        include:
+          - server-versions: 'stable29'
+            server-major: '29'
+          - server-versions: 'master'
+            server-major: ''
 
     env:
       PUPPETEER_SKIP_DOWNLOAD: true
@@ -127,6 +132,38 @@ jobs:
           repository: nextcloud/viewer
           path: apps/viewer
           ref: ${{ matrix.server-versions }}
+
+      - name: Save current date and hour for the cache key
+        run: echo "DATE_HOUR=$(date +"%Y-%m-%d-%H")" >> $GITHUB_ENV
+
+      - name: Restore appstore apps.json
+        id: cache_appstore_apps
+        uses: actions/cache@v4
+        with:
+          path: 'apps.json'
+          key: 'appstore_apps_${{ env.DATE_HOUR }}'
+
+      - name: Fetch appstore repository
+        if: ${{ steps.cache_appstore_apps.outputs.cache-hit != 'true' }}
+        id: appstore_apps
+        run: curl -fL -o 'apps.json' https://apps.nextcloud.com/api/v1/apps.json
+
+      - name: Get contacts app from app store
+        id: contacts-app
+        uses: mejo-/nextcloud-appstore-action@1873692fd1b3c198b3c57280462ed6ac7d6dde0a # v1.0.0
+        with:
+          appid: contacts
+          server_major: ${{ matrix.server-major }}
+
+      - name: Fetch contacts release tarball
+        run: |
+          curl -fL -o '${{ runner.temp }}/contacts.tar.gz' '${{ steps.contacts-app.outputs.download }}'
+
+      - name: Unpack contacts release tarball
+        run: |
+          cd apps
+          tar -xzf '${{ runner.temp }}/contacts.tar.gz'
+          cd ..
 
       - name: Checkout app
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/psalm-migrations.yml
+++ b/.github/workflows/psalm-migrations.yml
@@ -27,23 +27,31 @@ jobs:
 
     name: static-psalm-analysis-migrations
     steps:
+      - name: Save current date and hour for the cache key
+        run: echo "DATE_HOUR=$(date +"%Y-%m-%d-%H")" >> $GITHUB_ENV
+
+      - name: Restore appstore apps.json
+        id: cache_appstore_apps
+        uses: actions/cache@v4
+        with:
+          path: 'apps.json'
+          key: 'appstore_apps_${{ env.DATE_HOUR }}'
+
       - name: Fetch appstore repository
+        if: ${{ steps.cache_appstore_apps.outputs.cache-hit != 'true' }}
         id: appstore_apps
-        run: curl -fL -o '${{ runner.temp }}/apps.json' https://apps.nextcloud.com/api/v1/apps.json
+        run: curl -fL -o 'apps.json' https://apps.nextcloud.com/api/v1/apps.json
 
-      - name: Setup jq
-        uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3
-
-      - name: Get latest app release version
-        id: app_release_version
-        run: |
-          echo -n 'version=' >> $GITHUB_OUTPUT
-          jq -r '.[] | select(.id == "${{ env.APP_NAME }}") | .releases | max_by(.version | split(".") | map(tonumber)) | .download | split("/")[-2]' ${{ runner.temp }}/apps.json >> $GITHUB_OUTPUT
+      - name: Get collectives app from app store
+        id: collectives-app
+        uses: mejo-/nextcloud-appstore-action@1873692fd1b3c198b3c57280462ed6ac7d6dde0a # v1.0.0
+        with:
+          appid: collectives
 
       - name: Checkout release tag
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ steps.app_release_version.outputs.version }}
+          ref: 'v${{ steps.collectives-app.outputs.version }}'
           persist-credentials: false
 
       - name: Checkout migrations from main branch


### PR DESCRIPTION
* Use current hour to only cache it for maximum one hour

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
