### PR TITLE
test(cy): Only test link handling against `https` URLs

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -42,7 +42,7 @@ jobs:
               - 'babel.config.js'
               - 'composer.json'
               - 'composer.lock'
-              - 'cypress.config.js'
+              - 'cypress.config.mjs'
               - 'package.json'
               - 'package-lock.json'
               - 'tsconfig.json'

--- a/cypress/e2e/pages-links.spec.js
+++ b/cypress/e2e/pages-links.spec.js
@@ -74,7 +74,7 @@ describe('Page link handling', function() {
 * URL to another app in Nextcloud: [Contacts](${baseUrl}/index.php/apps/contacts)
 * Absolute path to another app in Nextcloud: [Contacts](/index.php/apps/contacts)
 * URL to a page in Collectives on another instance: [Foreign Page](https://example.org/apps/collectives/Foreign%20Collective/Foreign%20Page?fileId=123)
-* URL to external website: [example.org](https://example.org/)
+* URL to external website: [github.com](https://github.com/)
 * Some content
 			`)
 		})
@@ -363,7 +363,7 @@ describe('Page link handling', function() {
 
 	describe('Link handling to external in view mode', function() {
 		it('Opens link to external website in new tab', function() {
-			const href = 'https://example.org/'
+			const href = 'https://github.com/'
 			testLinkToNewTab(href)
 		})
 		it('Opens link to foreign Collectives page in new tab', function() {
@@ -374,7 +374,7 @@ describe('Page link handling', function() {
 
 	describe('Link handling to external in edit mode', function() {
 		it('Opens link to external website in new tab', function() {
-			const href = 'https://example.org/'
+			const href = 'https://github.com/'
 			cy.switchToEditMode()
 			testLinkToNewTab(href, { edit: true })
 		})
@@ -446,13 +446,13 @@ describe('Page link handling', function() {
 		it('Public share in view mode: opens link to external website in new tab', function() {
 			cy.logout()
 			cy.visit(`${shareUrl}/Link Source`)
-			const href = 'https://example.org/'
+			const href = 'https://github.com/'
 			testLinkToNewTab(href, { isPublic: true })
 		})
 		it('Public share in edit mode: opens link to external website in new tab', function() {
 			cy.logout()
 			cy.visit(`${shareUrl}/Link Source`)
-			const href = 'https://example.org/'
+			const href = 'https://github.com/'
 			cy.switchToEditMode()
 			testLinkToNewTab(href, { edit: true, isPublic: true })
 		})

--- a/cypress/e2e/pages-links.spec.js
+++ b/cypress/e2e/pages-links.spec.js
@@ -74,7 +74,7 @@ describe('Page link handling', function() {
 * URL to another app in Nextcloud: [Contacts](${baseUrl}/index.php/apps/contacts)
 * Absolute path to another app in Nextcloud: [Contacts](/index.php/apps/contacts)
 * URL to a page in Collectives on another instance: [Foreign Page](https://example.org/apps/collectives/Foreign%20Collective/Foreign%20Page?fileId=123)
-* URL to external website: [example.org](http://example.org/)
+* URL to external website: [example.org](https://example.org/)
 * Some content
 			`)
 		})
@@ -363,7 +363,7 @@ describe('Page link handling', function() {
 
 	describe('Link handling to external in view mode', function() {
 		it('Opens link to external website in new tab', function() {
-			const href = 'http://example.org/'
+			const href = 'https://example.org/'
 			testLinkToNewTab(href)
 		})
 		it('Opens link to foreign Collectives page in new tab', function() {
@@ -374,7 +374,7 @@ describe('Page link handling', function() {
 
 	describe('Link handling to external in edit mode', function() {
 		it('Opens link to external website in new tab', function() {
-			const href = 'http://example.org/'
+			const href = 'https://example.org/'
 			cy.switchToEditMode()
 			testLinkToNewTab(href, { edit: true })
 		})
@@ -446,13 +446,13 @@ describe('Page link handling', function() {
 		it('Public share in view mode: opens link to external website in new tab', function() {
 			cy.logout()
 			cy.visit(`${shareUrl}/Link Source`)
-			const href = 'http://example.org/'
+			const href = 'https://example.org/'
 			testLinkToNewTab(href, { isPublic: true })
 		})
 		it('Public share in edit mode: opens link to external website in new tab', function() {
 			cy.logout()
 			cy.visit(`${shareUrl}/Link Source`)
-			const href = 'http://example.org/'
+			const href = 'https://example.org/'
 			cy.switchToEditMode()
 			testLinkToNewTab(href, { edit: true, isPublic: true })
 		})

--- a/cypress/e2e/pages-links.spec.js
+++ b/cypress/e2e/pages-links.spec.js
@@ -73,7 +73,7 @@ describe('Page link handling', function() {
 
 * URL to another app in Nextcloud: [Contacts](${baseUrl}/index.php/apps/contacts)
 * Absolute path to another app in Nextcloud: [Contacts](/index.php/apps/contacts)
-* URL to a page in Collectives on another instance: [Foreign Page](https://example.org/apps/collectives/Foreign%20Collective/Foreign%20Page?fileId=123)
+* URL to a page in Collectives on another instance: [Foreign Page](https://github.com/apps/collectives/Foreign%20Collective/Foreign%20Page?fileId=123)
 * URL to external website: [github.com](https://github.com/)
 * Some content
 			`)
@@ -367,7 +367,7 @@ describe('Page link handling', function() {
 			testLinkToNewTab(href)
 		})
 		it('Opens link to foreign Collectives page in new tab', function() {
-			const href = 'https://example.org/apps/collectives/Foreign%20Collective/Foreign%20Page?fileId=123'
+			const href = 'https://github.com/apps/collectives/Foreign%20Collective/Foreign%20Page?fileId=123'
 			testLinkToNewTab(href)
 		})
 	})
@@ -379,7 +379,7 @@ describe('Page link handling', function() {
 			testLinkToNewTab(href, { edit: true })
 		})
 		it('Opens link to foreign Collectives page in new tab', function() {
-			const href = 'https://example.org/apps/collectives/Foreign%20Collective/Foreign%20Page?fileId=123'
+			const href = 'https://github.com/apps/collectives/Foreign%20Collective/Foreign%20Page?fileId=123'
 			cy.switchToEditMode()
 			testLinkToNewTab(href, { edit: true })
 		})

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -657,7 +657,6 @@ class PageService {
 		$pageInfo->setLastUserId($userId);
 		$pageInfo->setLastUserDisplayName($this->userManager->getDisplayName($userId));
 		$this->updatePage($collectiveId, $pageInfo->getId(), $userId);
-		$file->touch();
 		return $pageInfo;
 	}
 
@@ -675,7 +674,6 @@ class PageService {
 		$pageInfo->setLastUserDisplayName($this->userManager->getDisplayName($userId));
 		$pageInfo->setFullWidth($fullWidth);
 		$this->updatePage($collectiveId, $pageInfo->getId(), $userId, fullWidth: $fullWidth);
-		$file->touch();
 		return $pageInfo;
 	}
 
@@ -897,7 +895,6 @@ class PageService {
 		$pageInfo->setLastUserDisplayName($this->userManager->getDisplayName($userId));
 		$pageInfo->setEmoji($emoji);
 		$this->updatePage($collectiveId, $pageInfo->getId(), $userId, $emoji);
-		$file->touch();
 		return $pageInfo;
 	}
 


### PR DESCRIPTION
Opening `http://example.org` (instead of `https`) resulted in `ERR_EMPTY_RESPONSE (-324) loading 'http://example.org/'` recently.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
