### PR TITLE
Make tag filtering and sorting case-insensitive

### DIFF
--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -318,15 +318,15 @@ export default {
 			return this.sortedTags
 				// Ignore already selected tags
 				.filter(t => !this.filterTags.some(ft => ft.id === t.id))
-				.filter(t => t.name.includes(this.filterStringTagPart))
+				.filter(t => t.name.toLowerCase().includes(this.filterStringTagPart))
 				.sort((t1, t2) => {
-					if (t1.name.startsWith(this.filterStringTagPart)) {
+					if (t1.name.toLowerCase().startsWith(this.filterStringTagPart)) {
 						return -1
-					} else if (t2.name.startsWith(this.filterStringTagPart)) {
+					} else if (t2.name.toLowerCase().startsWith(this.filterStringTagPart)) {
 						return 1
-					} else if (t1.name.split(' ').some(str => str.startsWith(this.filterStringTagPart))) {
+					} else if (t1.name.toLowerCase().split(' ').some(str => str.startsWith(this.filterStringTagPart))) {
 						return -1
-					} else if (t2.name.split(' ').some(str => str.startsWith(this.filterStringTagPart))) {
+					} else if (t2.name.toLowerCase().split(' ').some(str => str.startsWith(this.filterStringTagPart))) {
 						return 1
 					}
 					return 0


### PR DESCRIPTION
### 📝 Summary

* Resolves: #1950 

### Problem
When searching for tags that contain uppercase letters, they are not found because the search and sorting logic was case-sensitive. For example, a tag named "PageTag" could only be matched using lowercase input.

### Solution
Convert both the tag names and the search string to lowercase before filtering and sorting. This makes the search and sorting logic case-insensitive, so tags can be found regardless of capitalization.


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
