### PR TITLE
chore: migrate some @nextcloud/vue usages

### DIFF
--- a/src/components/Member/Member.vue
+++ b/src/components/Member/Member.vue
@@ -19,7 +19,7 @@
 			:icon-class="iconClass"
 			:disable-menu="true"
 			:disable-tooltip="true"
-			:show-user-status="false"
+			:hide-status="true"
 			:size="avatarSize" />
 
 		<!-- Data -->

--- a/src/components/Member/MemberPicker.vue
+++ b/src/components/Member/MemberPicker.vue
@@ -12,7 +12,7 @@
 			:show-trailing-button="hasSearchQuery"
 			:label="t('collectives', 'Search accounts, groups, teams')"
 			@trailing-button-click="clearSearch"
-			@input="onSearch">
+			@update:modelValue="onSearch">
 			<MagnifyIcon :size="16" />
 		</NcTextField>
 

--- a/src/components/Nav/CollectiveListItem.vue
+++ b/src/components/Nav/CollectiveListItem.vue
@@ -30,7 +30,7 @@ import { mapActions, mapState } from 'pinia'
 import { useRootStore } from '../../stores/root.js'
 import { useCollectivesStore } from '../../stores/collectives.js'
 import { NcAppNavigationItem } from '@nextcloud/vue'
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import CollectiveActions from '../Collective/CollectiveActions.vue'
 import CollectivesIcon from '../Icon/CollectivesIcon.vue'
 
@@ -43,15 +43,16 @@ export default {
 		CollectivesIcon,
 	},
 
