### PR TITLE
fix(session): Raise session valid time to 120 seconds

### DIFF
--- a/lib/Service/SessionService.php
+++ b/lib/Service/SessionService.php
@@ -16,7 +16,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Security\ISecureRandom;
 
 class SessionService {
-	public const SESSION_VALID_TIME = 92;
+	public const SESSION_VALID_TIME = 120;
 
 	public function __construct(
 		private CollectiveMapper $collectiveMapper,

--- a/tests/Integration/features/collectiveSession.feature
+++ b/tests/Integration/features/collectiveSession.feature
@@ -23,7 +23,7 @@ Feature: collectiveSession
 
   Scenario: Create a session as member, fail to update after it got invalidated
     When user "jane" creates session for "BehatSessionCollective"
-    And we wait for "95" seconds
+    And we wait for "122" seconds
     Then user "jane" fails to update session for "BehatSessionCollective"
 
   Scenario: Delete collective


### PR DESCRIPTION
Should fix racy situations where update session request comes too late and as a result a new session needs to get created.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
