### PR TITLE
fix(gitignore): ignore all css files except `collectives.css`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ node_modules/
 
 # Compiled frontend output of vite
 js/*
-css/collectives-style.css
+css/*
+!css/collectives.css
 
 # PHPunit cache
 .phpunit.result.cache


### PR DESCRIPTION
That's the only css file we maintain manually, all others are generated by the bundler.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
