### PR TITLE
fix(PageTags): no focus trap for popover

### DIFF
--- a/src/components/Page/PageTags.vue
+++ b/src/components/Page/PageTags.vue
@@ -23,7 +23,7 @@
 				:tag="tag"
 				@select="onSelectTag(tag.id)" />
 
-			<NcPopover v-if="pageTagsInvisible.length > 0" popup-role="listbox">
+			<NcPopover v-if="pageTagsInvisible.length > 0" popup-role="listbox" no-focus-trap>
 				<template #trigger="{ attrs }">
 					<PageTag
 						v-bind="attrs"


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
