### PR TITLE
fix(GenerateSlugs): Stop migration if slugs already got generated

### DIFF
--- a/lib/Migration/GenerateSlugs.php
+++ b/lib/Migration/GenerateSlugs.php
@@ -40,6 +40,7 @@ class GenerateSlugs implements IRepairStep {
 	public function run(IOutput $output): void {
 		if ($this->config->getValueBool('collectives', 'migrated_slugs')) {
 			$output->info('Slugs already generated');
+			return;
 		}
 
 		$output->info('Generating slugs for collectives ...');


### PR DESCRIPTION
Fixes: #1907

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
