### PR TITLE
fix(CollectiveMembersModal): don't escape collective name in title

### DIFF
--- a/src/components/Nav/CollectiveMembersModal.vue
+++ b/src/components/Nav/CollectiveMembersModal.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<NcDialog :name="t('collectives', 'Members of collective {name}', { name: collective.name })"
+	<NcDialog :name="t('collectives', 'Members of collective {name}', { name: collective.name }, { escape: false })"
 		size="normal"
 		@closing="onClose">
 		<div class="modal-collective-members">


### PR DESCRIPTION
Per default, the translate function of @nextcloud/l10n runs escape-html against replacement variables, which turns quote characters into their HTML escaped equivalents. No need to do this here.

Fixes: #1690

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
