### PR TITLE
fix(build): separate files for css entry points

### DIFF
--- a/lib/Listeners/BeforeTemplateRenderedListener.php
+++ b/lib/Listeners/BeforeTemplateRenderedListener.php
@@ -52,11 +52,12 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			$userFolder = $this->userFolderHelper->getUserFolderSetting($userId);
 		}
 
-		Util::addStyle('collectives', 'collectives-style');
 		Util::addInitScript('collectives', 'collectives-init');
+		Util::addStyle('collectives', 'collectives-init');
 
 		if ($event->getResponse()->getApp() === 'files') {
 			Util::addScript('collectives', 'collectives-files');
+			Util::addStyle('collectives', 'collectives-files');
 		}
 
 		$isCollectivesResponse = $event->getResponse()->getApp() === Application::APP_NAME;

--- a/lib/Listeners/CollectivesReferenceListener.php
+++ b/lib/Listeners/CollectivesReferenceListener.php
@@ -25,5 +25,6 @@ class CollectivesReferenceListener implements IEventListener {
 		}
 
 		Util::addScript(Application::APP_NAME, Application::APP_NAME . '-reference');
+		Util::addStyle(Application::APP_NAME, Application::APP_NAME . '-reference');
 	}
 }

--- a/templates/main.php
+++ b/templates/main.php
@@ -8,6 +8,7 @@
 use OCP\Util;
 
 Util::addScript('collectives', 'collectives-main', 'text');
+Util::addStyle('collectives', 'collectives-main');
 ?>
 
 <div id="q-app"></div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,7 +16,6 @@ export default createAppConfig(
 	{
 		config: {
 			build: {
-				cssCodeSplit: false,
 				rollupOptions: {
 					output: {
 						manualChunks: {
@@ -25,6 +24,12 @@ export default createAppConfig(
 					},
 				},
 			},
+			css: {
+				modules: {
+					localsConvention: 'camelCase',
+				},
+			},
 		},
+		createEmptyCSSEntryPoints: true,
 	},
 )


### PR DESCRIPTION
Fixes https://github.com/nextcloud/text/issues/7751

Right now the single `collectives-style.css` is loaded everywhere.

I tried to only load it in collectives
but we also have some styles for files.

So we need separate entry points.
Trying to follow what text is doing here.
