### PR TITLE
chore(release): v3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.1.2 - 2025.09.01
+
+### 🚧Updates & Tooling
+* ⬆️ Bump guzzlehttp/guzzle from 7.9.3 to 7.10.0. (#1942)
+* ⬆️ Bump codecov/codecov-action from 5.4.3 to 5.5.0. (#1943)
+* ⬆️ Update dependency jest to ^30.1.1. (#1947)
+
+
 ## 3.1.1 - 2025.08.18
 
 ### 🐛Fixes

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ In your Nextcloud instance, simply navigate to **»Apps«**, find the
 **»Teams«** and **»Collectives«** apps and enable them.
 
 	]]></description>
-	<version>3.1.1</version>
+	<version>3.1.2</version>
 	<licence>agpl</licence>
 	<author>CollectiveCloud Team</author>
 	<namespace>Collectives</namespace>
@@ -47,7 +47,7 @@ In your Nextcloud instance, simply navigate to **»Apps«**, find the
 		https://raw.githubusercontent.com/nextcloud/collectives/main/docs/static/images/screenshot.png
 	</screenshot>
 	<dependencies>
-		<nextcloud min-version="30" max-version="31" />
+		<nextcloud min-version="30" max-version="32" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\Collectives\BackgroundJob\CleanupSessions</job>


### PR DESCRIPTION
Release v3.1.2, which is compatible with NC 32
