### PR TITLE
feat(PageActions): Streamline menu, show similar options in both places

### DIFF
--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -158,6 +158,7 @@
 </template>
 
 <script>
+import { emit } from '@nextcloud/event-bus'
 import { NcActionButton, NcActionCheckbox, NcActionLink, NcActions, NcActionSeparator } from '@nextcloud/vue'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { mapActions, mapState } from 'pinia'
@@ -377,7 +378,7 @@ export default {
 				this.$router.push(this.pageUrl)
 			}
 			this.$nextTick(() => {
-				this.show('pageEmojiPicker')
+				emit('collectives:page:open-emoji-picker')
 			})
 		},
 

--- a/src/components/Page/PageTitleBar.vue
+++ b/src/components/Page/PageTitleBar.vue
@@ -104,6 +104,7 @@
 
 <script>
 import { showError } from '@nextcloud/dialogs'
+import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { NcButton, NcEmojiPicker, NcLoadingIcon } from '@nextcloud/vue'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { mapActions, mapState } from 'pinia'
@@ -194,10 +195,6 @@ export default {
 			return this.loading(`pageEmoji-${this.currentPage.id}`)
 		},
 
-		showingPageEmojiPicker() {
-			return this.showing('pageEmojiPicker')
-		},
-
 		pageTitleIconSize() {
 			return this.isMobile ? 25 : 30
 		},
@@ -208,12 +205,6 @@ export default {
 			document.title = this.documentTitle
 		},
 
-		showingPageEmojiPicker: function(val) {
-			if (val === true) {
-				this.openPageEmojiPicker()
-			}
-		},
-
 		'currentPage.id': function() {
 			this.initTitleEntry()
 		},
@@ -222,13 +213,16 @@ export default {
 	mounted() {
 		document.title = this.documentTitle
 		this.initTitleEntry()
+
+		subscribe('collectives:page:open-emoji-picker', this.openPageEmojiPicker)
+	},
+
+	beforeDestroy() {
+		unsubscribe('collectives:page:open-emoji-picker', this.openPageEmojiPicker)
 	},
 
 	methods: {
-		...mapActions(useRootStore, [
-			'done',
-			'hide',
-		]),
+		...mapActions(useRootStore, ['done']),
 
 		...mapActions(usePagesStore, [
 			'getPages',
@@ -260,7 +254,6 @@ export default {
 
 		openPageEmojiPicker() {
 			this.$refs['page-emoji-picker'].open = true
-			this.hide('pageEmojiPicker')
 		},
 
 		/**


### PR DESCRIPTION
### 📝 Summary

* feat(PageActions): Streamline menu, show similar options in both places
* chore(PageActions): remove "Show in Files" option
* fix(EmojiPicker): Use event-bus instead of store flag to open
* Resolves: #2013

#### 🖼️ Screenshots

See #2013 (except for the "Open in Files" option that got removed)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
