### PR TITLE
Fix arrow buttons visual feedback in move/copy modal

### DIFF
--- a/src/components/Page/PagePicker.vue
+++ b/src/components/Page/PagePicker.vue
@@ -315,15 +315,12 @@ export default {
 		swapSubpages(from, to) {
 			const length = this.subpages.length - 1
 			if (from >= 0 && from <= length && to >= 0 && to <= length) {
-				// Create a copy of the subpages array to manipulate
-				const reorderedPages = [...this.subpages]
-				// Swap the elements
-				const temp = reorderedPages[from]
-				reorderedPages[from] = reorderedPages[to]
-				reorderedPages[to] = temp
-
-				// Update the component data to trigger reactivity
-				this.$set(this, 'reorderedSubpages', reorderedPages)
+				// Initialize reorderedSubpages if not already set
+				if (!this.reorderedSubpages) {
+					this.reorderedSubpages = [...this.subpages]
+				}
+				// Use splice to swap elements while maintaining reactivity
+				this.reorderedSubpages.splice(from, 1, this.reorderedSubpages.splice(to, 1, this.reorderedSubpages[from])[0])
 			}
 
 			// Scroll current page into view


### PR DESCRIPTION
### 📝 Summary

* Resolves: #1912 

**Before**:
- When users clicked the up/down arrow buttons in the "Move or Copy" modal, the list items did not move inside the modal, i.e., there was no visual feedback.

**How it works now**:
- When users click the up/down arrow buttons in the "Move or Copy" modal, they'll see immediate visual feedback as the page moves in the list
- The reordered position is preserved while they're in the same location
- When they navigate away and come back, or when they click "Move page here", the actual move operation will use the new position they selected
- The visual feedback makes it clear where the page will be moved to before they confirm the action
→ This gives users the visual feedback they need to understand where their page will be positioned before completing the move operation.

#### 🖼️ Screenshots

<img width="674" height="558" alt="Screenshot from 2025-09-24 15-36-55" src="https://github.com/user-attachments/assets/8b342aaf-bff8-4a46-aee7-6fb4a3a8f387" />

### 🏁 Checklist

- [X] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [X] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
