### PR TITLE
fix(slugs): Ignore errors from CircleHelper

### DIFF
--- a/.github/workflows/app-upgrade-mysql.yml
+++ b/.github/workflows/app-upgrade-mysql.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Get collectives app from app store
         id: collectives_app
-        uses: nextcloud/appstore-action@74efb3de5a06a74f2bdf6f4f635468f14d8fee2c # v1.0.0
+        uses: nextcloud/appstore-action@facdd26645c34b31d2b58ddc658d7012299d2a14 # v1.0.0
         with:
           appid: collectives
           download: true

--- a/.github/workflows/app-upgrade-postgres.yml
+++ b/.github/workflows/app-upgrade-postgres.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Get collectives app from app store
         id: collectives_app
-        uses: nextcloud/appstore-action@74efb3de5a06a74f2bdf6f4f635468f14d8fee2c # v1.0.0
+        uses: nextcloud/appstore-action@facdd26645c34b31d2b58ddc658d7012299d2a14 # v1.0.0
         with:
           appid: collectives
           download: true

--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Get contacts app from app store
         id: contacts_app
-        uses: nextcloud/appstore-action@74efb3de5a06a74f2bdf6f4f635468f14d8fee2c # v1.0.0
+        uses: nextcloud/appstore-action@facdd26645c34b31d2b58ddc658d7012299d2a14 # v1.0.0
         with:
           appid: contacts
           server_major: ${{ matrix.server-major }}

--- a/.github/workflows/psalm-migrations.yml
+++ b/.github/workflows/psalm-migrations.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Get collectives app from app store
         id: collectives_app
-        uses: nextcloud/appstore-action@74efb3de5a06a74f2bdf6f4f635468f14d8fee2c # v1.0.0
+        uses: nextcloud/appstore-action@facdd26645c34b31d2b58ddc658d7012299d2a14 # v1.0.0
         with:
           appid: collectives
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.1 - 2025.07.14
+
+### 🐛Fixes
+* 🪤 Catch more circles errors when generating slugs.
+
 ## 3.0.0 - 2025.07.14
 
 ### ✨New
@@ -9,7 +14,6 @@
 * 🧹 Remove Nextcloud 29 and PHP 8.0 support.
 
 ### 🐛Fixes
-
 * 🧹 Remove debugYjs function.
 * 🔥 Only initialize a collective session as logged in user.
 * 🩹 Add getRevision function required by NC 32.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ In your Nextcloud instance, simply navigate to **»Apps«**, find the
 **»Teams«** and **»Collectives«** apps and enable them.
 
 	]]></description>
-	<version>3.0.0</version>
+	<version>3.0.1</version>
 	<licence>agpl</licence>
 	<author>CollectiveCloud Team</author>
 	<namespace>Collectives</namespace>

--- a/lib/Migration/GenerateSlugs.php
+++ b/lib/Migration/GenerateSlugs.php
@@ -14,6 +14,7 @@ use OCA\Collectives\Model\PageInfo;
 use OCA\Collectives\Mount\CollectiveFolderManager;
 use OCA\Collectives\Service\CircleHelper;
 use OCA\Collectives\Service\NotFoundException;
+use OCA\Collectives\Service\NotPermittedException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\File;
 use OCP\IAppConfig;
@@ -39,7 +40,7 @@ class GenerateSlugs implements IRepairStep {
 	public function run(IOutput $output): void {
 		$appVersion = $this->config->getValueString('collectives', 'installed_version');
 
-		if (!$appVersion || version_compare($appVersion, '3.0.0') !== -1) {
+		if (!$appVersion || version_compare($appVersion, '3.0.2') !== -1) {
 			return;
 		}
 
@@ -74,8 +75,8 @@ class GenerateSlugs implements IRepairStep {
 		while ($row = $result->fetch()) {
 			try {
 				$circle = $this->circleHelper->getCircle($row['circle_unique_id'], null, true);
-			} catch (NotFoundException) {
-				// Cruft collective without circle
+			} catch (NotFoundException|NotPermittedException) {
+				// Ignore exceptions from CircleManager (e.g. due to cruft collective without circle)
 				continue;
 			}
 			$slug = $this->slugger->slug($circle->getSanitizedName())->toString();


### PR DESCRIPTION
Prevents the slug generation from failing early when the CircleHelper throws an error.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
