### PR TITLE
use filled star icon for fav items in page list

### DIFF
--- a/src/components/PageList/Item.vue
+++ b/src/components/PageList/Item.vue
@@ -48,7 +48,7 @@
 					:class="isCollapsed(pageId) ? 'collapsed' : 'expanded'" />
 			</template>
 			<template v-if="showFavoriteStar">
-				<StarIcon v-show="!filteredView"
+				<StarIconFilled v-show="!filteredView"
 					:size="18"
 					fill-color="var(--color-warning)"
 					:title="t('collectives', 'Favorite')"
@@ -106,7 +106,7 @@ import MenuRightIcon from 'vue-material-design-icons/MenuRightOutline.vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import PageIcon from '../Icon/PageIcon.vue'
 import PageActionMenu from '../Page/PageActionMenu.vue'
-import StarIcon from 'vue-material-design-icons/StarOutline.vue'
+import StarIconFilled from 'vue-material-design-icons/Star.vue'
 
 export default {
 	name: 'Item',
@@ -119,7 +119,7 @@ export default {
 		PageIcon,
 		PageActionMenu,
 		PlusIcon,
-		StarIcon,
+		StarIconFilled,
 	},
 
 	mixins: [


### PR DESCRIPTION
### 📝 Summary

This PR replaces the outlined star icon which is placed on a favorite item in the pages' list with a filled variant.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
<img width="151" height="123" alt="20250909_113755" src="https://github.com/user-attachments/assets/ba18b77a-6b1a-4cb0-891b-4ba50e72152b" />
|
<img width="142" height="127" alt="Screenshot from 2025-09-09 13-59-43" src="https://github.com/user-attachments/assets/98d1a27b-3306-46b5-b9a1-9300ed775981" />


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
