### PR TITLE
fix(pageList): Current page loading only when moving itself

### DIFF
--- a/src/mixins/pageMixin.js
+++ b/src/mixins/pageMixin.js
@@ -101,14 +101,11 @@ export default {
 		async copy(oldParentId, newParentId, pageId, newIndex) {
 			// Copy subpage to new parent
 			try {
-				this.load('currentPage')
 				await this.copyPage({ newParentId, pageId, index: newIndex })
 			} catch (e) {
 				console.error(e)
 				showError(t('collectives', 'Could not copy page'))
 				return
-			} finally {
-				this.done('currentPage')
 			}
 
 			showSuccess(t('collectives', `Page ${this.pageTitle(pageId)} copied to ${this.pageTitle(newParentId)}`))
@@ -129,8 +126,10 @@ export default {
 			this.addToSubpageOrder({ parentId: newParentId, pageId, newIndex })
 
 			// Move subpage to new parent
-			try {
+			if (currentPageId === pageId) {
 				this.load('currentPage')
+			}
+			try {
 				await this.movePage({ newParentId, pageId, index: newIndex })
 			} catch (e) {
 				showError(t('collectives', 'Could not move page'))


### PR DESCRIPTION
No need to mark current page as loading when copying a page or moving another page.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
