### PR TITLE
fix(ci): bump php workflows

### DIFF
--- a/.github/workflows/lint-php-cs.yml
+++ b/.github/workflows/lint-php-cs.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer remove nextcloud/ocp --dev
+          composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
       - name: Lint

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -126,7 +126,7 @@ jobs:
         if: steps.check_composer.outputs.files_exists == 'true'
         working-directory: apps/${{ env.APP_NAME }}
         run: |
-          composer remove nextcloud/ocp --dev
+          composer remove nextcloud/ocp --dev --no-scripts
           composer i
 
       - name: Set up Nextcloud


### PR DESCRIPTION
Include changes from https://github.com/nextcloud/.github/pull/538
"Do not update dependencies in vendor-bin when removing nextcloud/ocp".

* Found when investigating #1821 failure.