### PR TITLE
feat: track online/offline state

### DIFF
--- a/cypress/e2e/collective-offline.js
+++ b/cypress/e2e/collective-offline.js
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+describe('Collective offline', function() {
+	let collectiveId, pageId, pageSlugUrl
+	const collectiveName = 'Offline'
+	const pageName = 'First Page'
+	const pageSlug = 'First-Page'
+
+	before(function() {
+		cy.loginAs('bob')
+		cy.deleteAndSeedCollective(collectiveName)
+			.seedPage(pageName, '', 'Readme.md').then(({ collectiveId: cid, pageId: pid }) => {
+				collectiveId = cid
+				pageId = pid
+				pageSlugUrl = `/apps/collectives/${collectiveName}-${collectiveId}/${pageSlug}-${pageId}`
+			})
+	})
+
+	beforeEach(function() {
+		cy.loginAs('bob')
+		cy.visit(pageSlugUrl)
+		// make sure the page list loaded properly
+		cy.contains('.app-content-list-item a', pageName)
+	})
+
+	describe('Offline mode', function() {
+		it('Shows offline indicator', function() {
+			cy.get('.offline-indicator').should('not.exist')
+			cy.goOffline()
+			cy.get('.offline-indicator').should('be.visible')
+			cy.goOnline()
+		})
+
+		it('Shows offline state in version tab', function() {
+			cy.get('button.app-sidebar__toggle').click()
+			cy.get('#tab-button-versions').click()
+
+			cy.get('.app-sidebar-tabs__content .version-list .list-item')
+				.should('contain', 'Current version')
+
+			cy.goOffline()
+			cy.get('.app-sidebar-tabs__content .version-list .list-item')
+				.should('not.exist')
+			cy.get('.app-sidebar-tabs__content .versions-container')
+				.should('contain', 'Offline')
+			cy.goOnline()
+		})
+	})
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,6 +29,42 @@ Cypress.on('uncaught:exception', (err) => {
 	}
 })
 
+// Switch network state
+Cypress.Commands.add('goOffline', () => {
+	cy.log('**go offline**')
+		.then(() => {
+			return Cypress.automation('remote:debugger:protocol', { command: 'Network.enable' })
+		})
+		.then(() => {
+			return Cypress.automation('remote:debugger:protocol', {
+				command: 'Network.emulateNetworkConditions',
+				params: {
+					offline: true,
+					latency: -1,
+					downloadThroughput: -1,
+					uploadThroughput: -1,
+				},
+			})
+		})
+})
+Cypress.Commands.add('goOnline', () => {
+	cy.log('**go online**')
+		.then(() => {
+			return Cypress.automation('remote:debugger:protocol', {
+				command: 'Network.emulateNetworkConditions',
+				params: {
+					offline: false,
+					latency: -1,
+					downloadThroughput: -1,
+					uploadThroughput: -1,
+				},
+			})
+		})
+		.then(() => {
+			return Cypress.automation('remote:debugger:protocol', { command: 'Network.disable' })
+		})
+})
+
 // Copy of the new login command as long as we are blocked to upgrade @nextcloud/cypress by cypress crashes
 const login = function(user) {
 	cy.session(user, function() {

--- a/src/components/Collective.vue
+++ b/src/components/Collective.vue
@@ -188,8 +188,6 @@ export default {
 	border-radius: var(--border-radius-element);
 
 	&__button {
-		border: 1px solid var(--color-border) !important;
-
 		&.mobile {
 			// Same padding left and right on mobile without text
 			padding-inline: var(--default-grid-baseline);
@@ -203,8 +201,8 @@ export default {
 
 	&__dot {
 		display: inline-block;
-		height: 14px;
-		width: 14px;
+		height: 12px;
+		width: 12px;
 		background-color: var(--color-element-error, var(--color-error));
 		border-radius: 50%;
 	}

--- a/src/components/Collective.vue
+++ b/src/components/Collective.vue
@@ -11,6 +11,27 @@
 		<PageVersion v-else-if="currentPage && selectedVersion" />
 		<Page v-else-if="currentPage" />
 		<PageNotFound v-else />
+
+		<NcPopover v-if="!networkOnline"
+			:aria-label="t('collectives', 'Offline')"
+			:auto-hide="false"
+			no-focus-trap
+			class="offline-indicator">
+			<template #trigger>
+				<NcButton type="tertiary"
+					:aria-label="t('collectives', 'Offline')"
+					class="trigger offline-indicator__button"
+					:class="{'mobile': isMobile, 'desktop': !isMobile }">
+					<template #icon>
+						<span class="offline-indicator__dot" />
+					</template>
+					{{ offlineIndicatorText }}
+				</NcButton>
+			</template>
+			<div class="offline-indicator__hint">
+				<span>{{ t('collectives', 'Offline') }}</span>
+			</div>
+		</NcPopover>
 	</NcAppContentDetails>
 </template>
 
@@ -23,22 +44,32 @@ import { useTagsStore } from '../stores/tags.js'
 import { usePagesStore } from '../stores/pages.js'
 import { useVersionsStore } from '../stores/versions.js'
 import { emit } from '@nextcloud/event-bus'
-import { NcAppContentDetails } from '@nextcloud/vue'
+import { NcAppContentDetails, NcButton, NcPopover } from '@nextcloud/vue'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import displayError from '../util/displayError.js'
 import Page from './Page.vue'
 import PageVersion from './PageVersion.vue'
 import PageNotFound from './Page/PageNotFound.vue'
 import SkeletonLoading from './SkeletonLoading.vue'
+import { useNetworkState } from '../composables/useNetworkState.ts'
 
 export default {
 	name: 'Collective',
 
 	components: {
-		SkeletonLoading,
 		NcAppContentDetails,
+		NcButton,
+		NcPopover,
 		Page,
 		PageNotFound,
 		PageVersion,
+		SkeletonLoading,
+	},
+
+	setup() {
+		const isMobile = useIsMobile()
+		const { networkOnline } = useNetworkState()
+		return { isMobile, networkOnline }
 	},
 
 	computed: {
@@ -59,6 +90,12 @@ export default {
 
 		notFound() {
 			return !this.loading('pagelist') && !this.loading('currentPage') && !this.currentPage
+		},
+
+		offlineIndicatorText() {
+			return this.isMobile
+				? ''
+				: t('collectives', 'Offline')
 		},
 	},
 
@@ -120,6 +157,45 @@ export default {
 
 }
 </script>
+
+<style scoped lang="scss">
+.offline-indicator {
+	position: absolute;
+	z-index: 100010;
+	bottom: calc(var(--default-grid-baseline) * 3);
+	margin-left: calc(var(--default-grid-baseline) * 3);
+	background-color: var(--color-main-background);
+	border-radius: var(--border-radius-element);
+
+	&__button {
+		border: 1px solid var(--color-border) !important;
+
+		&.mobile {
+			// Same padding left and right on mobile without text
+			padding-inline: var(--default-grid-baseline);
+		}
+
+		&.desktop {
+			// No tooltip on desktop
+			pointer-events: none;
+		}
+	}
+
+	&__dot {
+		display: inline-block;
+		height: 14px;
+		width: 14px;
+		background-color: var(--color-element-error, var(--color-error));
+		border-radius: 50%;
+	}
+
+	&__hint {
+		padding: 12px;
+		max-width: 300px;
+		text-align: start;
+	}
+}
+</style>
 
 <style lang="scss">
 .app-content-details {

--- a/src/components/PageSidebar/OfflineContent.vue
+++ b/src/components/PageSidebar/OfflineContent.vue
@@ -1,0 +1,28 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcEmptyContent :name="t('collectives', 'Offline')"
+		:description="t('collectives', 'Make sure you are online and can reach the server.')">
+		<template #icon>
+			<CloudOffOutlineIcon />
+		</template>
+	</NcEmptyContent>
+</template>
+
+<script lang="ts">
+import { NcEmptyContent } from '@nextcloud/vue'
+import { defineComponent } from 'vue'
+import CloudOffOutlineIcon from 'vue-material-design-icons/CloudOffOutline.vue'
+
+export default defineComponent({
+	name: 'OfflineContent',
+
+	components: {
+		CloudOffOutlineIcon,
+		NcEmptyContent,
+	},
+})
+</script>

--- a/src/components/PageSidebar/SharingEntryLink.vue
+++ b/src/components/PageSidebar/SharingEntryLink.vue
@@ -31,6 +31,7 @@
 							ref="quickShareDropdown"
 							class="share-select-dropdown"
 							:aria-labelledby="dropdownId"
+							:title="offlineTitle"
 							tabindex="0"
 							@keydown.down="handleArrowDown"
 							@keydown.up="handleArrowUp"
@@ -38,7 +39,10 @@
 							<button v-for="option in dropdownOptions"
 								:key="option"
 								class="dropdown-item"
-								:class="{ 'selected': option === selectedDropdownOption }"
+								:class="{
+									'button--disabled': !networkOnline,
+									'selected': option === selectedDropdownOption,
+								}"
 								:aria-selected="option === selectedDropdownOption"
 								@click="selectOption(option)">
 								{{ option }}
@@ -116,6 +120,8 @@
 				class="sharing-entry__actions"
 				:aria-label="actionsTooltip"
 				menu-align="right"
+				:disabled="!networkOnline"
+				:title="offlineTitle"
 				:open.sync="open">
 				<template v-if="share">
 					<NcActionButton class="new-share-link" @click.prevent.stop="onNewShare">
@@ -186,6 +192,8 @@ import { mapActions, mapState } from 'pinia'
 import { useCollectivesStore } from '../../stores/collectives.js'
 import { useSharesStore } from '../../stores/shares.js'
 import { usePagesStore } from '../../stores/pages.js'
+import { useNetworkState } from '../../composables/useNetworkState.ts'
+
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { showError, showSuccess } from '@nextcloud/dialogs'
@@ -254,6 +262,11 @@ export default {
 		},
 	},
 
+	setup() {
+		const { networkOnline } = useNetworkState()
+		return { networkOnline }
+	},
+
 	data() {
 		return {
 			showDropdown: false,
@@ -276,6 +289,12 @@ export default {
 			return this.index > 1
 				? t('collectives', 'Share link ({index})', { index: this.index })
 				: t('collectives', 'Share link')
+		},
+
+		offlineTitle() {
+			return this.networkOnline
+				? ''
+				: t('collectives', 'You are offline')
 		},
 
 		dropdownId() {
@@ -715,6 +734,11 @@ export default {
 			width: 100%;
 			white-space: nowrap;
 			text-align: left;
+
+			&.button--disabled {
+				pointer-events: none;
+				opacity: .5;
+			}
 
 			&:hover {
 				background-color: var(--color-background-dark);

--- a/src/components/PageSidebar/SidebarTabAttachments.vue
+++ b/src/components/PageSidebar/SidebarTabAttachments.vue
@@ -16,7 +16,7 @@
 		<OfflineContent v-else-if="!loaded && !networkOnline" />
 
 		<!-- error message -->
-		<NcEmptyContent v-else-if="error " :name="error">
+		<NcEmptyContent v-else-if="error" :name="error">
 			<template #icon>
 				<AlertOctagonIcon />
 			</template>
@@ -294,6 +294,7 @@ export default {
 
 	watch: {
 		'page.id'() {
+			this.loaded = false
 			this.getAttachmentsForPage(true)
 		},
 		'networkOnline'(val) {

--- a/src/components/PageSidebar/SidebarTabAttachments.vue
+++ b/src/components/PageSidebar/SidebarTabAttachments.vue
@@ -200,6 +200,7 @@ export default {
 	data() {
 		return {
 			loaded: false,
+			loadPending: true,
 			error: '',
 		}
 	},
@@ -296,7 +297,7 @@ export default {
 			this.getAttachmentsForPage(true)
 		},
 		'networkOnline'(val) {
-			if (val && !this.loaded) {
+			if (val && this.loadPending) {
 				this.getAttachmentsForPage(true)
 			}
 		},
@@ -335,6 +336,7 @@ export default {
 		 * @param {boolean} setLoading Whether to set loading attribute
 		 */
 		async getAttachmentsForPage(setLoading) {
+			this.loadPending = true
 			if (!this.networkOnline) {
 				return
 			}
@@ -345,6 +347,7 @@ export default {
 			try {
 				await this.getAttachments(this.page)
 				this.loaded = true
+				this.loadPending = false
 			} catch (e) {
 				this.error = t('collectives', 'Could not get attachments')
 				console.error('Failed to get page attachments', e)

--- a/src/components/PageSidebar/SidebarTabBacklinks.vue
+++ b/src/components/PageSidebar/SidebarTabBacklinks.vue
@@ -121,6 +121,7 @@ export default {
 
 	watch: {
 		'page.id'() {
+			this.loaded = false
 			this.getBacklinksForPage()
 		},
 		'networkOnline'(val) {

--- a/src/components/PageSidebar/SidebarTabBacklinks.vue
+++ b/src/components/PageSidebar/SidebarTabBacklinks.vue
@@ -99,6 +99,7 @@ export default {
 	data() {
 		return {
 			loaded: false,
+			loadPending: true,
 			error: '',
 		}
 	},
@@ -123,7 +124,7 @@ export default {
 			this.getBacklinksForPage()
 		},
 		'networkOnline'(val) {
-			if (val && !this.loaded) {
+			if (val && this.loadPending) {
 				this.getBacklinksForPage()
 			}
 		},
@@ -141,6 +142,7 @@ export default {
 		 * Get backlinks for a page
 		 */
 		async getBacklinksForPage() {
+			this.loadPending = true
 			if (!this.networkOnline) {
 				return
 			}
@@ -149,6 +151,7 @@ export default {
 			try {
 				await this.getBacklinks(this.page)
 				this.loaded = true
+				this.loadPending = false
 			} catch (e) {
 				this.error = t('collectives', 'Could not get page backlinks')
 				console.error('Failed to get page backlinks', e)

--- a/src/components/PageSidebar/SidebarTabVersions.vue
+++ b/src/components/PageSidebar/SidebarTabVersions.vue
@@ -101,7 +101,7 @@ export default {
 
 	data() {
 		return {
-			loaded: false,
+			loadPending: true,
 			error: '',
 			showVersionLabelForm: false,
 			editedVersion: null,
@@ -157,7 +157,7 @@ export default {
 			this.getPageVersions()
 		},
 		'networkOnline'(val) {
-			if (val && !this.loaded) {
+			if (val && this.loadPending) {
 				this.getPageVersions()
 			}
 		},
@@ -181,6 +181,7 @@ export default {
 		 * Get versions of a page
 		 */
 		async getPageVersions() {
+			this.loadPending = true
 			if (!this.networkOnline) {
 				return
 			}
@@ -188,7 +189,7 @@ export default {
 			this.load('versions')
 			try {
 				await this.getVersions(this.pageId)
-				this.loaded = true
+				this.loadPending = false
 			} catch (e) {
 				this.error = t('collectives', 'Could not get page versions')
 				console.error('Failed to get page versions', e)

--- a/src/composables/useNetworkState.ts
+++ b/src/composables/useNetworkState.ts
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { subscribe } from '@nextcloud/event-bus'
+import { computed, ref } from 'vue'
+
+declare module '@nextcloud/event-bus' {
+	export interface NextcloudEvents {
+		networkOnline: { success: boolean }
+	}
+}
+
+/**
+ * Get network online/offline state
+ */
+export function useNetworkState() {
+	const offlineSince = ref(navigator.onLine ? null : Date.now())
+	const networkOnline = computed(() => !offlineSince.value)
+
+	subscribe('networkOnline', (event) => {
+		if (event.success) {
+			offlineSince.value = null
+		}
+	})
+	subscribe('networkOffline', () => {
+		offlineSince.value = Date.now()
+	})
+
+	return { networkOnline, offlineSince }
+}

--- a/src/views/CollectiveView.vue
+++ b/src/views/CollectiveView.vue
@@ -64,7 +64,6 @@ export default {
 
 	data() {
 		return {
-			loadPending: true,
 			backgroundFetching: false,
 			/** @type {number} */
 			pollIntervalBase: 60 * 1000, // milliseconds
@@ -198,7 +197,6 @@ export default {
 		},
 
 		async getAllPages(setLoading = true) {
-			this.loadPending = true
 			if (!this.networkOnline) {
 				return
 			}
@@ -220,7 +218,6 @@ export default {
 
 			try {
 				await Promise.all(promises)
-				this.loadPending = false
 			} catch (e) {
 				displayError('Could not fetch collective details')(e)
 			}


### PR DESCRIPTION
### 📝 Summary

* Handle offline state in all page sidebar tabs
* Add offline state indicator
* Don't send page API requests when offline
* Resolves: #1796
* Resolves: #1961 

#### 🖼️ Screenshots offline indicator

Desktop | Mobile | Mobile clicked
--- | --- | ---
<img width="1918" height="852" alt="image" src="https://github.com/user-attachments/assets/59b40cf3-4ca4-44f2-8055-b55e00ed3e7f" /> | <img width="600" height="717" alt="image" src="https://github.com/user-attachments/assets/784edf52-0bf1-46a7-a665-77f25cc3f6de" /> | <img width="600" height="720" alt="image" src="https://github.com/user-attachments/assets/ff930d8b-13ad-4fbe-b693-4933e90d56bc" />

#### 🖼️ Screenshots page sidebar tabs

Versions tab | Attachments tab | Shares tab
---|--- | ---
<img width="745" height="750" alt="image" src="https://github.com/user-attachments/assets/62955c19-ce0a-4615-9981-f54318cfcc13" /> | <img width="757" height="760" alt="image" src="https://github.com/user-attachments/assets/554ba9a1-ee5e-4c2b-9f18-161eb2512ab9" /> | <img width="760" height="754" alt="image" src="https://github.com/user-attachments/assets/76bbeedc-e19a-48d6-a81f-8936a119f501" />

#### 🖼️ Screenshots request errors

Before | Pages request error new | Any other request error new
--- | --- | ---
<img width="496" height="549" alt="image" src="https://github.com/user-attachments/assets/99a91893-1fb8-4771-b885-e2cef985bfea" /> | <img width="420" height="223" alt="image" src="https://github.com/user-attachments/assets/769700c5-51b0-4858-9a37-88e22dee5f6a" /> | <img width="519" height="256" alt="image" src="https://github.com/user-attachments/assets/3b812447-cd67-468d-aadb-1822ce24d708" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
