### PR TITLE
fix(LastUserBubble): Explicitely import `t` from `@nextcloud/l10n`

### DIFF
--- a/src/components/LastUserBubble.vue
+++ b/src/components/LastUserBubble.vue
@@ -19,6 +19,7 @@
 <script>
 import { NcUserBubble } from '@nextcloud/vue'
 import moment from '@nextcloud/moment'
+import { t } from '@nextcloud/l10n'
 
 export default {
 	name: 'LastUserBubble',
@@ -50,6 +51,10 @@ export default {
 		lastUpdate() {
 			return moment.unix(this.timestamp).fromNow()
 		},
+	},
+
+	methods: {
+		t,
 	},
 }
 </script>


### PR DESCRIPTION
Since `PageInfoBar` component is injected into Text, it's required now that Text doesn't have a `t()` global anymore.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
