### PR TITLE
fix(favorites): disable drag'n'drop and sort according to page list

### DIFF
--- a/src/components/PageList/PageListItem.vue
+++ b/src/components/PageList/PageListItem.vue
@@ -299,6 +299,8 @@ export default {
 				&& !this.isDragged
 				// Ignore if in filtered view
 				&& !this.filteredView
+				// Ignore if inside favorite list
+				&& !this.inFavoriteList
 				// Ignore if dragged element is a parent of self
 				&& !this.pageParents(this.pageId).includes(this.draggedPageId)
 		},
@@ -358,10 +360,13 @@ export default {
 		},
 
 		onDragstart(event) {
-			// Set as dragged page if not root page (allows to move the page)
-			if (!this.isRootPage) {
-				this.setDraggedPageId(this.pageId)
+			// Don't set root page or favorite as dragged page
+			if (this.isRootPage || this.inFavoriteList) {
+				return
 			}
+
+			// Set dragged page (allows to move the page)
+			this.setDraggedPageId(this.pageId)
 
 			// Set drag data
 			const path = generateUrl(`/apps/collectives${this.to}`)

--- a/src/stores/pages.js
+++ b/src/stores/pages.js
@@ -216,7 +216,7 @@ export const usePagesStore = defineStore('pages', {
 		favoritePages(state) {
 			const collectivesStore = useCollectivesStore()
 			const favoritePages = collectivesStore.currentCollective.userFavoritePages
-			return state.pages.filter((p) => favoritePages.includes(p.id))
+			return state.allPagesSorted(state.rootPage.id).filter((p) => favoritePages.includes(p.id))
 		},
 
 		hasFavoritePages(state) {


### PR DESCRIPTION
Both bugs were direct feedback from a user who got very confused when they wanted to use page favorites. 

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
