### PR TITLE
fix(collectives): don't fetch collectives when offline

### DIFF
--- a/src/components/CollectiveContainer.vue
+++ b/src/components/CollectiveContainer.vue
@@ -5,7 +5,7 @@
 
 <template>
 	<NcAppContentDetails>
-		<div v-if="loading('pagelist') || loading('currentPage')" class="sheet-view">
+		<div v-if="loading('pagelist') || loading('currentPage') || !pagesLoaded" class="sheet-view">
 			<SkeletonLoading :count="1" class="page-heading-skeleton" type="page-heading" />
 		</div>
 		<PageVersion v-else-if="currentPage && selectedVersion" />
@@ -90,9 +90,10 @@ export default {
 		...mapState(usePagesStore, [
 			'currentFileIdPage',
 			'currentPage',
+			'currentPagePath',
 			'isLandingPage',
 			'pagePath',
-			'currentPagePath',
+			'pagesLoaded',
 		]),
 
 		...mapState(useVersionsStore, ['selectedVersion']),

--- a/src/stores/pages.js
+++ b/src/stores/pages.js
@@ -62,6 +62,10 @@ export const usePagesStore = defineStore('pages', {
 			return state.allTrashPages[state.collectiveId] || []
 		},
 
+		pagesLoaded: (state) => {
+			return state.pages.length > 0
+		},
+
 		isLandingPage: (state) => {
 			const rootStore = useRootStore()
 			const collectivesStore = useCollectivesStore()
@@ -523,7 +527,7 @@ export const usePagesStore = defineStore('pages', {
 		 */
 		async getPages(setLoading = true) {
 			const rootStore = useRootStore()
-			if (setLoading && this.pages.length === 0) {
+			if (setLoading && !this.pagesLoaded) {
 				rootStore.load('pagelist')
 			}
 			const response = await api.getPages(this.context)


### PR DESCRIPTION
Also make sure we display the SkeletonLoading in CollectiveContainer if no pages were loaded for the current collective yet.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
