### PR TITLE
fix(RecentPageTile): Correct semantics for hover

### DIFF
--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -96,12 +96,12 @@ export default {
 
 	scroll-snap-align: start;
 	border-radius: var(--border-radius-large);
-	box-shadow: 0 0 8px 0 var(--color-box-shadow);
+	box-shadow: 0 0 4px 0 var(--color-box-shadow);
 
 	padding: 8px;
 
 	&:hover {
-		box-shadow: 0 0 4px 0 var(--color-box-shadow);
+		box-shadow: 0 0 8px 0 var(--color-box-shadow);
 	}
 
 	&.dark {


### PR DESCRIPTION
### 📝 Summary

Objects which are hovered should float instead of pressing down, I'm guessing this was an oversight :)

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="167" alt="image" src="https://github.com/user-attachments/assets/00cb1077-a6bb-4b51-be34-6fae11b33a78" /> | <img width="167" alt="image" src="https://github.com/user-attachments/assets/56dd3370-6124-43b9-907b-5364da22024a" />


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
