### PR TITLE
fix: string validation fixes

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -315,7 +315,7 @@ Cypress.Commands.add('seedPage',
  */
 Cypress.Commands.add('seedPageContent', (pagePath, content) => {
 	const contentForLog = content.length > 200
-		? content.substring(0, 200) + '...'
+		? content.substring(0, 200) + '…'
 		: content
 	Cypress.log({ message: `${pagePath}, ${contentForLog}` })
 	cy.uploadContent(`Collectives/${pagePath}`, content)

--- a/l10n/ar.js
+++ b/l10n/ar.js
@@ -288,7 +288,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "مُلّاك الدائرة فقط لهم صلاحية حذفها",
     "Create collective for existing circle" : "أنشيء تجميعة لدائرة التواصل القائمة",
     "New collective name" : "اسم تجميعة جديدة",
-    "Select circle..." : "إختر دائرة اتصال Circle ...",
     "Create a new collective" : "إنشاء تجميعة جديدة",
     "Cancel creating a new collective" : "إلغاء عملية إنشاء تجميعة جديدة",
     "Link copied to the clipboard." : "تمّ نسخ الرابط إلى الحافظة",

--- a/l10n/ar.json
+++ b/l10n/ar.json
@@ -286,7 +286,6 @@
     "Only circle owners can delete a circle" : "مُلّاك الدائرة فقط لهم صلاحية حذفها",
     "Create collective for existing circle" : "أنشيء تجميعة لدائرة التواصل القائمة",
     "New collective name" : "اسم تجميعة جديدة",
-    "Select circle..." : "إختر دائرة اتصال Circle ...",
     "Create a new collective" : "إنشاء تجميعة جديدة",
     "Cancel creating a new collective" : "إلغاء عملية إنشاء تجميعة جديدة",
     "Link copied to the clipboard." : "تمّ نسخ الرابط إلى الحافظة",

--- a/l10n/bg.js
+++ b/l10n/bg.js
@@ -190,7 +190,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Само собствениците на кръгове могат да изтриват кръгове",
     "Create collective for existing circle" : "Създаване на колектив за съществуващ кръг",
     "New collective name" : "Име на нов колектив",
-    "Select circle..." : "Избор на кръг ...",
     "Create a new collective" : "Създаване на новия колектив",
     "Cancel creating a new collective" : "Отказ от създаване на новия колектив",
     "Link copied to the clipboard." : "Връзката е копирана в клипборда.",

--- a/l10n/bg.json
+++ b/l10n/bg.json
@@ -188,7 +188,6 @@
     "Only circle owners can delete a circle" : "Само собствениците на кръгове могат да изтриват кръгове",
     "Create collective for existing circle" : "Създаване на колектив за съществуващ кръг",
     "New collective name" : "Име на нов колектив",
-    "Select circle..." : "Избор на кръг ...",
     "Create a new collective" : "Създаване на новия колектив",
     "Cancel creating a new collective" : "Отказ от създаване на новия колектив",
     "Link copied to the clipboard." : "Връзката е копирана в клипборда.",

--- a/l10n/ca.js
+++ b/l10n/ca.js
@@ -256,7 +256,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Sols els propietaris d'un cercle poden suprimir un cercle",
     "Create collective for existing circle" : "Crear un Col·lectiu per al cercle existent",
     "New collective name" : "Nom del nou Col·lectiu",
-    "Select circle..." : "Seleccionar cercle...",
     "Create a new collective" : "Crear un nou col·lectiu",
     "Cancel creating a new collective" : "Cancel·la la creació d'un col·lectiu nou",
     "Link copied to the clipboard." : "S'ha copiat l'enllaç al porta-retalls.",

--- a/l10n/ca.json
+++ b/l10n/ca.json
@@ -254,7 +254,6 @@
     "Only circle owners can delete a circle" : "Sols els propietaris d'un cercle poden suprimir un cercle",
     "Create collective for existing circle" : "Crear un Col·lectiu per al cercle existent",
     "New collective name" : "Nom del nou Col·lectiu",
-    "Select circle..." : "Seleccionar cercle...",
     "Create a new collective" : "Crear un nou col·lectiu",
     "Cancel creating a new collective" : "Cancel·la la creació d'un col·lectiu nou",
     "Link copied to the clipboard." : "S'ha copiat l'enllaç al porta-retalls.",

--- a/l10n/cs.js
+++ b/l10n/cs.js
@@ -321,7 +321,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Okruh mohou smazat jen jeho vlastníci",
     "Create collective for existing circle" : "Vytvořit kolektiv pro existující okruh",
     "New collective name" : "Název pro nový kolektiv",
-    "Select circle..." : "Vybrat okruh…",
     "Create a new collective" : "Vytvořit nový kolektiv",
     "Cancel creating a new collective" : "Zrušit vytváření nového kolektivu",
     "Link copied to the clipboard." : "Odkaz na sdílení zkopírován do schránky.",

--- a/l10n/cs.json
+++ b/l10n/cs.json
@@ -319,7 +319,6 @@
     "Only circle owners can delete a circle" : "Okruh mohou smazat jen jeho vlastníci",
     "Create collective for existing circle" : "Vytvořit kolektiv pro existující okruh",
     "New collective name" : "Název pro nový kolektiv",
-    "Select circle..." : "Vybrat okruh…",
     "Create a new collective" : "Vytvořit nový kolektiv",
     "Cancel creating a new collective" : "Zrušit vytváření nového kolektivu",
     "Link copied to the clipboard." : "Odkaz na sdílení zkopírován do schránky.",

--- a/l10n/da.js
+++ b/l10n/da.js
@@ -285,7 +285,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Kun cirkelejere kan slette en cirkel",
     "Create collective for existing circle" : "Opret kollektiv for eksisterende cirkel",
     "New collective name" : "Nyt Kollektiv navn",
-    "Select circle..." : "Vælg cirkel...",
     "Create a new collective" : "Opret et nyt kollektiv",
     "Cancel creating a new collective" : "Annuller oprettelse af et nyt kollektiv",
     "Link copied to the clipboard." : "Linket er kopieret til udklipsholderen.",

--- a/l10n/da.json
+++ b/l10n/da.json
@@ -283,7 +283,6 @@
     "Only circle owners can delete a circle" : "Kun cirkelejere kan slette en cirkel",
     "Create collective for existing circle" : "Opret kollektiv for eksisterende cirkel",
     "New collective name" : "Nyt Kollektiv navn",
-    "Select circle..." : "Vælg cirkel...",
     "Create a new collective" : "Opret et nyt kollektiv",
     "Cancel creating a new collective" : "Annuller oprettelse af et nyt kollektiv",
     "Link copied to the clipboard." : "Linket er kopieret til udklipsholderen.",

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -321,7 +321,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Kreise können nur von ihren Besitzer:innen gelöscht werden",
     "Create collective for existing circle" : "Kollektiv für einen bestehenden Kreis anlegen",
     "New collective name" : "Name des neuen Kollektivs",
-    "Select circle..." : "Wähle Kreis …",
     "Create a new collective" : "Neues Kollektiv erstellen",
     "Cancel creating a new collective" : "Die Erstellung eines neuen Kollektivs abbrechen",
     "Link copied to the clipboard." : "Link in die Zwischenablage kopiert.",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -319,7 +319,6 @@
     "Only circle owners can delete a circle" : "Kreise können nur von ihren Besitzer:innen gelöscht werden",
     "Create collective for existing circle" : "Kollektiv für einen bestehenden Kreis anlegen",
     "New collective name" : "Name des neuen Kollektivs",
-    "Select circle..." : "Wähle Kreis …",
     "Create a new collective" : "Neues Kollektiv erstellen",
     "Cancel creating a new collective" : "Die Erstellung eines neuen Kollektivs abbrechen",
     "Link copied to the clipboard." : "Link in die Zwischenablage kopiert.",

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -321,7 +321,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Kreise können nur von ihren Besitzer:innen gelöscht werden",
     "Create collective for existing circle" : "Kollektiv für einen bestehenden Kreis anlegen",
     "New collective name" : "Name des neuen Kollektivs",
-    "Select circle..." : "Wähle Kreis…",
     "Create a new collective" : "Neues Kollektiv erstellen",
     "Cancel creating a new collective" : "Erstellung eines neuen Kollektivs abbrechen",
     "Link copied to the clipboard." : "Link in die Zwischenablage kopiert.",

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -319,7 +319,6 @@
     "Only circle owners can delete a circle" : "Kreise können nur von ihren Besitzer:innen gelöscht werden",
     "Create collective for existing circle" : "Kollektiv für einen bestehenden Kreis anlegen",
     "New collective name" : "Name des neuen Kollektivs",
-    "Select circle..." : "Wähle Kreis…",
     "Create a new collective" : "Neues Kollektiv erstellen",
     "Cancel creating a new collective" : "Erstellung eines neuen Kollektivs abbrechen",
     "Link copied to the clipboard." : "Link in die Zwischenablage kopiert.",

--- a/l10n/el.js
+++ b/l10n/el.js
@@ -273,7 +273,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Μόνο οι ιδιοκτήτες του κύκλου μπορούν να διαγράψουν έναν κύκλο",
     "Create collective for existing circle" : "Δημιουργία συλλογικότητας για υπάρχοντα κύκλο",
     "New collective name" : "Νέο όνομα συλλογικότητας",
-    "Select circle..." : "Επιλογή κύκλου...",
     "Create a new collective" : "Δημιουργία νέας συλλογικότητας",
     "Cancel creating a new collective" : "Ακύρωση δημιουργίας νέας συλλογικότητας",
     "Link copied to the clipboard." : "Ο σύνδεσμος αντιγράφηκε στο πρόχειρο.",

--- a/l10n/el.json
+++ b/l10n/el.json
@@ -271,7 +271,6 @@
     "Only circle owners can delete a circle" : "Μόνο οι ιδιοκτήτες του κύκλου μπορούν να διαγράψουν έναν κύκλο",
     "Create collective for existing circle" : "Δημιουργία συλλογικότητας για υπάρχοντα κύκλο",
     "New collective name" : "Νέο όνομα συλλογικότητας",
-    "Select circle..." : "Επιλογή κύκλου...",
     "Create a new collective" : "Δημιουργία νέας συλλογικότητας",
     "Cancel creating a new collective" : "Ακύρωση δημιουργίας νέας συλλογικότητας",
     "Link copied to the clipboard." : "Ο σύνδεσμος αντιγράφηκε στο πρόχειρο.",

--- a/l10n/en_GB.js
+++ b/l10n/en_GB.js
@@ -321,7 +321,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Only circle owners can delete a circle",
     "Create collective for existing circle" : "Create collective for existing circle",
     "New collective name" : "New collective name",
-    "Select circle..." : "Select circle...",
     "Create a new collective" : "Create a new collective",
     "Cancel creating a new collective" : "Cancel creating a new collective",
     "Link copied to the clipboard." : "Link copied to the clipboard.",

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -319,7 +319,6 @@
     "Only circle owners can delete a circle" : "Only circle owners can delete a circle",
     "Create collective for existing circle" : "Create collective for existing circle",
     "New collective name" : "New collective name",
-    "Select circle..." : "Select circle...",
     "Create a new collective" : "Create a new collective",
     "Cancel creating a new collective" : "Cancel creating a new collective",
     "Link copied to the clipboard." : "Link copied to the clipboard.",

--- a/l10n/es.js
+++ b/l10n/es.js
@@ -269,7 +269,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Solo los propietarios del círculo pueden borrarlo",
     "Create collective for existing circle" : "Crear cuaderno colectivo para círculo existente",
     "New collective name" : "Nombre del cuaderno colectivo nuevo",
-    "Select circle..." : "Seleccionar círculo...",
     "Create a new collective" : "Crear un cuaderno colectivo nuevo",
     "Cancel creating a new collective" : "Cancelar la creación del cuaderno colectivo nuevo",
     "Link copied to the clipboard." : "Enlace copiado al portapapeles.",

--- a/l10n/es.json
+++ b/l10n/es.json
@@ -267,7 +267,6 @@
     "Only circle owners can delete a circle" : "Solo los propietarios del círculo pueden borrarlo",
     "Create collective for existing circle" : "Crear cuaderno colectivo para círculo existente",
     "New collective name" : "Nombre del cuaderno colectivo nuevo",
-    "Select circle..." : "Seleccionar círculo...",
     "Create a new collective" : "Crear un cuaderno colectivo nuevo",
     "Cancel creating a new collective" : "Cancelar la creación del cuaderno colectivo nuevo",
     "Link copied to the clipboard." : "Enlace copiado al portapapeles.",

--- a/l10n/es_EC.js
+++ b/l10n/es_EC.js
@@ -191,7 +191,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Solo los propietarios del círculo pueden eliminarlo",
     "Create collective for existing circle" : "Crear colectivo para círculo existente",
     "New collective name" : "Nuevo nombre del colectivo",
-    "Select circle..." : "Seleccionar círculo...",
     "Create a new collective" : "Crear un nuevo colectivo",
     "Cancel creating a new collective" : "Cancelar la creación de un nuevo colectivo",
     "Link copied to the clipboard." : "Enlace copiado al portapapeles.",

--- a/l10n/es_EC.json
+++ b/l10n/es_EC.json
@@ -189,7 +189,6 @@
     "Only circle owners can delete a circle" : "Solo los propietarios del círculo pueden eliminarlo",
     "Create collective for existing circle" : "Crear colectivo para círculo existente",
     "New collective name" : "Nuevo nombre del colectivo",
-    "Select circle..." : "Seleccionar círculo...",
     "Create a new collective" : "Crear un nuevo colectivo",
     "Cancel creating a new collective" : "Cancelar la creación de un nuevo colectivo",
     "Link copied to the clipboard." : "Enlace copiado al portapapeles.",

--- a/l10n/et_EE.js
+++ b/l10n/et_EE.js
@@ -321,7 +321,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Tiimi saavad kustutada vaid tiimi omanikud",
     "Create collective for existing circle" : "Loo vabaühendus olemasoleva tiimi jaoks",
     "New collective name" : "Uue vabaühenduse nimi",
-    "Select circle..." : "Vali tiim...",
     "Create a new collective" : "Loo uus vabaühendus",
     "Cancel creating a new collective" : "Katkesta vabaühenduse loomine",
     "Link copied to the clipboard." : "Link on kopeeritud lõikelauale.",

--- a/l10n/et_EE.json
+++ b/l10n/et_EE.json
@@ -319,7 +319,6 @@
     "Only circle owners can delete a circle" : "Tiimi saavad kustutada vaid tiimi omanikud",
     "Create collective for existing circle" : "Loo vabaühendus olemasoleva tiimi jaoks",
     "New collective name" : "Uue vabaühenduse nimi",
-    "Select circle..." : "Vali tiim...",
     "Create a new collective" : "Loo uus vabaühendus",
     "Cancel creating a new collective" : "Katkesta vabaühenduse loomine",
     "Link copied to the clipboard." : "Link on kopeeritud lõikelauale.",

--- a/l10n/eu.js
+++ b/l10n/eu.js
@@ -259,7 +259,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Zirkulu-jabeek soilik ezabatu dezakete zirkulu bat",
     "Create collective for existing circle" : "Sortu kolektiboa existittzen den zirkulurako",
     "New collective name" : "Kolektibo izen berria",
-    "Select circle..." : "Hautatu zirkulua...",
     "Create a new collective" : "Sortu kolektibo berria",
     "Cancel creating a new collective" : "Utzi kolektibo berria sortzeari",
     "Link copied to the clipboard." : "Esteka arbelera kopiatu da.",

--- a/l10n/eu.json
+++ b/l10n/eu.json
@@ -257,7 +257,6 @@
     "Only circle owners can delete a circle" : "Zirkulu-jabeek soilik ezabatu dezakete zirkulu bat",
     "Create collective for existing circle" : "Sortu kolektiboa existittzen den zirkulurako",
     "New collective name" : "Kolektibo izen berria",
-    "Select circle..." : "Hautatu zirkulua...",
     "Create a new collective" : "Sortu kolektibo berria",
     "Cancel creating a new collective" : "Utzi kolektibo berria sortzeari",
     "Link copied to the clipboard." : "Esteka arbelera kopiatu da.",

--- a/l10n/fa.js
+++ b/l10n/fa.js
@@ -274,7 +274,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "تنها مالکان حلقه می‌توانند حلقه را پاک کنند",
     "Create collective for existing circle" : "ساخت انجمن برای حلقه موجود",
     "New collective name" : "نام انجمن جدید",
-    "Select circle..." : "انتخاب حلقه...",
     "Create a new collective" : "ساخت یک انجمن جدید",
     "Cancel creating a new collective" : "رد ساخت انجمن جدید",
     "Link copied to the clipboard." : "Link copied to the clipboard.",

--- a/l10n/fa.json
+++ b/l10n/fa.json
@@ -272,7 +272,6 @@
     "Only circle owners can delete a circle" : "تنها مالکان حلقه می‌توانند حلقه را پاک کنند",
     "Create collective for existing circle" : "ساخت انجمن برای حلقه موجود",
     "New collective name" : "نام انجمن جدید",
-    "Select circle..." : "انتخاب حلقه...",
     "Create a new collective" : "ساخت یک انجمن جدید",
     "Cancel creating a new collective" : "رد ساخت انجمن جدید",
     "Link copied to the clipboard." : "Link copied to the clipboard.",

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -303,7 +303,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Seuls les propriétaires de cercles peuvent supprimer un cercle",
     "Create collective for existing circle" : "Créer un collectif pour un cercle existant",
     "New collective name" : "Nom du nouveau collectif",
-    "Select circle..." : "Sélectionner un cercle…",
     "Create a new collective" : "Créer un nouveau collectif",
     "Cancel creating a new collective" : "Annuler la création d'un nouveau collectif",
     "Link copied to the clipboard." : "Lien copié dans le presse-papiers.",

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -301,7 +301,6 @@
     "Only circle owners can delete a circle" : "Seuls les propriétaires de cercles peuvent supprimer un cercle",
     "Create collective for existing circle" : "Créer un collectif pour un cercle existant",
     "New collective name" : "Nom du nouveau collectif",
-    "Select circle..." : "Sélectionner un cercle…",
     "Create a new collective" : "Créer un nouveau collectif",
     "Cancel creating a new collective" : "Annuler la création d'un nouveau collectif",
     "Link copied to the clipboard." : "Lien copié dans le presse-papiers.",

--- a/l10n/ga.js
+++ b/l10n/ga.js
@@ -317,7 +317,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Ní féidir ach le húinéirí ciorcail ciorcal a scriosadh",
     "Create collective for existing circle" : "Cruthaigh comhchoiteann don chiorcal atá ann cheana féin",
     "New collective name" : "Ainm comhchoiteann nua",
-    "Select circle..." : "Roghnaigh ciorcal...",
     "Create a new collective" : "Cruthaigh grúpa nua",
     "Cancel creating a new collective" : "Cealaigh cruthú comhchoiteann nua",
     "Link copied to the clipboard." : "Cóipeáladh an nasc chuig an ngearrthaisce.",

--- a/l10n/ga.json
+++ b/l10n/ga.json
@@ -315,7 +315,6 @@
     "Only circle owners can delete a circle" : "Ní féidir ach le húinéirí ciorcail ciorcal a scriosadh",
     "Create collective for existing circle" : "Cruthaigh comhchoiteann don chiorcal atá ann cheana féin",
     "New collective name" : "Ainm comhchoiteann nua",
-    "Select circle..." : "Roghnaigh ciorcal...",
     "Create a new collective" : "Cruthaigh grúpa nua",
     "Cancel creating a new collective" : "Cealaigh cruthú comhchoiteann nua",
     "Link copied to the clipboard." : "Cóipeáladh an nasc chuig an ngearrthaisce.",

--- a/l10n/gl.js
+++ b/l10n/gl.js
@@ -288,7 +288,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Só a propiedade dos círculos poden eliminar un círculo",
     "Create collective for existing circle" : "Creouse o colectivo para o círculo existente",
     "New collective name" : "Novo nome do colectivo",
-    "Select circle..." : "Seleccionar un círculo…",
     "Create a new collective" : "Crear un novo colectivo",
     "Cancel creating a new collective" : "Cancelar a creación dun novo colectivo",
     "Link copied to the clipboard." : "A ligazón foi copiada no portapapeis.",

--- a/l10n/gl.json
+++ b/l10n/gl.json
@@ -286,7 +286,6 @@
     "Only circle owners can delete a circle" : "Só a propiedade dos círculos poden eliminar un círculo",
     "Create collective for existing circle" : "Creouse o colectivo para o círculo existente",
     "New collective name" : "Novo nome do colectivo",
-    "Select circle..." : "Seleccionar un círculo…",
     "Create a new collective" : "Crear un novo colectivo",
     "Cancel creating a new collective" : "Cancelar a creación dun novo colectivo",
     "Link copied to the clipboard." : "A ligazón foi copiada no portapapeis.",

--- a/l10n/hu.js
+++ b/l10n/hu.js
@@ -223,7 +223,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Csak a körök tulajdonosai törölhetnek köröket",
     "Create collective for existing circle" : "Kollektíva létrehozása egy meglévő körhöz",
     "New collective name" : "Új kollektíva neve",
-    "Select circle..." : "Kör kiválasztása…",
     "Create a new collective" : "Új kollektíva létrehozása",
     "Cancel creating a new collective" : "Új kollektíva létrehozásának megszakítása",
     "Link copied to the clipboard." : "Hivatkozás a vágólapra másolva.",

--- a/l10n/hu.json
+++ b/l10n/hu.json
@@ -221,7 +221,6 @@
     "Only circle owners can delete a circle" : "Csak a körök tulajdonosai törölhetnek köröket",
     "Create collective for existing circle" : "Kollektíva létrehozása egy meglévő körhöz",
     "New collective name" : "Új kollektíva neve",
-    "Select circle..." : "Kör kiválasztása…",
     "Create a new collective" : "Új kollektíva létrehozása",
     "Cancel creating a new collective" : "Új kollektíva létrehozásának megszakítása",
     "Link copied to the clipboard." : "Hivatkozás a vágólapra másolva.",

--- a/l10n/it.js
+++ b/l10n/it.js
@@ -186,7 +186,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Solo i proprietari di una cerchia possono rimuoverla",
     "Create collective for existing circle" : "Crea un collettivo per una cerchia esistente",
     "New collective name" : "Nome del nuovo collettivo",
-    "Select circle..." : "Seleziona cerchia...",
     "Create a new collective" : "Crea un nuovo collettivo",
     "Cancel creating a new collective" : "Annulla la creazione di un nuovo collettivo",
     "Link copied to the clipboard." : "Collegamento copiato negli appunti.",

--- a/l10n/it.json
+++ b/l10n/it.json
@@ -184,7 +184,6 @@
     "Only circle owners can delete a circle" : "Solo i proprietari di una cerchia possono rimuoverla",
     "Create collective for existing circle" : "Crea un collettivo per una cerchia esistente",
     "New collective name" : "Nome del nuovo collettivo",
-    "Select circle..." : "Seleziona cerchia...",
     "Create a new collective" : "Crea un nuovo collettivo",
     "Cancel creating a new collective" : "Annulla la creazione di un nuovo collettivo",
     "Link copied to the clipboard." : "Collegamento copiato negli appunti.",

--- a/l10n/ja.js
+++ b/l10n/ja.js
@@ -141,7 +141,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "サークルの所有者のみがサークルを削除できます",
     "Create collective for existing circle" : "既存のサークルにコレクティブを作成",
     "New collective name" : "新規コレクティブの名称",
-    "Select circle..." : "サークルを選択...",
     "Link copied to the clipboard." : "クリップボードにリンクをコピーしました。",
     "New Page" : "新規ページ",
     "_%n byte_::_%n bytes_" : ["%n バイト"]

--- a/l10n/ja.json
+++ b/l10n/ja.json
@@ -139,7 +139,6 @@
     "Only circle owners can delete a circle" : "サークルの所有者のみがサークルを削除できます",
     "Create collective for existing circle" : "既存のサークルにコレクティブを作成",
     "New collective name" : "新規コレクティブの名称",
-    "Select circle..." : "サークルを選択...",
     "Link copied to the clipboard." : "クリップボードにリンクをコピーしました。",
     "New Page" : "新規ページ",
     "_%n byte_::_%n bytes_" : ["%n バイト"]

--- a/l10n/nb.js
+++ b/l10n/nb.js
@@ -286,7 +286,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Kun eiere av sirkler kan slette en sirkel",
     "Create collective for existing circle" : "Opprett kollektiv for eksisterende sirkel",
     "New collective name" : "Nytt navn på kollektiv",
-    "Select circle..." : "Velg sirkel …",
     "Create a new collective" : "Opprett et nytt kollektiv",
     "Cancel creating a new collective" : "Avbryt oppretting av nytt kollektiv",
     "Link copied to the clipboard." : "Kobling kopiert til utklippstavlen.",

--- a/l10n/nb.json
+++ b/l10n/nb.json
@@ -284,7 +284,6 @@
     "Only circle owners can delete a circle" : "Kun eiere av sirkler kan slette en sirkel",
     "Create collective for existing circle" : "Opprett kollektiv for eksisterende sirkel",
     "New collective name" : "Nytt navn på kollektiv",
-    "Select circle..." : "Velg sirkel …",
     "Create a new collective" : "Opprett et nytt kollektiv",
     "Cancel creating a new collective" : "Avbryt oppretting av nytt kollektiv",
     "Link copied to the clipboard." : "Kobling kopiert til utklippstavlen.",

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -301,7 +301,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Alleen kring eigenaren kunnen een kring verwijderen",
     "Create collective for existing circle" : "Collectief maken voor bestaande kring",
     "New collective name" : "Nieuwe naam collectief",
-    "Select circle..." : "Selecteer kring...",
     "Create a new collective" : "Een nieuw collectief maken",
     "Cancel creating a new collective" : "Aanmaken van een nieuw collectief annuleren",
     "Link copied to the clipboard." : "Link gekopieerd naar het klembord.",

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -299,7 +299,6 @@
     "Only circle owners can delete a circle" : "Alleen kring eigenaren kunnen een kring verwijderen",
     "Create collective for existing circle" : "Collectief maken voor bestaande kring",
     "New collective name" : "Nieuwe naam collectief",
-    "Select circle..." : "Selecteer kring...",
     "Create a new collective" : "Een nieuw collectief maken",
     "Cancel creating a new collective" : "Aanmaken van een nieuw collectief annuleren",
     "Link copied to the clipboard." : "Link gekopieerd naar het klembord.",

--- a/l10n/pl.js
+++ b/l10n/pl.js
@@ -218,7 +218,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Tylko właściciele kręgu mogą usunąć krąg",
     "Create collective for existing circle" : "Utwórz kolektyw dla istniejącego kręgu",
     "New collective name" : "Nowa nazwa kolektywu",
-    "Select circle..." : "Wybierz krąg...",
     "Create a new collective" : "Stwórz nowy kolektyw",
     "Cancel creating a new collective" : "Anuluj tworzenie nowego kolektywu",
     "Link copied to the clipboard." : "Łącze skopiowane do schowka.",

--- a/l10n/pl.json
+++ b/l10n/pl.json
@@ -216,7 +216,6 @@
     "Only circle owners can delete a circle" : "Tylko właściciele kręgu mogą usunąć krąg",
     "Create collective for existing circle" : "Utwórz kolektyw dla istniejącego kręgu",
     "New collective name" : "Nowa nazwa kolektywu",
-    "Select circle..." : "Wybierz krąg...",
     "Create a new collective" : "Stwórz nowy kolektyw",
     "Cancel creating a new collective" : "Anuluj tworzenie nowego kolektywu",
     "Link copied to the clipboard." : "Łącze skopiowane do schowka.",

--- a/l10n/pt_BR.js
+++ b/l10n/pt_BR.js
@@ -321,7 +321,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Apenas proprietários de círculos podem excluir um círculo",
     "Create collective for existing circle" : "Criar coletivo para círculo existente",
     "New collective name" : "Nome do novo coletivo",
-    "Select circle..." : "Selecionar círculo...",
     "Create a new collective" : "Criar um novo coletivo",
     "Cancel creating a new collective" : "Cancelar a criação do novo coletivo",
     "Link copied to the clipboard." : "Link copiado para a área de transferência.",

--- a/l10n/pt_BR.json
+++ b/l10n/pt_BR.json
@@ -319,7 +319,6 @@
     "Only circle owners can delete a circle" : "Apenas proprietários de círculos podem excluir um círculo",
     "Create collective for existing circle" : "Criar coletivo para círculo existente",
     "New collective name" : "Nome do novo coletivo",
-    "Select circle..." : "Selecionar círculo...",
     "Create a new collective" : "Criar um novo coletivo",
     "Cancel creating a new collective" : "Cancelar a criação do novo coletivo",
     "Link copied to the clipboard." : "Link copiado para a área de transferência.",

--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -180,7 +180,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Удалить круг могут только владельцы окружения",
     "Create collective for existing circle" : "Создать группу для существующего окружения",
     "New collective name" : "Новое название группы",
-    "Select circle..." : "Выбор окружения...",
     "Create a new collective" : "Создать новую группу",
     "Cancel creating a new collective" : "Отменить создание группы",
     "Link copied to the clipboard." : "Ссылка скопирована в буфер обмена.",

--- a/l10n/ru.json
+++ b/l10n/ru.json
@@ -178,7 +178,6 @@
     "Only circle owners can delete a circle" : "Удалить круг могут только владельцы окружения",
     "Create collective for existing circle" : "Создать группу для существующего окружения",
     "New collective name" : "Новое название группы",
-    "Select circle..." : "Выбор окружения...",
     "Create a new collective" : "Создать новую группу",
     "Cancel creating a new collective" : "Отменить создание группы",
     "Link copied to the clipboard." : "Ссылка скопирована в буфер обмена.",

--- a/l10n/sk.js
+++ b/l10n/sk.js
@@ -288,7 +288,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Kruh môžu odstrániť iba jeho vlastníci",
     "Create collective for existing circle" : "Vytvoriť kolektív pre existujúci kruh",
     "New collective name" : "Nový názov kolektívu",
-    "Select circle..." : "Vyberte kruh...",
     "Create a new collective" : "Vytvoriť nový kolektív",
     "Cancel creating a new collective" : "Zrušiť vytváranie nového kolektívu",
     "Link copied to the clipboard." : "Odkaz bol skopírovaný do schránky.",

--- a/l10n/sk.json
+++ b/l10n/sk.json
@@ -286,7 +286,6 @@
     "Only circle owners can delete a circle" : "Kruh môžu odstrániť iba jeho vlastníci",
     "Create collective for existing circle" : "Vytvoriť kolektív pre existujúci kruh",
     "New collective name" : "Nový názov kolektívu",
-    "Select circle..." : "Vyberte kruh...",
     "Create a new collective" : "Vytvoriť nový kolektív",
     "Cancel creating a new collective" : "Zrušiť vytváranie nového kolektívu",
     "Link copied to the clipboard." : "Odkaz bol skopírovaný do schránky.",

--- a/l10n/sl.js
+++ b/l10n/sl.js
@@ -194,7 +194,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Le lastnik kroga lahko krog izbriše.",
     "Create collective for existing circle" : "Ustvari zbirko za obstoječ krog",
     "New collective name" : "Ime nove zbirke",
-    "Select circle..." : "Izbor kroga ...",
     "Create a new collective" : "Ustvari novo zbirko",
     "Cancel creating a new collective" : "Prekliči ustvarjanje nove zbirke",
     "Link copied to the clipboard." : "Povezava je kopirana v odložišče.",

--- a/l10n/sl.json
+++ b/l10n/sl.json
@@ -192,7 +192,6 @@
     "Only circle owners can delete a circle" : "Le lastnik kroga lahko krog izbriše.",
     "Create collective for existing circle" : "Ustvari zbirko za obstoječ krog",
     "New collective name" : "Ime nove zbirke",
-    "Select circle..." : "Izbor kroga ...",
     "Create a new collective" : "Ustvari novo zbirko",
     "Cancel creating a new collective" : "Prekliči ustvarjanje nove zbirke",
     "Link copied to the clipboard." : "Povezava je kopirana v odložišče.",

--- a/l10n/sr.js
+++ b/l10n/sr.js
@@ -317,7 +317,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Круг могу да обришу само власници круга",
     "Create collective for existing circle" : "Креирај колектив за подтојећи круг",
     "New collective name" : "Нови назив колектива",
-    "Select circle..." : "Изаберите круг...",
     "Create a new collective" : "Креирај нови колектив",
     "Cancel creating a new collective" : "Откажи креирање новог колектива",
     "Link copied to the clipboard." : "Линк је копиран у клипборд",

--- a/l10n/sr.json
+++ b/l10n/sr.json
@@ -315,7 +315,6 @@
     "Only circle owners can delete a circle" : "Круг могу да обришу само власници круга",
     "Create collective for existing circle" : "Креирај колектив за подтојећи круг",
     "New collective name" : "Нови назив колектива",
-    "Select circle..." : "Изаберите круг...",
     "Create a new collective" : "Креирај нови колектив",
     "Cancel creating a new collective" : "Откажи креирање новог колектива",
     "Link copied to the clipboard." : "Линк је копиран у клипборд",

--- a/l10n/sv.js
+++ b/l10n/sv.js
@@ -315,7 +315,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Endast cirkelägare kan ta bort en cirkel",
     "Create collective for existing circle" : "Skapa collective för befintlig cirkel",
     "New collective name" : "Nytt namn för collective",
-    "Select circle..." : "Välj cirkel...",
     "Create a new collective" : "Skapa ett nytt collective",
     "Cancel creating a new collective" : "Avbryt skapande av nytt collective",
     "Link copied to the clipboard." : "Länken har kopierats till urklipp.",

--- a/l10n/sv.json
+++ b/l10n/sv.json
@@ -313,7 +313,6 @@
     "Only circle owners can delete a circle" : "Endast cirkelägare kan ta bort en cirkel",
     "Create collective for existing circle" : "Skapa collective för befintlig cirkel",
     "New collective name" : "Nytt namn för collective",
-    "Select circle..." : "Välj cirkel...",
     "Create a new collective" : "Skapa ett nytt collective",
     "Cancel creating a new collective" : "Avbryt skapande av nytt collective",
     "Link copied to the clipboard." : "Länken har kopierats till urklipp.",

--- a/l10n/ta.js
+++ b/l10n/ta.js
@@ -40,7 +40,6 @@ OC.L10N.register(
     "Copied" : "நகலெடுக்கப்பட்டது",
     "Cannot copy" : "நகலெடுக்க முடியாது",
     "Copy share link" : "பகிர்வு இணைப்பை நகலெடுக்கவும்",
-    "Select circle..." : "வட்டத்தைத் தேர்ந்தெடுக்கவும்...",
     "New Page" : "புதிய பக்கம்"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/ta.json
+++ b/l10n/ta.json
@@ -38,7 +38,6 @@
     "Copied" : "நகலெடுக்கப்பட்டது",
     "Cannot copy" : "நகலெடுக்க முடியாது",
     "Copy share link" : "பகிர்வு இணைப்பை நகலெடுக்கவும்",
-    "Select circle..." : "வட்டத்தைத் தேர்ந்தெடுக்கவும்...",
     "New Page" : "புதிய பக்கம்"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/tr.js
+++ b/l10n/tr.js
@@ -289,7 +289,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Bir takımı yalnızca sahipleri silebilir ",
     "Create collective for existing circle" : "Var olan takım için topluluk ekle",
     "New collective name" : "Yeni topluluğun adı",
-    "Select circle..." : "Takım seçin...",
     "Create a new collective" : "Yeni bir topluluk ekle",
     "Cancel creating a new collective" : "Yeni bir topluluk eklemekten vazgeç",
     "Link copied to the clipboard." : "Bağlantı panoya kopyalandı.",

--- a/l10n/tr.json
+++ b/l10n/tr.json
@@ -287,7 +287,6 @@
     "Only circle owners can delete a circle" : "Bir takımı yalnızca sahipleri silebilir ",
     "Create collective for existing circle" : "Var olan takım için topluluk ekle",
     "New collective name" : "Yeni topluluğun adı",
-    "Select circle..." : "Takım seçin...",
     "Create a new collective" : "Yeni bir topluluk ekle",
     "Cancel creating a new collective" : "Yeni bir topluluk eklemekten vazgeç",
     "Link copied to the clipboard." : "Bağlantı panoya kopyalandı.",

--- a/l10n/ug.js
+++ b/l10n/ug.js
@@ -287,7 +287,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "پەقەت چەمبىرەك ئىگىلىرىلا چەمبىرەكنى ئۆچۈرەلەيدۇ",
     "Create collective for existing circle" : "مەۋجۇت چەمبىرەك ئۈچۈن كوللىكتىپ قۇرۇش",
     "New collective name" : "يېڭى كوللىكتىپ ئىسمى",
-    "Select circle..." : "چەمبىرەكنى تاللاڭ ...",
     "Create a new collective" : "يېڭى كوللىكتىپ قۇرۇش",
     "Cancel creating a new collective" : "يېڭى كوللىكتىپ قۇرۇشنى ئەمەلدىن قالدۇرۇڭ",
     "Link copied to the clipboard." : "ئۇلىنىش چاپلاش تاختىسىغا كۆچۈرۈلدى.",

--- a/l10n/ug.json
+++ b/l10n/ug.json
@@ -285,7 +285,6 @@
     "Only circle owners can delete a circle" : "پەقەت چەمبىرەك ئىگىلىرىلا چەمبىرەكنى ئۆچۈرەلەيدۇ",
     "Create collective for existing circle" : "مەۋجۇت چەمبىرەك ئۈچۈن كوللىكتىپ قۇرۇش",
     "New collective name" : "يېڭى كوللىكتىپ ئىسمى",
-    "Select circle..." : "چەمبىرەكنى تاللاڭ ...",
     "Create a new collective" : "يېڭى كوللىكتىپ قۇرۇش",
     "Cancel creating a new collective" : "يېڭى كوللىكتىپ قۇرۇشنى ئەمەلدىن قالدۇرۇڭ",
     "Link copied to the clipboard." : "ئۇلىنىش چاپلاش تاختىسىغا كۆچۈرۈلدى.",

--- a/l10n/uk.js
+++ b/l10n/uk.js
@@ -230,7 +230,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "Тільки власники кола можуть його вилучити",
     "Create collective for existing circle" : "Створити колектив на базі наявного кола",
     "New collective name" : "Назва нового колективу",
-    "Select circle..." : "Вибрати коло...",
     "Create a new collective" : "Створити новий колектив",
     "Cancel creating a new collective" : "Скасувати створення нового колективу",
     "Link copied to the clipboard." : "Посилання скопійовано до буферу обміну.",

--- a/l10n/uk.json
+++ b/l10n/uk.json
@@ -228,7 +228,6 @@
     "Only circle owners can delete a circle" : "Тільки власники кола можуть його вилучити",
     "Create collective for existing circle" : "Створити колектив на базі наявного кола",
     "New collective name" : "Назва нового колективу",
-    "Select circle..." : "Вибрати коло...",
     "Create a new collective" : "Створити новий колектив",
     "Cancel creating a new collective" : "Скасувати створення нового колективу",
     "Link copied to the clipboard." : "Посилання скопійовано до буферу обміну.",

--- a/l10n/zh_CN.js
+++ b/l10n/zh_CN.js
@@ -253,7 +253,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "只有圈子所有者才能删除圈子",
     "Create collective for existing circle" : "为已有圈子创建知识库",
     "New collective name" : "新知识库名称",
-    "Select circle..." : "选择圈子 ...",
     "Create a new collective" : "创建新知识库",
     "Cancel creating a new collective" : "取消创建新知识库",
     "Link copied to the clipboard." : "已复制链接至剪贴板。",

--- a/l10n/zh_CN.json
+++ b/l10n/zh_CN.json
@@ -251,7 +251,6 @@
     "Only circle owners can delete a circle" : "只有圈子所有者才能删除圈子",
     "Create collective for existing circle" : "为已有圈子创建知识库",
     "New collective name" : "新知识库名称",
-    "Select circle..." : "选择圈子 ...",
     "Create a new collective" : "创建新知识库",
     "Cancel creating a new collective" : "取消创建新知识库",
     "Link copied to the clipboard." : "已复制链接至剪贴板。",

--- a/l10n/zh_HK.js
+++ b/l10n/zh_HK.js
@@ -321,7 +321,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "只有社交圈子所有者可以刪除社交圈子",
     "Create collective for existing circle" : "為現有社交圈子創建知識庫",
     "New collective name" : "新知識庫名稱",
-    "Select circle..." : "選擇社交圈子...",
     "Create a new collective" : "創建新知識庫",
     "Cancel creating a new collective" : "取消創建新知識庫",
     "Link copied to the clipboard." : "已複製連結至剪貼板",

--- a/l10n/zh_HK.json
+++ b/l10n/zh_HK.json
@@ -319,7 +319,6 @@
     "Only circle owners can delete a circle" : "只有社交圈子所有者可以刪除社交圈子",
     "Create collective for existing circle" : "為現有社交圈子創建知識庫",
     "New collective name" : "新知識庫名稱",
-    "Select circle..." : "選擇社交圈子...",
     "Create a new collective" : "創建新知識庫",
     "Cancel creating a new collective" : "取消創建新知識庫",
     "Link copied to the clipboard." : "已複製連結至剪貼板",

--- a/l10n/zh_TW.js
+++ b/l10n/zh_TW.js
@@ -317,7 +317,6 @@ OC.L10N.register(
     "Only circle owners can delete a circle" : "僅小圈圈擁有者可刪除小圈圈",
     "Create collective for existing circle" : "為既有的小圈圈建立知識庫",
     "New collective name" : "新知識庫名稱",
-    "Select circle..." : "選取小圈圈……",
     "Create a new collective" : "建立新知識庫",
     "Cancel creating a new collective" : "取消建立新知識庫",
     "Link copied to the clipboard." : "連結已複製到剪貼簿。",

--- a/l10n/zh_TW.json
+++ b/l10n/zh_TW.json
@@ -315,7 +315,6 @@
     "Only circle owners can delete a circle" : "僅小圈圈擁有者可刪除小圈圈",
     "Create collective for existing circle" : "為既有的小圈圈建立知識庫",
     "New collective name" : "新知識庫名稱",
-    "Select circle..." : "選取小圈圈……",
     "Create a new collective" : "建立新知識庫",
     "Cancel creating a new collective" : "取消建立新知識庫",
     "Link copied to the clipboard." : "連結已複製到剪貼簿。",

--- a/lib/Command/CreateCollective.php
+++ b/lib/Command/CreateCollective.php
@@ -53,7 +53,7 @@ class CreateCollective extends Command {
 		$this->userSession->setUser($user);
 		$lang = $this->l10nFactory->getUserLanguage($this->userSession->getUser());
 
-		$output->write('<info>Creating new collective ' . $name . ' ... </info>');
+		$output->write('<info>Creating new collective ' . $name . ' …</info>');
 
 		[, $info] = $this->collectiveService->createCollective($userId, $lang, $name);
 

--- a/lib/Command/ExpirePageVersions.php
+++ b/lib/Command/ExpirePageVersions.php
@@ -37,7 +37,7 @@ class ExpirePageVersions extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
-			$output->write('<info>Expiring old page versions ... </info>');
+			$output->write('<info>Expiring old page versions …</info>');
 			$this->expireManager->expireAll();
 			$output->writeln('<info>done</info>');
 			return 0;

--- a/lib/Command/IndexCollectives.php
+++ b/lib/Command/IndexCollectives.php
@@ -52,8 +52,9 @@ class IndexCollectives extends Command {
 				if ($name && $name !== $circleName) {
 					continue;
 				}
-				$output->writeln('<info>Creating index for ' . $circleName . ' ... </info>');
+				$output->write('<info>Creating index for ' . $circleName . ' …</info>');
 				$this->searchService->indexCollective($collective);
+				$output->writeln('<info>done</info>');
 			} catch (MissingDependencyException|NotFoundException|NotPermittedException) {
 				$output->writeln("<error>Failed to find team associated with collective with ID={$collective->getId()}</error>");
 				return 1;

--- a/lib/Command/PurgeObsoletePages.php
+++ b/lib/Command/PurgeObsoletePages.php
@@ -29,7 +29,7 @@ class PurgeObsoletePages extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$output->write('Start to purge cruft pages from database ...');
+		$output->write('Purging cruft pages from database …');
 		$count = $this->garbageCollector->purgeObsoletePages();
 		$output->writeln('done.');
 		$output->writeln(sprintf('Purged %d cruft pages from database.', $count));

--- a/skeleton/Readme.es.md
+++ b/skeleton/Readme.es.md
@@ -5,7 +5,7 @@
 
 ### 👥 Invita a otras personas a colaborar en el cuaderno
 
-Para agregar personas, grupos o círculos, sigue el enlace a "Gestionar colaboradores" que se encuentra en el menú contextual (...) de cada cuaderno en la lista de cuadernos en el panel lateral izquierdo.
+Para agregar personas, grupos o círculos, sigue el enlace a "Gestionar colaboradores" que se encuentra en el menú contextual (…) de cada cuaderno en la lista de cuadernos en el panel lateral izquierdo.
 
 ### 🌱 Aquí conspiramos para lograr cambios
 

--- a/skeleton/Readme.sl.md
+++ b/skeleton/Readme.sl.md
@@ -16,7 +16,7 @@ Ustvarjajte strani in si skupinsko izmenjujte misli, ki so zares pomembne. Ni po
 Pritisnite gumb s svinčnikom in začnite! ↗️
 
 
-## Dobro je tudi vedeti ...
+## Dobro je tudi vedeti…
 
 * Stran lahko hkrati ureja več oseb.
 * Krajevne strani je mogoče povezati tudi kot »povezave na datoteke«. Podprta je tudi možnost povleci in spusti s seznama strani v urejevalnik.

--- a/src/components/Nav/NewCollectiveModal.vue
+++ b/src/components/Nav/NewCollectiveModal.vue
@@ -34,7 +34,7 @@
 					:append-to-body="false"
 					:options="circles"
 					:aria-label-combobox="t('collectives', 'Select an existing team')"
-					:placeholder="t('collectives', 'Select a team...')" />
+					:placeholder="t('collectives', 'Select a team…')" />
 				<NcButton v-if="anyCircle && !pickCircle"
 					:title="t('collectives', 'Select an existing team')"
 					type="tertiary"

--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -10,7 +10,7 @@
 				:label="t('collectives', 'Search pages')"
 				:value.sync="filterString"
 				class="page-filter"
-				:placeholder="t('collectives', 'Search pages ...')"
+				:placeholder="t('collectives', 'Search pages…')"
 				trailing-button-icon="close"
 				:show-trailing-button="isFilteredView"
 				@trailing-button-click="clearFilterString" />

--- a/templates/error.php
+++ b/templates/error.php
@@ -18,7 +18,7 @@
 	">
 	<div>
 		<h2><?php print_unescaped($l->t('Error: Missing apps')); ?></h2>
-		<?php print_unescaped($l->t('The following dependency apps are missing: ')); ?>
+		<?php print_unescaped($l->t('The following dependency apps are missing:')); ?>
 	</div>
 	<br />
 	<ul style="font-weight: bold;">


### PR DESCRIPTION
Source string validation was turned on for l10n strings, which caught a few usages of `...` instead of `…`. I took the opportunity to search for other occurrences of this.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
