### PR TITLE
fix(Version): don't override text color for active NcListItem element

### DIFF
--- a/src/components/PageSidebar/Version.vue
+++ b/src/components/PageSidebar/Version.vue
@@ -240,7 +240,6 @@ export default {
 		flex-direction: row;
 		align-items: center;
 		gap: 0.5rem;
-		color: var(--color-main-text);
 		font-weight: 500;
 
 		&__label {
@@ -254,10 +253,6 @@ export default {
 			// Fix overflow on narrow screens
 			overflow: hidden;
 			text-overflow: ellipsis;
-		}
-
-		&__subline {
-			// color: var(--color-text-maxcontrast);
 		}
 	}
 }


### PR DESCRIPTION
#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="998" height="880" alt="image" src="https://github.com/user-attachments/assets/60a2a0f4-338e-4a8d-aae5-a2b36ff4fb77" /> | <img width="998" height="882" alt="image" src="https://github.com/user-attachments/assets/e974fbdc-e488-4d7e-b425-249f6e2cbd0a" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
