### PR TITLE
fix(pageShare): Don't try to fetch templates in page share

### DIFF
--- a/lib/Controller/PublicTemplateController.php
+++ b/lib/Controller/PublicTemplateController.php
@@ -79,7 +79,7 @@ class PublicTemplateController extends CollectivesPublicOCSController {
 			}
 
 			if ($this->collectiveShare->getPageId() !== 0) {
-				throw new OCSNotFoundException('Page share does not support page trash');
+				throw new OCSNotFoundException('Page share does not support templates');
 			}
 		}
 

--- a/src/components/Collective.vue
+++ b/src/components/Collective.vue
@@ -220,9 +220,9 @@ export default {
 			await this.getPages(setLoading)
 				.catch(displayError('Could not fetch pages'))
 			if (this.currentCollectiveCanEdit) {
-				await this.getTemplates(setLoading)
-					.catch(displayError('Could not fetch templates'))
 				if (!this.currentCollectiveIsPageShare) {
+					await this.getTemplates(setLoading)
+						.catch(displayError('Could not fetch templates'))
 					await this.getTrashPages()
 						.catch(displayError('Could not fetch page trash'))
 				}


### PR DESCRIPTION
When just sharing a subset of pages, templates are unavailable.

Also fix the backend error message.

### 📝 Summary

* Resolves: # <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
