### PR TITLE
feat(PageActions): Add action to download markdown file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ js/*
 .php-cs-fixer.cache
 
 # Cypress test artifacts
+cypress/downloads/
 cypress/screenshots/
 cypress/videos/

--- a/cypress/e2e/page-details.spec.js
+++ b/cypress/e2e/page-details.spec.js
@@ -26,12 +26,9 @@ describe('Page details', function() {
 			cy.getReadOnlyEditor()
 				.contains('Second-Level Heading')
 			cy.wait(200) // eslint-disable-line cypress/no-unnecessary-waiting
-			cy.get('[data-cy-collectives="page-title-container"] .action-item__menutoggle')
-				.click()
 
-			cy.log('Show outline in view mode')
-			cy.contains('button', 'Show outline')
-				.click()
+			cy.openPageTitleMenu()
+			cy.clickMenuButton('Show outline')
 			cy.getReadOnlyEditor()
 				.find('.editor--toc .editor--toc__item')
 				.should('contain', 'Second-Level Heading')
@@ -62,6 +59,19 @@ describe('Page details', function() {
 
 			cy.get('.editor--toc')
 				.should('not.exist')
+		})
+	})
+
+	describe('Download markdown file', function() {
+		it('Allows to download markdown file', function() {
+			cy.intercept('PUT', '**/apps/text/session/*/create').as('textCreateSession')
+			cy.openPage('Day 1')
+			cy.wait('@textCreateSession')
+
+			cy.openPageTitleMenu()
+			cy.clickMenuButton('Download')
+
+			cy.readFile(`${Cypress.config('downloadsFolder')}/Day 1.md`)
 		})
 	})
 

--- a/cypress/support/navigation.js
+++ b/cypress/support/navigation.js
@@ -49,7 +49,7 @@ Cypress.Commands.add('openTrashedCollectiveMenu', (collectiveName) => {
 
 Cypress.Commands.add('clickMenuButton', (title) => {
 	Cypress.log()
-	cy.get('button.action-button')
+	cy.get('button.action-button, a.action-link')
 		.contains(title)
 		.click()
 })

--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -55,15 +55,8 @@
 				</template>
 				{{ toggleOutlineString }}
 			</NcActionButton>
-			<NcActionSeparator v-if="!inPageList" />
 
-			<!-- Open in files app action: only displayed in page title menu -->
-			<NcActionLink v-if="!inPageList && showFilesLink"
-				:href="filesUrl"
-				icon="icon-files-dark"
-				:close-after-click="true">
-				{{ t('collectives', 'Show in Files') }}
-			</NcActionLink>
+			<NcActionSeparator v-if="!inPageList" />
 
 			<!-- Favor page action: only displayed in page list and not for landing page -->
 			<NcActionButton v-if="inPageList"
@@ -98,6 +91,16 @@
 				{{ setEmojiString }}
 			</NcActionButton>
 
+			<!-- Open tags modal: always displayed if has edit permissions -->
+			<NcActionButton v-if="currentCollectiveCanEdit"
+				:close-after-click="true"
+				@click="onOpenTagsModal">
+				<template #icon>
+					<TagMultipleIcon :size="20" />
+				</template>
+				{{ t('collectives', 'Manage tags') }}
+			</NcActionButton>
+
 			<!-- Move/copy page via modal: only displayed in page list -->
 			<NcActionButton v-if="inPageList && currentCollectiveCanEdit && !isLandingPage"
 				:close-after-click="true"
@@ -108,14 +111,27 @@
 				{{ t('collectives', 'Move or copy') }}
 			</NcActionButton>
 
-			<NcActionButton v-if="currentCollectiveCanEdit"
-				:close-after-click="true"
-				@click="onOpenTagsModal">
+			<!-- Download action: only displayed in page title menu -->
+			<NcActionLink v-if="!inPageList"
+				:href="currentPageDavUrl"
+				:download="currentPage.fileName"
+				:close-after-click="true">
 				<template #icon>
-					<TagMultipleIcon :size="20" />
+					<DownloadIcon :size="20" />
 				</template>
-				{{ t('collectives', 'Manage tags') }}
-			</NcActionButton>
+				{{ t('collectives', 'Download') }}
+			</NcActionLink>
+
+			<!-- Open in files app action: only displayed in page title menu -->
+			<NcActionLink v-if="!inPageList && showFilesLink"
+				:href="filesUrl"
+				:close-after-click="true">
+				<template #icon>
+					<FolderIcon :size="20" />
+				</template>
+				{{ t('collectives', 'Show in Files') }}
+			</NcActionLink>
+
 			<!-- Delete page -->
 			<NcActionButton v-if="displayDeleteAction"
 				:close-after-click="true"
@@ -146,7 +162,9 @@ import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 import CollectiveActions from '../Collective/CollectiveActions.vue'
 import DeleteIcon from 'vue-material-design-icons/Delete.vue'
 import DockRightIcon from 'vue-material-design-icons/DockRight.vue'
+import DownloadIcon from 'vue-material-design-icons/Download.vue'
 import EmoticonIcon from 'vue-material-design-icons/Emoticon.vue'
+import FolderIcon from 'vue-material-design-icons/Folder.vue'
 import FormatListBulletedIcon from 'vue-material-design-icons/FormatListBulleted.vue'
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import MoveOrCopyModal from './MoveOrCopyModal.vue'
@@ -172,7 +190,9 @@ export default {
 		NcActionSeparator,
 		DeleteIcon,
 		DockRightIcon,
+		DownloadIcon,
 		EmoticonIcon,
+		FolderIcon,
 		FormatListBulletedIcon,
 		OpenInNewIcon,
 		PageActionLastUser,
@@ -244,6 +264,7 @@ export default {
 			'isFavoritePage',
 		]),
 		...mapState(usePagesStore, [
+			'currentPageDavUrl',
 			'hasOutline',
 			'hasSubpages',
 			'pagesTreeWalk',


### PR DESCRIPTION
Also move "Manage tags" action up in front of copy/move action.

Fixes: #1347

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1606" height="1530" alt="grafik" src="https://github.com/user-attachments/assets/15a6f4a2-fb27-41fe-bfb9-dd80eb026092" /> | <img width="1606" height="1530" alt="grafik" src="https://github.com/user-attachments/assets/03af8e87-03a3-4f1e-85a0-2f580ba4a46d" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
