### PR TITLE
chore: remove CSS rules for pre Nextcloud 30 support

### DIFF
--- a/src/components/Page/PageTitleBar.vue
+++ b/src/components/Page/PageTitleBar.vue
@@ -8,7 +8,6 @@
 		:class="{
 			'full-width-view': isFullWidth,
 			'sheet-view': !isFullWidth,
-			'pre-nc30': isPreNc30,
 		}"
 		data-cy-collectives="page-title-container">
 		<!-- Page emoji or icon -->
@@ -160,11 +159,6 @@ export default {
 			'isTextEdit',
 		]),
 
-		// TODO: remove when we stop supporting NC < 30
-		isPreNc30() {
-			return window.getComputedStyle(document.body).getPropertyValue('--default-clickable-area') === '44px'
-		},
-
 		titleChanged() {
 			return this.newTitle && this.newTitle !== this.currentPage.title
 		},
@@ -300,11 +294,6 @@ export default {
 
 	&.sheet-view {
 		margin: 0 0 0 max(0px, calc(50% - (var(--text-editor-max-width) / 2)));
-	}
-
-	// TODO: remove when we stop supporting NC < 30
-	&.pre-nc30 {
-		padding-top: 11px;
 	}
 
 	.button-emoji-page {

--- a/src/components/PageSidebar.vue
+++ b/src/components/PageSidebar.vue
@@ -11,7 +11,6 @@
 		:no-toggle="isMobile"
 		:toggle-classes="{
 			'page-sidebar-button': true,
-			'pre-nc30': isPreNc30,
 		}"
 		@close="close">
 		<NcAppSidebarTab id="attachments"
@@ -119,11 +118,6 @@ export default {
 				}
 			},
 		},
-
-		// TODO: remove when we stop supporting NC < 30
-		isPreNc30() {
-			return window.getComputedStyle(document.body).getPropertyValue('--default-clickable-area') === '44px'
-		},
 	},
 
 	methods: {
@@ -144,9 +138,3 @@ export default {
 	},
 }
 </script>
-
-<style lang="scss">
-.page-sidebar-button.pre-nc30 {
-	inset-block-start: 2px;
-}
-</style>

--- a/src/components/PageVersion.vue
+++ b/src/components/PageVersion.vue
@@ -9,7 +9,6 @@
 			:class="{
 				'full-width-view': isFullWidth,
 				'sheet-view': !isFullWidth,
-				'pre-nc30': isPreNc30,
 			}"
 			data-cy-collective="page-title-container">
 			<div class="page-title-icon">
@@ -96,11 +95,6 @@ export default {
 			'title',
 		]),
 
-		// TODO: remove when we stop supporting NC < 30
-		isPreNc30() {
-			return window.getComputedStyle(document.body).getPropertyValue('--default-clickable-area') === '44px'
-		},
-
 		isFullWidth() {
 			return this.currentPage.isFullWidth
 		},
@@ -171,11 +165,6 @@ export default {
 
 	&.sheet-view {
 		margin: 0 0 0 max(0px, calc(50% - (var(--text-editor-max-width) / 2)));
-	}
-
-	// TODO: remove when we stop supporting NC < 30
-	&.pre-nc30 {
-		padding-top: 11px;
 	}
 
 	.button-emoji-page {


### PR DESCRIPTION
We no longer support Nextcloud < 30.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