-	mixins: [
-		isMobile,
-	],
-
 	props: {
 		collective: {
 			type: Object,
 			required: true,
 		},
+	},
+
+	setup() {
+		const isMobile = useIsMobile()
+		return { isMobile }
 	},
 
 	computed: {

--- a/src/components/Nav/CollectiveSettings.vue
+++ b/src/components/Nav/CollectiveSettings.vue
@@ -14,7 +14,7 @@
 					:selected-emoji="collective.emoji"
 					@select="updateEmoji"
 					@unselect="unselectEmoji">
-					<NcButton type="tertiary"
+					<NcButton variant="tertiary"
 						:aria-label="t('collectives', 'Select emoji for collective')"
 						:class="{'loading': loading('updateCollectiveEmoji') || loading('renameCollective')}"
 						class="button-emoji"
@@ -31,7 +31,7 @@
 					:label="getRenameLabel"
 					:error="isNameTooShort"
 					:show-trailing-button="!isNameTooShort"
-					trailing-button-icon="arrowRight"
+					trailing-button-icon="arrowEnd"
 					class="collective-name-input"
 					@blur="renameCollective()"
 					@keypress.enter.prevent="renameCollective()"
@@ -130,7 +130,7 @@
 
 		<NcAppSettingsSection id="danger-zone" :name="t('collectives', 'Danger zone')">
 			<div>
-				<NcButton type="error" :aria-label="t('collectives', 'Delete collective')" @click="onTrashCollective()">
+				<NcButton variant="error" :aria-label="t('collectives', 'Delete collective')" @click="onTrashCollective()">
 					{{ t('collectives', 'Delete collective') }}
 				</NcButton>
 			</div>
@@ -147,9 +147,8 @@ import { useCollectivesStore } from '../../stores/collectives.js'
 import { usePagesStore } from '../../stores/pages.js'
 import { emit } from '@nextcloud/event-bus'
 import { showError, showSuccess } from '@nextcloud/dialogs'
-import { NcAppSettingsDialog, NcAppSettingsSection, NcButton, NcCheckboxRadioSwitch, NcTextField } from '@nextcloud/vue'
+import { NcAppSettingsDialog, NcAppSettingsSection, NcButton, NcCheckboxRadioSwitch, NcEmojiPicker, NcTextField } from '@nextcloud/vue'
 import AlertCircleIcon from 'vue-material-design-icons/AlertCircleOutline.vue'
-import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
 import Emoticon from 'vue-material-design-icons/EmoticonOutline.vue'
 import displayError from '../../util/displayError.js'
 

--- a/src/components/Nav/CollectivesTrash.vue
+++ b/src/components/Nav/CollectivesTrash.vue
@@ -96,7 +96,7 @@
 import { mapState } from 'pinia'
 import { useCollectivesStore } from '../../stores/collectives.js'
 import { NcActionButton, NcAppNavigationItem, NcButton, NcDialog } from '@nextcloud/vue'
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import CollectivesIcon from '../Icon/CollectivesIcon.vue'
 import DeleteIcon from 'vue-material-design-icons/TrashCanOutline.vue'
 import RestoreIcon from 'vue-material-design-icons/Restore.vue'
@@ -119,9 +119,10 @@ export default {
 		RestoreIcon,
 	},
 
-	mixins: [
-		isMobile,
-	],
+	setup() {
+		const isMobile = useIsMobile()
+		return { isMobile }
+	},
 
 	data() {
 		return {

--- a/src/components/Nav/CollectivesTrash.vue
+++ b/src/components/Nav/CollectivesTrash.vue
@@ -8,7 +8,7 @@
 		v-click-outside="closeTrash"
 		:class="{ open }">
 		<div id="collectives-trash__header">
-			<NcButton type="tertiary"
+			<NcButton variant="tertiary"
 				:aria-label="t('collectives', 'Deleted collectives')"
 				class="collectives-trash-button"
 				@click="toggleTrash">
@@ -64,21 +64,21 @@
 				</div>
 			</div>
 			<template #actions>
-				<NcButton type="error"
+				<NcButton variant="error"
 					:aria-label="t('collectives', 'Delete only collective')"
 					:wide="true"
 					@click="deleteCollective(modalCollective, false)">
 					{{ t('collectives', 'Only collective') }}
 				</NcButton>
 				<NcButton v-if="isCollectiveOwner(modalCollective)"
-					type="error"
+					variant="error"
 					:aria-label="t('collectives', 'Delete collective and team')"
 					:wide="true"
 					@click="deleteCollective(modalCollective, true)">
 					{{ t('collectives', 'Collective and team') }}
 				</NcButton>
 				<NcButton v-else
-					type="primary"
+					variant="primary"
 					disabled
 					:title="t('collectives', 'Only team owners can delete a team')"
 					:wide="true">

--- a/src/components/Nav/NewCollectiveModal.vue
+++ b/src/components/Nav/NewCollectiveModal.vue
@@ -10,7 +10,7 @@
 		<div v-if="state === 0" class="modal-collective-wrapper">
 			<div class="modal-collective-name">
 				<NcEmojiPicker :show-preview="true" @select="updateEmoji">
-					<NcButton type="tertiary"
+					<NcButton variant="tertiary"
 						:aria-label="t('collectives', 'Select emoji for collective')"
 						:title="t('collectives', 'Select emoji')"
 						class="button-emoji"
@@ -37,7 +37,7 @@
 					:placeholder="t('collectives', 'Select a team…')" />
 				<NcButton v-if="anyCircle && !pickCircle"
 					:title="t('collectives', 'Select an existing team')"
-					type="tertiary"
+					variant="tertiary"
 					@click.stop.prevent="startSelectCircle">
 					<template #icon>
 						<TeamsIcon :size="16" />
@@ -45,7 +45,7 @@
 				</NcButton>
 				<NcButton v-if="anyCircle && pickCircle"
 					:title="t('collectives', 'Cancel selecting a team')"
-					type="tertiary"
+					variant="tertiary"
 					@click.stop.prevent="stopSelectCircle">
 					<template #icon>
 						<CloseIcon :size="16" />
@@ -84,7 +84,7 @@
 				<NcButton :aria-label="t('collectives', 'Cancel')" @click="onClose">
 					{{ t('collectives', 'Cancel') }}
 				</NcButton>
-				<NcButton type="primary"
+				<NcButton variant="primary"
 					:aria-label="t('collectives', 'Add members')"
 					:disabled="!newCollectiveName || nameIsInvalid"
 					class="modal-buttons-right"
@@ -96,7 +96,7 @@
 				<NcButton :aria-label="t('collectives', 'Go back')" @click="state = 0">
 					{{ t('collectives', 'Back') }}
 				</NcButton>
-				<NcButton type="primary"
+				<NcButton variant="primary"
 					:aria-label="createButtonString"
 					:disabled="loading"
 					class="modal-buttons-right"

--- a/src/components/Nav/TemplateListItem.vue
+++ b/src/components/Nav/TemplateListItem.vue
@@ -12,7 +12,7 @@
 				:selected-emoji="template.emoji"
 				@select="onSelectEmoji($event, template.id)"
 				@unselect="onUnselectEmoji(template.id)">
-				<NcButton type="tertiary"
+				<NcButton variant="tertiary"
 					:aria-label="t('collectives', 'Select emoji for template')"
 					:title="t('collectives', 'Select emoji')"
 					class="button-template-emoji"
@@ -89,8 +89,7 @@ import { useTemplatesStore } from '../../stores/templates.js'
 import { showError } from '@nextcloud/dialogs'
 import { directive as ClickOutside } from 'v-click-outside'
 
-import { NcActionButton, NcActions, NcButton, NcLoadingIcon, NcTextField } from '@nextcloud/vue'
-import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
+import { NcActionButton, NcActions, NcButton, NcEmojiPicker, NcLoadingIcon, NcTextField } from '@nextcloud/vue'
 
 import DeleteIcon from 'vue-material-design-icons/TrashCanOutline.vue'
 import EmoticonIcon from 'vue-material-design-icons/EmoticonOutline.vue'

--- a/src/components/Nav/TemplatesDialog.vue
+++ b/src/components/Nav/TemplatesDialog.vue
@@ -21,7 +21,7 @@
 
 		<!-- Template actions -->
 		<template #actions>
-			<NcButton type="secondary"
+			<NcButton variant="secondary"
 				:aria-label="t('collectives', 'Add a template')"
 				@click="onCreate(0)">
 				<template #icon>

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -18,7 +18,7 @@
 			<li>
 				<NcAppNavigationNew v-if="!isPublic"
 					:text="t('collectives', 'New collective')"
-					type="secondary"
+					variant="secondary"
 					class="new-collective-button"
 					@click="onOpenNewCollectiveModal">
 					<template #icon>

--- a/src/components/Page/EditButton.vue
+++ b/src/components/Page/EditButton.vue
@@ -10,7 +10,7 @@
 			:aria-label="description"
 			class="titleform-button"
 			:class="{ 'mobile': mobile }"
-			type="primary"
+			variant="primary"
 			@click="handleClick()">
 			<template #icon>
 				<NcLoadingIcon v-if="showLoadingIcon"

--- a/src/components/Page/LandingPageWidgets/MembersWidget.vue
+++ b/src/components/Page/LandingPageWidgets/MembersWidget.vue
@@ -67,9 +67,8 @@ import { generateUrl } from '@nextcloud/router'
 import { circlesMemberTypes } from '../../../constants.js'
 import { showError } from '@nextcloud/dialogs'
 
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
-
 import { NcAvatar, NcButton } from '@nextcloud/vue'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import AccountMultipleIcon from 'vue-material-design-icons/AccountMultipleOutline.vue'
 import AccountMultiplePlusIcon from 'vue-material-design-icons/AccountMultiplePlus.vue'
 import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
@@ -91,9 +90,10 @@ export default {
 		WidgetHeading,
 	},
 
-	mixins: [
-		isMobile,
-	],
+	setup() {
+		const isMobile = useIsMobile()
+		return { isMobile }
+	},
 
 	data() {
 		return {

--- a/src/components/Page/LandingPageWidgets/MembersWidget.vue
+++ b/src/components/Page/LandingPageWidgets/MembersWidget.vue
@@ -43,7 +43,7 @@
 					:disable-menu="true"
 					:tooltip-message="member.displayName"
 					:size="avatarSize" />
-				<NcButton type="tertiary"
+				<NcButton variant="tertiary"
 					:title="showMembersTitle"
 					:aria-label="showMembersAriaLabel"
 					@click="openCollectiveMembers()">

--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -158,7 +158,7 @@ import { useRootStore } from '../../stores/root.js'
 import { useCollectivesStore } from '../../stores/collectives.js'
 import { generateUrl } from '@nextcloud/router'
 import { NcActions, NcActionButton, NcActionCheckbox, NcActionLink, NcActionSeparator } from '@nextcloud/vue'
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import CollectiveActions from '../Collective/CollectiveActions.vue'
 import DeleteIcon from 'vue-material-design-icons/TrashCanOutline.vue'
 import DockRightIcon from 'vue-material-design-icons/DockRight.vue'
@@ -204,7 +204,6 @@ export default {
 	},
 
 	mixins: [
-		isMobile,
 		pageMixin,
 	],
 
@@ -245,6 +244,11 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+	},
+
+	setup() {
+		const isMobile = useIsMobile()
+		return { isMobile }
 	},
 
 	data() {

--- a/src/components/Page/PagePicker.vue
+++ b/src/components/Page/PagePicker.vue
@@ -10,7 +10,7 @@
 		@closing="onClose">
 		<span class="crumbs">
 			<div v-if="!selectedCollective || !selectedCollective.isPageShare" class="crumbs-home">
-				<NcButton type="tertiary"
+				<NcButton variant="tertiary"
 					:aria-label="t('collectives', 'Breadcrumb for list of collectives')"
 					:disabled="!selectedCollective"
 					class="crumb-button home"
@@ -24,7 +24,7 @@
 			</div>
 			<template v-if="selectedCollective">
 				<div class="crumbs-level">
-					<NcButton type="tertiary"
+					<NcButton variant="tertiary"
 						:aria-label="collectiveBreadcrumbAriaLabel"
 						:disabled="pageCrumbs.length === 0"
 						class="crumb-button"
@@ -39,7 +39,7 @@
 					:key="page.id"
 					class="crumbs-level">
 					<ChevronRightIcon :size="20" />
-					<NcButton type="tertiary"
+					<NcButton variant="tertiary"
 						:aria-label="t('collectives', 'Breadcrumb, navigate to page {page}', {page: page.title })"
 						:disabled="(index + 1) === pageCrumbs.length"
 						class="crumb-button"
@@ -89,7 +89,7 @@
 						<div v-if="page.id === pageId" class="picker-move-buttons">
 							<NcButton :disabled="index === 0"
 								:aria-label="t('collectives', 'Move page up')"
-								type="tertiary"
+								variant="tertiary"
 								@click="onClickUp">
 								<template #icon>
 									<ArrowUpIcon :size="20" />
@@ -97,7 +97,7 @@
 							</NcButton>
 							<NcButton :disabled="index === (subpages.length - 1)"
 								:aria-label="t('collectives', 'Move page down')"
-								type="tertiary"
+								variant="tertiary"
 								@click="onClickDown">
 								<template #icon>
 									<ArrowDownIcon :size="20" />
@@ -109,7 +109,7 @@
 			</ul>
 		</div>
 		<template #actions>
-			<NcButton type="secondary"
+			<NcButton variant="secondary"
 				:aria-label="t('collectives', copyPageString)"
 				:disabled="isActionButtonsDisabled"
 				@click="onMoveOrCopy(true)">
@@ -118,7 +118,7 @@
 				</template>
 				{{ copyPageString }}
 			</NcButton>
-			<NcButton type="primary"
+			<NcButton variant="primary"
 				:aria-label="t('collectives', movePageString)"
 				:disabled="isActionButtonsDisabled"
 				@click="onMoveOrCopy(false)">

--- a/src/components/Page/PageTitle.vue
+++ b/src/components/Page/PageTitle.vue
@@ -22,14 +22,10 @@
 </template>
 
 <script>
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 
 export default {
 	name: 'PageTitle',
-
-	mixins: [
-		isMobile,
-	],
 
 	props: {
 		value: {
@@ -44,6 +40,11 @@ export default {
 			type: String,
 			default: '',
 		},
+	},
+
+	setup() {
+		const isMobile = useIsMobile()
+		return { isMobile }
 	},
 
 	data() {

--- a/src/components/Page/PageTitleBar.vue
+++ b/src/components/Page/PageTitleBar.vue
@@ -27,7 +27,7 @@
 				:selected-emoji="currentPage.emoji"
 				@select="onSelectEmoji"
 				@unselect="onUnselectEmoji">
-				<NcButton type="tertiary"
+				<NcButton variant="tertiary"
 					:aria-label="t('collectives', 'Select emoji for page')"
 					:title="t('collectives', 'Select emoji')"
 					class="button-emoji-page"
@@ -101,8 +101,7 @@ import { useCollectivesStore } from '../../stores/collectives.js'
 import { usePagesStore } from '../../stores/pages.js'
 import { showError } from '@nextcloud/dialogs'
 
-import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
-import NcEmojiPicker from '@nextcloud/vue/dist/Components/NcEmojiPicker.js'
+import { NcButton, NcEmojiPicker, NcLoadingIcon } from '@nextcloud/vue'
 import CollectivesIcon from '../Icon/CollectivesIcon.vue'
 import EmoticonIcon from 'vue-material-design-icons/EmoticonOutline.vue'
 import EditButton from './EditButton.vue'

--- a/src/components/Page/PageTitleBar.vue
+++ b/src/components/Page/PageTitleBar.vue
@@ -92,7 +92,6 @@
 	</div>
 </template>
 <script>
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 import pageMixin from '../../mixins/pageMixin.js'
 
 import { mapActions, mapState } from 'pinia'
@@ -102,6 +101,7 @@ import { usePagesStore } from '../../stores/pages.js'
 import { showError } from '@nextcloud/dialogs'
 
 import { NcButton, NcEmojiPicker, NcLoadingIcon } from '@nextcloud/vue'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import CollectivesIcon from '../Icon/CollectivesIcon.vue'
 import EmoticonIcon from 'vue-material-design-icons/EmoticonOutline.vue'
 import EditButton from './EditButton.vue'
@@ -123,7 +123,6 @@ export default {
 	},
 
 	mixins: [
-		isMobile,
 		pageMixin,
 	],
 
@@ -132,6 +131,11 @@ export default {
 			type: Boolean,
 			required: true,
 		},
+	},
+
+	setup() {
+		const isMobile = useIsMobile()
+		return { isMobile }
 	},
 
 	data() {
@@ -188,7 +192,7 @@ export default {
 		},
 
 		pageTitleIconSize() {
-			return isMobile ? 25 : 30
+			return this.isMobile ? 25 : 30
 		},
 	},
 

--- a/src/components/Page/SearchDialog.vue
+++ b/src/components/Page/SearchDialog.vue
@@ -7,7 +7,7 @@
 	<div v-if="shouldShow" class="search-dialog-container">
 		<div class="search-dialog__buttons">
 			<NcButton alignment="center-reverse"
-				type="tertiary"
+				variant="tertiary"
 				:aria-label="t('collectives', 'Clear search')"
 				@click="clearSearch">
 				<template #icon>

--- a/src/components/Page/TagsModal.vue
+++ b/src/components/Page/TagsModal.vue
@@ -60,7 +60,7 @@
 					class="tags-modal__tag-color"
 					@update:shown="openedPicker = $event ? tag.id : false"
 					@submit="onSubmitColor(tag, $event)">
-					<NcButton :aria-label="t('collectives', 'Change tag color')" type="tertiary">
+					<NcButton :aria-label="t('collectives', 'Change tag color')" variant="tertiary">
 						<template #icon>
 							<CircleIcon v-if="tag.color" :size="24" fill-color="var(--color-circle-icon)" />
 							<CircleOutlineIcon v-else :size="24" fill-color="var(--color-circle-icon" />
@@ -101,8 +101,8 @@
 					:aria-label="t('collectives', 'Create new tag {tag}', { tag: input.trim() })"
 					alignment="start"
 					class="tags-modal__tag-create"
-					native-type="submit"
-					type="tertiary"
+					type="submit"
+					variant="tertiary"
 					@click="onNewTag">
 					{{ input.trim() }}<br>
 					<span class="tags-modal__tag-create-subline">{{ t('collectives', 'Create new tag') }}</span>

--- a/src/components/Page/TagsModal.vue
+++ b/src/components/Page/TagsModal.vue
@@ -44,7 +44,7 @@
 					:loading="loading(`page-tag-${pageId}-${tag.id}`)"
 					:disabled="tag.deleted"
 					class="tags-modal__tag-checkbox"
-					@update:checked="onCheckUpdate(tag, $event)">
+					@update:modelValue="onCheckUpdate(tag, $event)">
 					<template v-if="!tag.deleted">
 						{{ tag.name }}
 					</template>

--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -126,7 +126,7 @@
 						{{ sortedByString }}
 					</span>
 					<NcButton :aria-label="t('collectives', 'Switch back to default sort order')"
-						type="tertiary"
+						variant="tertiary"
 						class="sort-order-chip-button"
 						@click="sortPagesAndScroll('byOrder')">
 						<template #icon>

--- a/src/components/PageList/Item.vue
+++ b/src/components/PageList/Item.vue
@@ -97,11 +97,11 @@ import { usePagesStore } from '../../stores/pages.js'
 import { useTemplatesStore } from '../../stores/templates.js'
 import { generateUrl } from '@nextcloud/router'
 import { scrollToPage } from '../../util/scrollToElement.js'
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 import pageMixin from '../../mixins/pageMixin.js'
 
 import CollectivesIcon from '../Icon/CollectivesIcon.vue'
 import { NcActionButton, NcActions } from '@nextcloud/vue'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import MenuRightIcon from 'vue-material-design-icons/MenuRightOutline.vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import PageIcon from '../Icon/PageIcon.vue'
@@ -123,7 +123,6 @@ export default {
 	},
 
 	mixins: [
-		isMobile,
 		pageMixin,
 	],
 
@@ -188,6 +187,11 @@ export default {
 			type: Boolean,
 			required: true,
 		},
+	},
+
+	setup() {
+		const isMobile = useIsMobile()
+		return { isMobile }
 	},
 
 	data() {

--- a/src/components/PageList/PageFavorites.vue
+++ b/src/components/PageList/PageFavorites.vue
@@ -12,7 +12,7 @@
 			<div class="app-content-list-item-line-one" @click="toggleFavorites">
 				{{ t('collectives', 'Favorites') }}
 				<NcButton :aria-label="t('collectives', 'Toggle favorites')"
-					type="tertiary"
+					variant="tertiary"
 					class="toggle-favorites-button">
 					<template #icon>
 						<ChevronDownIcon :size="22"

--- a/src/components/PageList/PageTrash.vue
+++ b/src/components/PageList/PageTrash.vue
@@ -87,7 +87,7 @@
 import { mapActions, mapState } from 'pinia'
 import { usePagesStore } from '../../stores/pages.js'
 import { NcActions, NcActionButton, NcButton, NcDialog, NcEmptyContent } from '@nextcloud/vue'
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { showSuccess } from '@nextcloud/dialogs'
 import moment from '@nextcloud/moment'
@@ -110,9 +110,10 @@ export default {
 		PageIcon,
 	},
 
-	mixins: [
-		isMobile,
-	],
+	setup() {
+		const isMobile = useIsMobile()
+		return { isMobile }
+	},
 
 	data() {
 		return {

--- a/src/components/PageList/PageTrash.vue
+++ b/src/components/PageList/PageTrash.vue
@@ -6,7 +6,7 @@
 <template>
 	<div class="page-trash">
 		<NcButton ref="pagetrashbutton"
-			type="tertiary"
+			variant="tertiary"
 			:aria-label="t('collectives', 'Show deleted pages')"
 			class="page-trash-button"
 			@click="openTrash">

--- a/src/components/PageSidebar.vue
+++ b/src/components/PageSidebar.vue
@@ -59,11 +59,11 @@ import { useCollectivesStore } from '../stores/collectives.js'
 import { usePagesStore } from '../stores/pages.js'
 import { useVersionsStore } from '../stores/versions.js'
 import { NcAppSidebar, NcAppSidebarTab } from '@nextcloud/vue'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import BackupRestoreIcon from 'vue-material-design-icons/BackupRestore.vue'
 import ArrowBottomLeftIcon from 'vue-material-design-icons/ArrowBottomLeft.vue'
 import PaperclipIcon from 'vue-material-design-icons/Paperclip.vue'
 import ShareVariantIcon from 'vue-material-design-icons/ShareVariantOutline.vue'
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 import SidebarTabAttachments from './PageSidebar/SidebarTabAttachments.vue'
 import SidebarTabBacklinks from './PageSidebar/SidebarTabBacklinks.vue'
 import SidebarTabSharing from './PageSidebar/SidebarTabSharing.vue'
@@ -85,9 +85,10 @@ export default {
 		SidebarTabVersions,
 	},
 
-	mixins: [
-		isMobile,
-	],
+	setup() {
+		const isMobile = useIsMobile()
+		return { isMobile }
+	},
 
 	computed: {
 		...mapState(useRootStore, ['activeSidebarTab', 'isPublic', 'showing']),

--- a/src/components/PageSidebar/SharingEntryLink.vue
+++ b/src/components/PageSidebar/SharingEntryLink.vue
@@ -173,7 +173,7 @@
 				<NcButton :aria-label="t('collectives', 'Cancel')" @click="cancelSettings">
 					{{ t('collectives', 'Cancel') }}
 				</NcButton>
-				<NcButton type="primary" :aria-label="t('collectives', 'Update share')" @click="saveSettings">
+				<NcButton variant="primary" :aria-label="t('collectives', 'Update share')" @click="saveSettings">
 					{{ t('collectives', 'Update share') }}
 				</NcButton>
 			</div>

--- a/src/components/PageSidebar/SharingEntryLink.vue
+++ b/src/components/PageSidebar/SharingEntryLink.vue
@@ -168,7 +168,7 @@
 				:required="isPasswordEnforced"
 				:minlength="passwordPolicy.minLength ?? 0"
 				:label="t('collectives', 'Password')"
-				@update:value="onPasswordChange" />
+				@update:modelValue="onPasswordChange" />
 			<div class="button-group">
 				<NcButton :aria-label="t('collectives', 'Cancel')" @click="cancelSettings">
 					{{ t('collectives', 'Cancel') }}

--- a/src/components/PageSidebar/Version.vue
+++ b/src/components/PageSidebar/Version.vue
@@ -39,7 +39,7 @@
 						:size="20"
 						disable-menu
 						disable-tooltip
-						:show-user-status="false" />
+						:hide-status="true" />
 					<div>{{ versionAuthor }}</div>
 				</div>
 			</div>

--- a/src/components/PageSidebar/VersionLabelDialog.vue
+++ b/src/components/PageSidebar/VersionLabelDialog.vue
@@ -23,14 +23,14 @@
 
 		<template #actions>
 			<NcButton v-if="versionLabel"
-				type="error"
-				native-type="reset"
+				variant="error"
+				type="reset"
 				:aria-label="t('collectives', 'Remove version name')"
 				@click="$emit('label-update', '')">
 				{{ t('collectives', 'Remove version name') }}
 			</NcButton>
-			<NcButton type="primary"
-				native-type="submit"
+			<NcButton variant="primary"
+				type="submit"
 				:aria-label="t('collectives', 'Save version name')"
 				:disabled="editedVersionLabel.trim() === ''">
 				<template #icon>

--- a/src/components/PageTag.vue
+++ b/src/components/PageTag.vue
@@ -18,7 +18,7 @@
 		</a>
 		<NcButton v-if="canRemove"
 			:aria-label="t('collectives', 'Remove tag')"
-			type="tertiary"
+			variant="tertiary"
 			class="remove-button"
 			@keydown.enter.prevent.stop="$emit('remove')"
 			@click="$emit('remove')">

--- a/src/components/PageVersion.vue
+++ b/src/components/PageVersion.vue
@@ -51,7 +51,6 @@
 </template>
 
 <script>
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 import pageContentMixin from '../mixins/pageContentMixin.js'
 
 import { mapActions, mapState } from 'pinia'
@@ -60,6 +59,7 @@ import { usePagesStore } from '../stores/pages.js'
 import { useVersionsStore } from '../stores/versions.js'
 
 import { NcActionButton, NcActions, NcButton } from '@nextcloud/vue'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import DockRightIcon from 'vue-material-design-icons/DockRight.vue'
 import EmoticonIcon from 'vue-material-design-icons/EmoticonOutline.vue'
 import RestoreIcon from 'vue-material-design-icons/Restore.vue'
@@ -83,14 +83,14 @@ export default {
 	},
 
 	mixins: [
-		isMobile,
 		pageContentMixin,
 	],
 
 	setup() {
+		const isMobile = useIsMobile()
 		const content = ref('')
 		const { reader, readerEl, setupReader } = useReader(content)
-		return { content, reader, readerEl, setupReader }
+		return { content, isMobile, reader, readerEl, setupReader }
 	},
 
 	computed: {
@@ -106,7 +106,7 @@ export default {
 		},
 
 		pageTitleIconSize() {
-			return isMobile ? 25 : 30
+			return this.isMobile ? 25 : 30
 		},
 
 		versionTitle() {

--- a/src/reference.js
+++ b/src/reference.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { registerWidget } from '@nextcloud/vue/dist/Components/NcRichText.js'
+import { registerWidget } from '@nextcloud/vue/components/NcRichText'
 import Vue from 'vue'
 import PageReferenceWidget from './views/PageReferenceWidget.vue'
 

--- a/src/views/FileListInfo.vue
+++ b/src/views/FileListInfo.vue
@@ -13,7 +13,7 @@
 
 				<a :href="collectivesLink">
 					<NcButton :aria-label="t('collectives', 'Open in Collectives')"
-						type="primary"
+						variant="primary"
 						class="button">
 						{{ t('collectives', 'Open in Collectives') }}
 					</NcButton>
@@ -26,7 +26,7 @@
 <script>
 import { generateUrl } from '@nextcloud/router'
 // As it's the only nextcloud-vue component used in collectives-files.js, import it separately to keep asset small
-import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcButton from '@nextcloud/vue/components/NcButton'
 import InformationIcon from 'vue-material-design-icons/InformationOutline.vue'
 
 export default {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -25,7 +25,6 @@
 import { emit } from '@nextcloud/event-bus'
 import { NcAppContent, NcEmptyContent, NcButton } from '@nextcloud/vue'
 import CollectivesIcon from '../components/Icon/CollectivesIcon.vue'
-import isMobile from '@nextcloud/vue/dist/Mixins/isMobile.js'
 import { mapState } from 'pinia'
 import { useCollectivesStore } from '../stores/collectives.js'
 
@@ -38,10 +37,6 @@ export default {
 		CollectivesIcon,
 		NcEmptyContent,
 	},
-
-	mixins: [
-		isMobile,
-	],
 
 	data() {
 		return {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -12,7 +12,7 @@
 				<CollectivesIcon />
 			</template>
 			<template #action>
-				<NcButton :aria-label="t('collectives', 'Create new collective')" :type="buttonType" @click="newCollective">
+				<NcButton :aria-label="t('collectives', 'Create new collective')" :variant="buttonVariant" @click="newCollective">
 					{{ t('collectives', 'New collective') }}
 				</NcButton>
 			</template>
@@ -45,7 +45,7 @@ export default {
 
 	data() {
 		return {
-			buttonType: 'primary',
+			buttonVariant: 'primary',
 		}
 	},
 
@@ -67,7 +67,7 @@ export default {
 		newCollective() {
 			emit('toggle-navigation', { open: true })
 			emit('open-new-collective-modal')
-			this.buttonType = 'secondary'
+			this.buttonVariant = 'secondary'
 		},
 	},
 

--- a/src/views/PageReferenceWidget.vue
+++ b/src/views/PageReferenceWidget.vue
@@ -37,7 +37,7 @@
 
 <script>
 import PageIcon from '../components/Icon/PageIcon.vue'
-import NcUserBubble from '@nextcloud/vue/dist/Components/NcUserBubble.js'
+import NcUserBubble from '@nextcloud/vue/components/NcUserBubble'
 import { generateUrl } from '@nextcloud/router'
 
 export default {


### PR DESCRIPTION
### 📝 Summary

* migrate NcButton and NcEmojiPicker usage
* migrate from isMobile mixin to useIsMobile directive
* migrate NcAvatar prop `showUserStatus` to `hideStatus`
* migrate `@input` and `@update` events to `@update:modalValue`

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
