### PR TITLE
fix(router): Compare just path without hash

### DIFF
--- a/src/components/Collective.vue
+++ b/src/components/Collective.vue
@@ -237,10 +237,10 @@ export default {
 			// Redirect to slugified URL if possible
 			if (this.currentCollective
 				&& this.isLandingPage
-				&& this.$route.fullPath !== this.currentCollectivePath) {
+				&& this.$route.path !== this.currentCollectivePath) {
 				this.$router.replace({ path: this.currentCollectivePath, hash: document.location.hash })
 			} else if (this.currentPage
-				&& this.$route.fullPath !== this.currentPagePath) {
+				&& this.$route.path !== this.currentPagePath) {
 				this.$router.replace({ path: this.currentPagePath, hash: document.location.hash })
 			}
 		},


### PR DESCRIPTION
When checking whether to redirect to the new slug URL, just check the path, without hash.

Fixes console error "NavigationDuplicated: Avoided redundant navigation to current location".

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
