### PR TITLE
Fix slugs migration and opening page slug routes without collective slug

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ In your Nextcloud instance, simply navigate to **»Apps«**, find the
 **»Teams«** and **»Collectives«** apps and enable them.
 
 	]]></description>
-	<version>3.0.1</version>
+	<version>3.0.2</version>
 	<licence>agpl</licence>
 	<author>CollectiveCloud Team</author>
 	<namespace>Collectives</namespace>
@@ -58,9 +58,11 @@ In your Nextcloud instance, simply navigate to **»Apps«**, find the
 	</background-jobs>
 	<repair-steps>
 		<post-migration>
-			<step>OCA\Collectives\Migration\GenerateSlugs</step>
 			<step>OCA\Collectives\Migration\MigrateTemplates</step>
 		</post-migration>
+		<live-migration>
+			<step>OCA\Collectives\Migration\GenerateSlugs</step>
+		</live-migration>
 	</repair-steps>
 	<commands>
 		<command>OCA\Collectives\Command\CreateCollective</command>

--- a/lib/Migration/GenerateSlugs.php
+++ b/lib/Migration/GenerateSlugs.php
@@ -38,10 +38,8 @@ class GenerateSlugs implements IRepairStep {
 	}
 
 	public function run(IOutput $output): void {
-		$appVersion = $this->config->getValueString('collectives', 'installed_version');
-
-		if (!$appVersion || version_compare($appVersion, '3.0.2') !== -1) {
-			return;
+		if ($this->config->getValueBool('collectives', 'migrated_slugs')) {
+			$output->info('Slugs already generated');
 		}
 
 		$output->info('Generating slugs for collectives ...');
@@ -55,6 +53,8 @@ class GenerateSlugs implements IRepairStep {
 		$this->generatePageSlugs($output);
 		$output->finishProgress();
 		$output->info('done');
+
+		$this->config->setValueBool('collectives', 'migrated_slugs', true);
 	}
 
 	private function generateCollectiveSlugs(IOutput $output): void {

--- a/src/router.js
+++ b/src/router.js
@@ -49,7 +49,10 @@ const routes = [
 		path: '/p/:token/:collective',
 		component: CollectiveView,
 		props: (route) => route.params,
-		children: [{ path: ':page*' }],
+		children: [
+			{ path: ':pageSlug-:pageId(\\d+)' },
+			{ path: ':page*' },
+		],
 	},
 	{
 		path: '/:collectiveSlug-:collectiveId(\\d+)',
@@ -64,7 +67,10 @@ const routes = [
 		path: '/:collective',
 		component: CollectiveView,
 		props: (route) => route.params,
-		children: [{ path: ':page*' }],
+		children: [
+			{ path: ':pageSlug-:pageId(\\d+)' },
+			{ path: ':page*' },
+		],
 	},
 ]
 


### PR DESCRIPTION
### 📝 Summary

* fix(router): Handle routes without collective slug but with page slug
* fix(migration): Change GenerateSlugs to a live-migration step
   The migration requires a newly introduced dependency `symfony/string`,
   so it will fail to run within the same PHP process that upgrades the
   app from any version before 3.0.0.
* Fixes: #1879

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
