### PR TITLE
Adjust colors of version list item

### DIFF
--- a/src/components/PageSidebar/Version.vue
+++ b/src/components/PageSidebar/Version.vue
@@ -226,6 +226,21 @@ export default {
 	display: flex;
 	flex-direction: row;
 
+	&.active :deep(.list-item) {
+		background-color: var(--color-background-hover) !important;
+	}
+
+	:deep(.action-item__menutoggle) {
+		border: none !important;
+		outline: none !important;
+		box-shadow: none !important;
+	}
+
+	&.active :deep(.action-item__menutoggle) {
+		background-color: var(--color-background-hover);
+		color: var(--color-main-text);
+	}
+
 	.version-icon {
 		height: 34px;
 		border-radius: var(--border-radius);


### PR DESCRIPTION
### 📝 Summary

Update the colors of the list items in the 'Versions' tab of the sidebar. Use the same colors as in the Files app.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
<img width="486" height="131" alt="Screenshot from 2025-09-24 14-40-26" src="https://github.com/user-attachments/assets/7a102f4f-d39d-427f-bf04-f05c27ecda56" />
|
<img width="486" height="131" alt="Screenshot from 2025-09-24 14-39-51" src="https://github.com/user-attachments/assets/a3396a24-7357-4e0e-a842-255561e664de" />

### 🏁 Checklist

- [X] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [X] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
