### PR TITLE
fix(PageList): Add bottom padding only to dragarea of top-level page list

### DIFF
--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -133,6 +133,7 @@
 
 			<!-- Unfiltered view page list -->
 			<Draggable v-else
+				class="page-list-dragarea"
 				:list="subpages"
 				:parent-id="rootPage.id"
 				:disable-sorting="isFilteredView">
@@ -482,6 +483,10 @@ li.toggle-button.selected {
 	flex-direction: column;
 	flex-grow: 1;
 	padding: 0 4px;
+}
+
+.page-list-dragarea {
+	padding-bottom: 20px;
 }
 
 .page-list-root-page {

--- a/src/components/PageList/Draggable.vue
+++ b/src/components/PageList/Draggable.vue
@@ -13,7 +13,6 @@
 		filter=".page-list-nodrag-item"
 		:sort="allowSorting"
 		:revert-on-spill="revertOnSpill"
-		class="page-list-dragarea"
 		:fallback-tolerance="5"
 		:animation="200"
 		:delay="500"
@@ -177,10 +176,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.page-list-dragarea {
-	padding-bottom: 20px;
-}
-
 // drag element in sortable.js lists
 :deep(.sortable-ghost) {
 	opacity: 0.7;


### PR DESCRIPTION
This amends #1808. With the former fix, every dragarea had a bottom padding, i.e. also the one from subpage lists.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
