### PR TITLE
fix(GenerateSlugs): Catch error when circle is missing

### DIFF
--- a/lib/Command/GenerateSlugs.php
+++ b/lib/Command/GenerateSlugs.php
@@ -12,6 +12,7 @@ namespace OCA\Collectives\Command;
 use OCA\Collectives\Fs\NodeHelper;
 use OCA\Collectives\Model\PageInfo;
 use OCA\Collectives\Service\CircleHelper;
+use OCA\Collectives\Service\NotFoundException;
 use OCA\Collectives\Service\PageService;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -62,7 +63,12 @@ class GenerateSlugs extends Command {
 			->where($update->expr()->eq('id', $update->createParameter('id')));
 
 		while ($row = $result->fetch()) {
-			$circle = $this->circleHelper->getCircle($row['circle_unique_id'], null, true);
+			try {
+				$circle = $this->circleHelper->getCircle($row['circle_unique_id'], null, true);
+			} catch (NotFoundException) {
+				// Cruft collective without circle
+				continue;
+			}
 			$slug = $this->slugger->slug($circle->getSanitizedName())->toString();
 
 			$update
@@ -86,7 +92,12 @@ class GenerateSlugs extends Command {
 			->where($update->expr()->eq('file_id', $update->createParameter('file_id')));
 
 		while ($rowCollective = $resultCollectives->fetch()) {
-			$circle = $this->circleHelper->getCircle($rowCollective['circle_unique_id'], null, true);
+			try {
+				$circle = $this->circleHelper->getCircle($rowCollective['circle_unique_id'], null, true);
+			} catch (NotFoundException) {
+				// Cruft collective without circle
+				continue;
+			}
 			$pageInfos = $this->pageService->findAll($rowCollective['id'], $circle->getOwner()->getUserId());
 
 			/** @var PageInfo $pageInfo */

--- a/lib/Migration/GenerateSlugs.php
+++ b/lib/Migration/GenerateSlugs.php
@@ -13,6 +13,7 @@ use OCA\Collectives\Fs\NodeHelper;
 use OCA\Collectives\Model\PageInfo;
 use OCA\Collectives\Mount\CollectiveFolderManager;
 use OCA\Collectives\Service\CircleHelper;
+use OCA\Collectives\Service\NotFoundException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\File;
 use OCP\IAppConfig;
@@ -68,7 +69,12 @@ class GenerateSlugs implements IRepairStep {
 			->where($update->expr()->eq('id', $update->createParameter('id')));
 
 		while ($row = $result->fetch()) {
-			$circle = $this->circleHelper->getCircle($row['circle_unique_id'], null, true);
+			try {
+				$circle = $this->circleHelper->getCircle($row['circle_unique_id'], null, true);
+			} catch (NotFoundException) {
+				// Cruft collective without circle
+				continue;
+			}
 			$slug = $this->slugger->slug($circle->getSanitizedName())->toString();
 
 			$update


### PR DESCRIPTION
There might be cruft collectives in the database where the cirlce is missing. We have a CircleDestroyedListener that removes the collective alongside with the circle. But there's still corner cases. E.g. the Collectives app might have been disabled while a circle got destroyed.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
