### PR TITLE
Persist parts of pinia store in browser localStorage

### DIFF
--- a/cypress/e2e/page-details.spec.js
+++ b/cypress/e2e/page-details.spec.js
@@ -36,6 +36,12 @@ describe('Page details', function() {
 				.find('.editor--toc .editor--toc__item')
 				.should('contain', 'Second-Level Heading')
 
+			// Reload to test persistence of outline
+			cy.reload()
+			cy.getReadOnlyEditor()
+				.find('.editor--toc .editor--toc__item')
+				.should('contain', 'Second-Level Heading')
+
 			cy.switchToEditMode()
 			cy.getEditor()
 				.contains('Second-Level Heading')

--- a/src/components/Page/EditButton.vue
+++ b/src/components/Page/EditButton.vue
@@ -29,6 +29,7 @@ import PencilIcon from 'vue-material-design-icons/Pencil.vue'
 import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
 import { mapActions, mapState } from 'pinia'
 import { useRootStore } from '../../stores/root.js'
+import { usePagesStore } from '../../stores/pages.js'
 
 export default {
 	name: 'EditButton',
@@ -48,7 +49,8 @@ export default {
 	},
 
 	computed: {
-		...mapState(useRootStore, ['isTextEdit', 'loading']),
+		...mapState(useRootStore, ['loading']),
+		...mapState(usePagesStore, ['isTextEdit']),
 
 		description() {
 			return this.isTextEdit ? t('collectives', 'Stop editing') : t('collectives', 'Start editing')
@@ -68,7 +70,7 @@ export default {
 	},
 
 	methods: {
-		...mapActions(useRootStore, ['setTextEdit', 'setTextView']),
+		...mapActions(usePagesStore, ['setTextEdit', 'setTextView']),
 
 		handleClick() {
 			if (this.isTextEdit) {

--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -49,7 +49,7 @@
 			</NcActionCheckbox>
 			<NcActionButton v-if="!inPageList"
 				:close-after-click="true"
-				@click.native="toggle('outline')">
+				@click.native="toggleOutline(currentPage.id)">
 				<template #icon>
 					<FormatListBulletedIcon :size="20" />
 				</template>
@@ -219,7 +219,6 @@ export default {
 	},
 
 	computed: {
-		...mapState(useRootStore, ['showing']),
 		...mapState(useCollectivesStore, [
 			'currentCollective',
 			'currentCollectiveCanEdit',
@@ -228,6 +227,7 @@ export default {
 			'isFavoritePage',
 		]),
 		...mapState(usePagesStore, [
+			'hasOutline',
 			'hasSubpages',
 			'pagesTreeWalk',
 			'visibleSubpages',
@@ -252,7 +252,7 @@ export default {
 		},
 
 		toggleOutlineString() {
-			return this.showing('outline')
+			return this.hasOutline(this.currentPage.id)
 				? t('collectives', 'Hide outline')
 				: t('collectives', 'Show outline')
 		},
@@ -306,6 +306,7 @@ export default {
 		]),
 		...mapActions(usePagesStore, [
 			'setFullWidthView',
+			'toggleOutline',
 		]),
 
 		onCheckFullWidthView() {

--- a/src/components/Page/PageTitleBar.vue
+++ b/src/components/Page/PageTitleBar.vue
@@ -212,7 +212,6 @@ export default {
 
 		'currentPage.id'() {
 			this.initTitleEntry()
-			this.hide('outline')
 		},
 	},
 

--- a/src/components/Page/PageTitleBar.vue
+++ b/src/components/Page/PageTitleBar.vue
@@ -145,7 +145,6 @@ export default {
 	computed: {
 		...mapState(useRootStore, [
 			'isPublic',
-			'isTextEdit',
 			'loading',
 			'showing',
 		]),
@@ -158,6 +157,7 @@ export default {
 			'currentPagePath',
 			'isIndexPage',
 			'isLandingPage',
+			'isTextEdit',
 		]),
 
 		// TODO: remove when we stop supporting NC < 30

--- a/src/components/Page/SearchDialog.vue
+++ b/src/components/Page/SearchDialog.vue
@@ -62,7 +62,7 @@
 
 <script>
 import { mapActions, mapState } from 'pinia'
-import { useRootStore } from '../../stores/root.js'
+import { usePagesStore } from '../../stores/pages.js'
 import { useSearchStore } from '../../stores/search.js'
 import { translate as t } from '@nextcloud/l10n'
 
@@ -90,7 +90,7 @@ export default {
 	},
 
 	computed: {
-		...mapState(useRootStore, ['isTextEdit']),
+		...mapState(usePagesStore, ['isTextEdit']),
 		...mapState(useSearchStore, [
 		  'searchQuery',
 		  'matchAll',

--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -72,7 +72,7 @@ export default {
 	},
 
 	computed: {
-		...mapState(useRootStore, ['isPublic', 'isTextEdit', 'loading']),
+		...mapState(useRootStore, ['isPublic', 'loading']),
 		...mapState(useCollectivesStore, [
 			'currentCollective',
 			'currentCollectiveCanEdit',
@@ -80,6 +80,7 @@ export default {
 		...mapState(usePagesStore, [
 			'currentPage',
 			'currentPageDavUrl',
+			'isTextEdit',
 		]),
 
 		showEditor() {
@@ -132,14 +133,9 @@ export default {
 	},
 
 	methods: {
-		...mapActions(useRootStore, [
-			'load',
-			'done',
-			'setTextEdit',
-			'setTextView',
-		]),
+		...mapActions(useRootStore, ['load', 'done']),
 		...mapActions(useVersionsStore, ['getVersions']),
-		...mapActions(usePagesStore, ['touchPage']),
+		...mapActions(usePagesStore, ['setTextEdit', 'setTextView', 'touchPage']),
 
 		restoreAttachment(name) {
 			// inspired by the fixedEncodeURIComponent function suggested in

--- a/src/components/PageSidebar/SidebarTabAttachments.vue
+++ b/src/components/PageSidebar/SidebarTabAttachments.vue
@@ -190,7 +190,6 @@ export default {
 	computed: {
 		...mapState(useRootStore, [
 			'isPublic',
-			'isTextEdit',
 			'loading',
 			'shareTokenParam',
 		]),
@@ -200,6 +199,7 @@ export default {
 			'deletedAttachments',
 			'pagePath',
 			'pagePathTitle',
+			'isTextEdit',
 		]),
 
 		noAttachmentsDescription() {

--- a/src/mixins/editorMixin.js
+++ b/src/mixins/editorMixin.js
@@ -120,6 +120,7 @@ export default {
 				onLoaded: () => {
 					// TODO: remove check once we only support Nextcloud 30+
 					this.reader.setSearchQuery && this.reader.setSearchQuery(this.searchQuery, this.matchAll)
+					this.reader.setShowOutline(this.showOutline)
 				},
 				onSearch: (results) => {
 					this.setSearchResults(results)
@@ -150,6 +151,7 @@ export default {
 					onLoaded: () => {
 						// TODO: remove check once we only support Nextcloud 30+
 						this.editor.setSearchQuery && this.editor.setSearchQuery(this.searchQuery, this.matchAll)
+						this.editor.setShowOutline(this.showOutline)
 						this.done('editor')
 					},
 					onUpdate: ({ markdown }) => {

--- a/src/mixins/editorMixin.js
+++ b/src/mixins/editorMixin.js
@@ -31,18 +31,17 @@ export default {
 			'editorApiFlags',
 			'loading',
 			'shareTokenParam',
-			'showing',
 		]),
 		...mapState(useSearchStore, ['searchQuery', 'matchAll']),
 		...mapState(useCollectivesStore, ['currentCollectiveCanEdit']),
-		...mapState(usePagesStore, ['currentPage', 'pageFilePath']),
+		...mapState(usePagesStore, ['currentPage', 'pageFilePath', 'hasOutline']),
 
 		pageContent() {
 			return this.editorContent?.trim() || this.davContent
 		},
 
-		showOutline() {
-			return this.showing('outline')
+		showCurrentPageOutline() {
+			return this.hasOutline(this.currentPage.id)
 		},
 
 		contentLoaded() {
@@ -71,7 +70,7 @@ export default {
 	},
 
 	watch: {
-		'showOutline'(value) {
+		'showCurrentPageOutline'(value) {
 			this.editor?.setShowOutline(value)
 			this.reader?.setShowOutline(value)
 		},
@@ -91,7 +90,8 @@ export default {
 	},
 
 	methods: {
-		...mapActions(useRootStore, ['done', 'hide', 'show']),
+		...mapActions(useRootStore, ['done']),
+		...mapActions(usePagesStore, ['showOutline', 'hideOutline']),
 		...mapActions(useSearchStore, ['showSearchDialog', 'setSearchResults']),
 
 		async setupReader() {
@@ -117,7 +117,7 @@ export default {
 				},
 				onLoaded: () => {
 					this.reader.setSearchQuery(this.searchQuery, this.matchAll)
-					this.reader.setShowOutline(this.showOutline)
+					this.reader.setShowOutline(this.showCurrentPageOutline)
 				},
 				onSearch: (results) => {
 					this.setSearchResults(results)
@@ -147,7 +147,7 @@ export default {
 					},
 					onLoaded: () => {
 						this.editor.setSearchQuery(this.searchQuery, this.matchAll)
-						this.editor.setShowOutline(this.showOutline)
+						this.editor.setShowOutline(this.showCurrentPageOutline)
 						this.done('editor')
 					},
 					onUpdate: ({ markdown }) => {
@@ -187,9 +187,9 @@ export default {
 
 		toggleOutlineFromEditor(visible) {
 			if (visible === true) {
-				this.show('outline')
+				this.showOutline(this.currentPage.id)
 			} else if (visible === false) {
-				this.hide('outline')
+				this.hideOutline(this.currentPage.id)
 			}
 		},
 

--- a/src/mixins/editorMixin.js
+++ b/src/mixins/editorMixin.js
@@ -76,14 +76,12 @@ export default {
 			this.reader?.setShowOutline(value)
 		},
 		'searchQuery'(value) {
-			// TODO: remove check once we only support Nextcloud 30+
-			this.editor?.setSearchQuery && this.editor.setSearchQuery(value)
-			this.reader?.setSearchQuery && this.reader.setSearchQuery(value)
+			this.editor?.setSearchQuery(value)
+			this.reader?.setSearchQuery(value)
 		},
 		'matchAll'(value) {
-			// TODO: remove check once we only support Nextcloud 30+
-			this.editor?.setSearchQuery && this.editor.setSearchQuery(this.searchQuery, value)
-			this.reader?.setSearchQuery && this.reader.setSearchQuery(this.searchQuery, value)
+			this.editor?.setSearchQuery(this.searchQuery, value)
+			this.reader?.setSearchQuery(this.searchQuery, value)
 		},
 	},
 
@@ -118,8 +116,7 @@ export default {
 					this.toggleOutlineFromEditor(visible)
 				},
 				onLoaded: () => {
-					// TODO: remove check once we only support Nextcloud 30+
-					this.reader.setSearchQuery && this.reader.setSearchQuery(this.searchQuery, this.matchAll)
+					this.reader.setSearchQuery(this.searchQuery, this.matchAll)
 					this.reader.setShowOutline(this.showOutline)
 				},
 				onSearch: (results) => {
@@ -149,8 +146,7 @@ export default {
 						this.updateEditorContentDebounced(markdown)
 					},
 					onLoaded: () => {
-						// TODO: remove check once we only support Nextcloud 30+
-						this.editor.setSearchQuery && this.editor.setSearchQuery(this.searchQuery, this.matchAll)
+						this.editor.setSearchQuery(this.searchQuery, this.matchAll)
 						this.editor.setShowOutline(this.showOutline)
 						this.done('editor')
 					},

--- a/src/stores/circles.js
+++ b/src/stores/circles.js
@@ -5,16 +5,19 @@
 
 import { defineStore } from 'pinia'
 import { set } from 'vue'
+import { useLocalStorage } from '@vueuse/core'
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 import { circlesMemberTypes } from '../constants.js'
 import { useCollectivesStore } from './collectives.js'
 import { useRootStore } from './root.js'
 
+const STORE_PREFIX = 'collectives/pinia/circles/'
+
 export const useCirclesStore = defineStore('circles', {
 	state: () => ({
-		circles: [],
-		circlesMembers: {},
+		circles: useLocalStorage(STORE_PREFIX + 'circles', []),
+		circlesMembers: useLocalStorage(STORE_PREFIX + 'circlesMembers', {}),
 	}),
 
 	getters: {

--- a/src/stores/collectives.js
+++ b/src/stores/collectives.js
@@ -5,6 +5,7 @@
 
 import { defineStore } from 'pinia'
 import { useRootStore } from './root.js'
+import { useLocalStorage } from '@vueuse/core'
 import { byName } from '../util/sortOrders.js'
 import { memberLevels } from '../constants.js'
 import randomEmoji from '../util/randomEmoji.js'
@@ -12,10 +13,12 @@ import * as api from '../apis/collectives/index.js'
 import { useSettingsStore } from './settings.js'
 import { useCirclesStore } from './circles.js'
 
+const STORE_PREFIX = 'collectives/pinia/collectives/'
+
 export const useCollectivesStore = defineStore('collectives', {
 	state: () => ({
-		collectives: [],
-		trashCollectives: [],
+		collectives: useLocalStorage(STORE_PREFIX + 'collectives', []),
+		trashCollectives: useLocalStorage(STORE_PREFIX + 'trashCollectives', []),
 		updatedCollective: undefined,
 		templatesCollectiveId: undefined,
 		membersCollectiveId: undefined,

--- a/src/stores/pages.js
+++ b/src/stores/pages.js
@@ -26,6 +26,7 @@ export const usePagesStore = defineStore('pages', {
 		newPageParentId: null,
 		sortBy: undefined,
 		collapsed: useLocalStorage(STORE_PREFIX + 'collapsed', {}),
+		outline: useLocalStorage(STORE_PREFIX + 'outline', {}),
 		attachments: [],
 		deletedAttachments: [],
 		backlinks: [],
@@ -341,6 +342,11 @@ export const usePagesStore = defineStore('pages', {
 			return pageId => state.collapsed[pageId] != null ? state.collapsed[pageId] : true
 		},
 
+		hasOutline(state) {
+			// Default to 'false' if unset
+			return pageId => state.outline[pageId] != null ? state.outline[pageId] : false
+		},
+
 		keptSortable(state) {
 			return (pageId) => state.pages.find(p => p.id === pageId)?.keepSortable
 		},
@@ -439,10 +445,15 @@ export const usePagesStore = defineStore('pages', {
 			// Default to 'false' if unset
 			set(this.collapsed, pageId, this.collapsed[pageId] == null ? false : !this.collapsed[pageId])
 		},
-
 		collapse(pageId) { set(this.collapsed, pageId, true) },
-
 		expand(pageId) { set(this.collapsed, pageId, false) },
+
+		toggleOutline(pageId) {
+			// Default to 'true' if unset
+			set(this.outline, pageId, this.outline[pageId] == null ? true : !this.outline[pageId])
+		},
+		showOutline(pageId) { set(this.outline, pageId, true) },
+		hideOutline(pageId) { set(this.outline, pageId, false) },
 
 		expandParents(pageId) {
 			for (const page of this.pageParents(pageId)) {

--- a/src/stores/pages.js
+++ b/src/stores/pages.js
@@ -5,6 +5,7 @@
 
 import { defineStore } from 'pinia'
 import { set } from 'vue'
+import { useLocalStorage } from '@vueuse/core'
 import { getCurrentUser } from '@nextcloud/auth'
 import { generateRemoteUrl } from '@nextcloud/router'
 import { useRootStore } from './root.js'
@@ -18,13 +19,13 @@ const STORE_PREFIX = 'collectives/pinia/pages/'
 
 export const usePagesStore = defineStore('pages', {
 	state: () => ({
-		allPages: {},
-		allTrashPages: {},
+		allPages: useLocalStorage(STORE_PREFIX + 'allPages', {}),
+		allTrashPages: useLocalStorage(STORE_PREFIX + 'allTrashPages', {}),
 		textMode: useLocalStorage(STORE_PREFIX + 'textMode', {}),
 		newPage: undefined,
 		newPageParentId: null,
 		sortBy: undefined,
-		collapsed: {},
+		collapsed: useLocalStorage(STORE_PREFIX + 'collapsed', {}),
 		attachments: [],
 		deletedAttachments: [],
 		backlinks: [],

--- a/src/stores/pages.js
+++ b/src/stores/pages.js
@@ -9,15 +9,18 @@ import { getCurrentUser } from '@nextcloud/auth'
 import { generateRemoteUrl } from '@nextcloud/router'
 import { useRootStore } from './root.js'
 import { useCollectivesStore } from './collectives.js'
-import { INDEX_PAGE } from '../constants.js'
+import { INDEX_PAGE, pageModes } from '../constants.js'
 /* eslint import/namespace: ['error', { allowComputed: true }] */
 import * as sortOrders from '../util/sortOrders.js'
 import * as api from '../apis/collectives/index.js'
+
+const STORE_PREFIX = 'collectives/pinia/pages/'
 
 export const usePagesStore = defineStore('pages', {
 	state: () => ({
 		allPages: {},
 		allTrashPages: {},
+		textMode: useLocalStorage(STORE_PREFIX + 'textMode', {}),
 		newPage: undefined,
 		newPageParentId: null,
 		sortBy: undefined,
@@ -328,6 +331,10 @@ export const usePagesStore = defineStore('pages', {
 			}
 		},
 
+		getTextMode: (state) => state.textMode[state.currentPage.id] ?? pageModes.MODE_VIEW,
+		isTextEdit: (state) => state.getTextMode === pageModes.MODE_EDIT,
+		isTextView: (state) => state.getTextMode === pageModes.MODE_VIEW,
+
 		isCollapsed(state) {
 			// Default to 'true' if unset
 			return pageId => state.collapsed[pageId] != null ? state.collapsed[pageId] : true
@@ -423,6 +430,9 @@ export const usePagesStore = defineStore('pages', {
 		setPageOrder(order) {
 			this.sortBy = order
 		},
+
+		setTextEdit() { set(this.textMode, this.currentPage.id, pageModes.MODE_EDIT) },
+		setTextView() { set(this.textMode, this.currentPage.id, pageModes.MODE_VIEW) },
 
 		toggleCollapsed(pageId) {
 			// Default to 'false' if unset

--- a/src/stores/root.js
+++ b/src/stores/root.js
@@ -5,15 +5,17 @@
 
 import { defineStore } from 'pinia'
 import { set } from 'vue'
-import { editorApiReaderFileId, editorApiUpdateReadonlyBarProps, pageModes } from '../constants.js'
+import { useLocalStorage } from '@vueuse/core'
+import { editorApiReaderFileId, editorApiUpdateReadonlyBarProps } from '../constants.js'
+
+const STORE_PREFIX = 'collectives/pinia/root/'
 
 export const useRootStore = defineStore('root', {
 	state: () => ({
-		textMode: pageModes.MODE_VIEW,
-		showings: {},
+		showings: useLocalStorage(STORE_PREFIX + 'showings', {}),
 		loadings: {},
 		printView: false,
-		activeSidebarTab: 'attachments',
+		activeSidebarTab: useLocalStorage(STORE_PREFIX + 'activeSidebarTab', 'attachments'),
 		collectiveParam: '',
 		collectiveId: null,
 		pageParam: '',
@@ -27,9 +29,6 @@ export const useRootStore = defineStore('root', {
 		showing: (state) => (aspect) => state.showings[aspect],
 
 		isPublic() { return !!this.shareTokenParam },
-
-		isTextEdit: (state) => state.textMode === pageModes.MODE_EDIT,
-		isTextView: (state) => state.textMode === pageModes.MODE_VIEW,
 
 		editorApiVersionCheck: () => (requiredVersion) => {
 			const apiVersion = window.OCA?.Text?.apiVersion || '0'
@@ -57,8 +56,6 @@ export const useRootStore = defineStore('root', {
 		toggle(aspect) { set(this.showings, aspect, !this.showings[aspect]) },
 
 		setPrintView() { this.printView = true },
-		setTextEdit() { this.textMode = pageModes.MODE_EDIT },
-		setTextView() { this.textMode = pageModes.MODE_VIEW },
 		setActiveSidebarTab(id) { this.activeSidebarTab = id },
 	},
 })

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -4,11 +4,14 @@
  */
 
 import { defineStore } from 'pinia'
+import { useLocalStorage } from '@vueuse/core'
 import * as settings from '../apis/collectives/settings.js'
+
+const STORE_PREFIX = 'collectives/pinia/settings/'
 
 export const useSettingsStore = defineStore('settings', {
 	state: () => ({
-		collectivesFolder: '',
+		collectivesFolder: useLocalStorage(STORE_PREFIX + 'collectivesFolder', ''),
 	}),
 
 	actions: {

--- a/src/stores/shares.js
+++ b/src/stores/shares.js
@@ -5,13 +5,16 @@
 
 import { defineStore } from 'pinia'
 import { set } from 'vue'
+import { useLocalStorage } from '@vueuse/core'
 import { useRootStore } from './root.js'
 import { useCollectivesStore } from './collectives.js'
 import * as api from '../apis/collectives/index.js'
 
+const STORE_PREFIX = 'collectives/pinia/shares/'
+
 export const useSharesStore = defineStore('shares', {
 	state: () => ({
-		allShares: {},
+		allShares: useLocalStorage(STORE_PREFIX + 'allShares', {}),
 	}),
 
 	getters: {

--- a/src/stores/templates.js
+++ b/src/stores/templates.js
@@ -5,6 +5,7 @@
 
 import { defineStore } from 'pinia'
 import { set } from 'vue'
+import { useLocalStorage } from '@vueuse/core'
 import { useRootStore } from './root.js'
 import { useCollectivesStore } from './collectives.js'
 import { usePagesStore } from './pages.js'
@@ -12,10 +13,12 @@ import * as api from '../apis/collectives/index.js'
 import { byTitleAsc } from '../util/sortOrders.js'
 import { TEMPLATE_PAGE } from '../constants.js'
 
+const STORE_PREFIX = 'collectives/pinia/templates/'
+
 export const useTemplatesStore = defineStore('templates', {
 	state: () => ({
-		allTemplates: {},
-		allTemplatesLoaded: {},
+		allTemplates: useLocalStorage(STORE_PREFIX + 'allTemplates', {}),
+		allTemplatesLoaded: useLocalStorage(STORE_PREFIX + 'allTemplatesLoaded', {}),
 	}),
 
 	getters: {


### PR DESCRIPTION
### 📝 Summary

Use `useLocalStorage` composable from vueuse to persist parts of the pinia store state.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
