### PR TITLE
fix(ui): Disable more actions when offline

### DIFF
--- a/src/components/Collective/CollectiveActions.vue
+++ b/src/components/Collective/CollectiveActions.vue
@@ -8,6 +8,7 @@
 		<NcActionButton
 			v-if="isCollectiveAdmin(collective)"
 			:close-after-click="true"
+			:disabled="!networkOnline"
 			@click="openCollectiveMembers()">
 			<template #icon>
 				<AccountMultipleIcon :size="20" />
@@ -17,6 +18,7 @@
 		<NcActionButton
 			v-if="!isPublic && collective.canEdit"
 			:close-after-click="true"
+			:disabled="!networkOnline"
 			@click="openTemplates()">
 			<template #icon>
 				<PageTemplateIcon :size="18" />
@@ -36,6 +38,7 @@
 		<NcActionLink
 			:close-after-click="true"
 			:href="printLink"
+			:class="{ 'action-link--disabled': !networkOnline }"
 			target="_blank">
 			{{ t('collectives', 'Export or print') }}
 			<template #icon>
@@ -45,6 +48,7 @@
 		<NcActionButton
 			v-if="isCollectiveAdmin(collective)"
 			:close-after-click="true"
+			:disabled="!networkOnline"
 			@click="openCollectiveSettings()">
 			<template #icon>
 				<CogIcon :size="20" />
@@ -54,6 +58,7 @@
 		<NcActionButton
 			v-if="!isPublic && collective.canLeave !== false"
 			:close-after-click="true"
+			:disabled="!networkOnline"
 			@click="leaveCollectiveWithUndo(collective)">
 			{{ t('collectives', 'Leave collective') }}
 			<template #icon>
@@ -96,6 +101,11 @@ export default {
 	props: {
 		collective: {
 			type: Object,
+			required: true,
+		},
+
+		networkOnline: {
+			type: Boolean,
 			required: true,
 		},
 	},
@@ -179,3 +189,10 @@ export default {
 	},
 }
 </script>
+
+<style scoped lang="scss">
+.action-link--disabled {
+	pointer-events: none;
+	opacity: 0.5;
+}
+</style>

--- a/src/components/Nav/CollectiveListItem.vue
+++ b/src/components/Nav/CollectiveListItem.vue
@@ -21,7 +21,9 @@
 			</template>
 		</template>
 		<template #actions>
-			<CollectiveActions :collective="collective" />
+			<CollectiveActions
+				:collective="collective"
+				:network-online="networkOnline" />
 		</template>
 	</NcAppNavigationItem>
 </template>
@@ -47,6 +49,11 @@ export default {
 	props: {
 		collective: {
 			type: Object,
+			required: true,
+		},
+
+		networkOnline: {
+			type: Boolean,
 			required: true,
 		},
 	},

--- a/src/components/Nav/CollectivesGlobalSettings.vue
+++ b/src/components/Nav/CollectivesGlobalSettings.vue
@@ -29,6 +29,13 @@ export default {
 		NcTextField,
 	},
 
+	props: {
+		networkOnline: {
+			type: Boolean,
+			required: true,
+		},
+	},
+
 	data() {
 		return {
 			collectivesFolderLoading: false,
@@ -39,7 +46,7 @@ export default {
 		...mapState(useSettingsStore, ['collectivesFolder']),
 
 		disabledPicker() {
-			return this.collectivesFolderLoading || !this.collectivesFolder
+			return this.collectivesFolderLoading || !this.networkOnline || !this.collectivesFolder
 		},
 
 		userFolderValue() {

--- a/src/components/Nav/CollectivesTrash.vue
+++ b/src/components/Nav/CollectivesTrash.vue
@@ -39,13 +39,19 @@
 							</template>
 						</template>
 						<template #actions>
-							<NcActionButton :close-after-click="true" @click="restoreCollective(collective)">
+							<NcActionButton
+								:close-after-click="true"
+								:disabled="!networkOnline"
+								@click="restoreCollective(collective)">
 								<template #icon>
 									<RestoreIcon :size="20" />
 								</template>
 								{{ t('collectives', 'Restore') }}
 							</NcActionButton>
-							<NcActionButton :close-after-click="true" @click="showDeleteModal(collective)">
+							<NcActionButton
+								:close-after-click="true"
+								:disabled="!networkOnline"
+								@click="showDeleteModal(collective)">
 								<template #icon>
 									<DeleteIcon :size="20" />
 								</template>
@@ -124,6 +130,13 @@ export default {
 		DeleteIcon,
 		NcDialog,
 		RestoreIcon,
+	},
+
+	props: {
+		networkOnline: {
+			type: Boolean,
+			required: true,
+		},
 	},
 
 	setup() {

--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -15,11 +15,13 @@
 				v-for="collective in sortedCollectives"
 				v-show="!collective.deleted"
 				:key="collective.id"
-				:collective="collective" />
+				:collective="collective"
+				:network-online="networkOnline" />
 			<li>
 				<NcAppNavigationNew
 					v-if="!isPublic"
 					:text="t('collectives', 'New collective')"
+					:disabled="!networkOnline"
 					variant="secondary"
 					class="new-collective-button"
 					@click="onOpenNewCollectiveModal">
@@ -32,9 +34,10 @@
 		<template #footer>
 			<CollectivesTrash
 				v-if="displayTrash"
+				:network-online="networkOnline"
 				@restore-collective="onRestoreCollective"
 				@delete-collective="onDeleteCollective" />
-			<CollectivesGlobalSettings v-if="!isPublic" />
+			<CollectivesGlobalSettings v-if="!isPublic" :network-online="networkOnline" />
 		</template>
 		<NewCollectiveModal v-if="showNewCollectiveModal" @close="onCloseNewCollectiveModal" />
 		<CollectiveMembersModal
@@ -57,6 +60,7 @@ import CollectivesTrash from './Nav/CollectivesTrash.vue'
 import NewCollectiveModal from './Nav/NewCollectiveModal.vue'
 import TemplatesDialog from './Nav/TemplatesDialog.vue'
 import SkeletonLoading from './SkeletonLoading.vue'
+import { useNetworkState } from '../composables/useNetworkState.js'
 import { useCollectivesStore } from '../stores/collectives.js'
 import { useRootStore } from '../stores/root.js'
 import displayError from '../util/displayError.js'
@@ -76,6 +80,11 @@ export default {
 		SkeletonLoading,
 		PlusIcon,
 		TemplatesDialog,
+	},
+
+	setup() {
+		const { networkOnline } = useNetworkState()
+		return { networkOnline }
 	},
 
 	data() {

--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -8,10 +8,11 @@
 		<NcActions :force-menu="true" @click.native.stop>
 			<!-- Collective actions: only displayed for landing page in page list -->
 			<template v-if="displayCollectiveActions">
-				<CollectiveActions :collective="currentCollective" />
+				<CollectiveActions :collective="currentCollective" :network-online="networkOnline" />
 				<NcActionButton
 					v-if="collectiveExtraAction"
 					:close-after-click="true"
+					:disabled="!networkOnline"
 					@click="collectiveExtraAction.click()">
 					{{ collectiveExtraAction.title }}
 					<template #icon>
@@ -49,7 +50,7 @@
 				<NcActionCheckbox
 					v-if="!isMobile"
 					:checked="currentPage.isFullWidth"
-					:disabled="!currentCollectiveCanEdit"
+					:disabled="!networkOnline || !currentCollectiveCanEdit"
 					@check="onCheckFullWidthView"
 					@uncheck="onUncheckFullWidthView">
 					{{ t('collectives', 'Full width') }}
@@ -69,6 +70,7 @@
 			<NcActionButton
 				v-if="!isLandingPage"
 				:close-after-click="true"
+				:disabled="!networkOnline"
 				@click="toggleFavoritePage({ id: currentCollective.id, pageId })">
 				<template #icon>
 					<StarOffIcon v-if="isFavoritePage(currentCollective.id, pageId)" :size="20" />
@@ -93,6 +95,7 @@
 			<NcActionButton
 				v-if="currentCollectiveCanEdit && !isLandingPage"
 				:close-after-click="true"
+				:disabled="!networkOnline"
 				@click.native="show('details')"
 				@click="gotoPageEmojiPicker">
 				<template #icon>
@@ -105,6 +108,7 @@
 			<NcActionButton
 				v-if="currentCollectiveCanEdit"
 				:close-after-click="true"
+				:disabled="!networkOnline"
 				@click="onOpenTagsModal">
 				<template #icon>
 					<TagMultipleIcon :size="20" />
@@ -116,6 +120,7 @@
 			<NcActionButton
 				v-if="currentCollectiveCanEdit && !isLandingPage"
 				:close-after-click="true"
+				:disabled="!networkOnline"
 				@click="onOpenMoveOrCopyModal">
 				<template #icon>
 					<OpenInNewIcon :size="20" />
@@ -126,6 +131,7 @@
 			<!-- Download action: always displayed -->
 			<NcActionLink
 				:href="currentPageDavUrl"
+				:class="{ 'action-link--disabled': !networkOnline }"
 				:download="currentPage.fileName"
 				:close-after-click="true">
 				<template #icon>
@@ -138,6 +144,7 @@
 			<NcActionButton
 				v-if="displayDeleteAction"
 				:close-after-click="true"
+				:disabled="!networkOnline"
 				@click="deletePage(pageId)">
 				<template #icon>
 					<DeleteIcon :size="20" />
@@ -249,6 +256,11 @@ export default {
 		inPageList: {
 			type: Boolean,
 			default: false,
+		},
+
+		networkOnline: {
+			type: Boolean,
+			required: true,
 		},
 	},
 
@@ -400,3 +412,10 @@ export default {
 	},
 }
 </script>
+
+<style scoped lang="scss">
+.action-link--disabled {
+	pointer-events: none;
+	opacity: 0.5;
+}
+</style>

--- a/src/components/Page/PageTitleBar.vue
+++ b/src/components/Page/PageTitleBar.vue
@@ -36,6 +36,7 @@
 					:title="t('collectives', 'Select emoji')"
 					class="button-emoji-page"
 					:class="{ mobile: isMobile }"
+					:disabled="!networkOnline"
 					@click.prevent>
 					<template #icon>
 						<NcLoadingIcon
@@ -78,7 +79,7 @@
 			ref="pageTitle"
 			v-model="newTitle"
 			:placeholder="t('collectives', 'Title')"
-			:disabled="!currentCollectiveCanEdit"
+			:disabled="!currentCollectiveCanEdit || !networkOnline"
 			@blur="onTitleBlur()"
 			@save="$emit('save-editor')"
 			@submit="onSubmit()" />
@@ -97,7 +98,8 @@
 				:timestamp="currentPage.timestamp"
 				:last-user-id="currentPage.lastUserId"
 				:last-user-display-name="currentPage.lastUserDisplayName"
-				:is-landing-page="isLandingPage" />
+				:is-landing-page="isLandingPage"
+				:network-online="networkOnline" />
 		</div>
 	</div>
 </template>
@@ -113,6 +115,7 @@ import CollectivesIcon from '../Icon/CollectivesIcon.vue'
 import EditButton from './EditButton.vue'
 import PageActionMenu from './PageActionMenu.vue'
 import PageTitle from './PageTitle.vue'
+import { useNetworkState } from '../../composables/useNetworkState.js'
 import pageMixin from '../../mixins/pageMixin.js'
 import { useCollectivesStore } from '../../stores/collectives.js'
 import { usePagesStore } from '../../stores/pages.js'
@@ -145,7 +148,8 @@ export default {
 
 	setup() {
 		const isMobile = useIsMobile()
-		return { isMobile }
+		const { networkOnline } = useNetworkState()
+		return { isMobile, networkOnline }
 	},
 
 	data() {

--- a/src/components/PageList.vue
+++ b/src/components/PageList.vue
@@ -126,6 +126,7 @@
 				:is-root-page="true"
 				:is-landing-page="!currentCollectiveIsPageShare"
 				:filtered-view="false"
+				:network-online="networkOnline"
 				class="page-list-root-page"
 				@click.native="show('details')" />
 
@@ -148,7 +149,7 @@
 			</div>
 
 			<!-- Favorites -->
-			<PageFavorites v-if="showFavorites" />
+			<PageFavorites v-if="showFavorites" :network-online="networkOnline" />
 
 			<!-- Filtered view page list -->
 			<div v-if="isFilteredView" ref="pageListFiltered" class="page-list-filtered">
@@ -166,6 +167,7 @@
 						:page="item"
 						:level="1"
 						:filtered-view="true"
+						:network-online="networkOnline"
 						class="page-list-drag-item" />
 				</RecycleScroller>
 				<NcAppNavigationCaption v-if="loadingContentFilteredPages || contentFilteredPages.length > 0" :name="t('Collectives', 'Results in content')" />
@@ -182,6 +184,7 @@
 						:page="item"
 						:level="1"
 						:filtered-view="true"
+						:network-online="networkOnline"
 						class="page-list-drag-item" />
 				</RecycleScroller>
 				<div v-if="loadingContentFilteredPages" class="scrollload">
@@ -203,12 +206,13 @@
 					:page="page"
 					:level="1"
 					:filtered-view="false"
+					:network-online="networkOnline"
 					class="page-list-drag-item" />
 			</DraggableElement>
 		</div>
 
 		<!-- Page trash -->
-		<PageTrash v-if="displayTrash" />
+		<PageTrash v-if="displayTrash" :network-online="networkOnline" />
 
 		<NewPageDialog v-if="newPageParentId" />
 	</NcAppContentList>
@@ -236,6 +240,7 @@ import PageTrash from './PageList/PageTrash.vue'
 import SubpageList from './PageList/SubpageList.vue'
 import PageTag from './PageTag.vue'
 import SkeletonLoading from './SkeletonLoading.vue'
+import { useNetworkState } from '../composables/useNetworkState.js'
 import { useCollectivesStore } from '../stores/collectives.js'
 import { usePagesStore } from '../stores/pages.js'
 import { useRootStore } from '../stores/root.js'
@@ -275,9 +280,10 @@ export default {
 	},
 
 	setup() {
+		const { networkOnline } = useNetworkState()
 		const pageListFiltered = ref()
 		const { height: pageListFilteredHeight } = useElementSize(pageListFiltered)
-		return { pageListFiltered, pageListFilteredHeight }
+		return { networkOnline, pageListFiltered, pageListFilteredHeight }
 	},
 
 	data() {

--- a/src/components/PageList/PageFavorites.vue
+++ b/src/components/PageList/PageFavorites.vue
@@ -40,6 +40,7 @@
 				:can-edit="currentCollectiveCanEdit"
 				:in-favorite-list="true"
 				:filtered-view="false"
+				:network-online="networkOnline"
 				@click.native="show('details')" />
 		</div>
 	</div>
@@ -63,6 +64,13 @@ export default {
 		NcButton,
 		ChevronDownIcon,
 		StarIcon,
+	},
+
+	props: {
+		networkOnline: {
+			type: Boolean,
+			required: true,
+		},
 	},
 
 	data() {

--- a/src/components/PageList/PageListItem.vue
+++ b/src/components/PageList/PageListItem.vue
@@ -81,11 +81,12 @@
 				:last-user-id="lastUserId"
 				:last-user-display-name="lastUserDisplayName"
 				:is-landing-page="isLandingPage"
-				:in-page-list="true" />
+				:in-page-list="true"
+				:network-online="networkOnline" />
 			<NcActions v-if="canEdit">
 				<NcActionButton
 					class="action-button-add"
-					:disabled="loading(`template-list-${templatesCollectiveId}`)"
+					:disabled="!networkOnline || loading(`template-list-${templatesCollectiveId}`)"
 					@click="onNewPage">
 					<template #icon>
 						<PlusIcon :size="20" fill-color="var(--color-main-text)" />
@@ -205,6 +206,11 @@ export default {
 		},
 
 		filteredView: {
+			type: Boolean,
+			required: true,
+		},
+
+		networkOnline: {
 			type: Boolean,
 			required: true,
 		},

--- a/src/components/PageList/PageTrash.vue
+++ b/src/components/PageList/PageTrash.vue
@@ -57,14 +57,20 @@
 									</div>
 								</td>
 								<td class="actions">
-									<NcButton :aria-label="t('collectives', 'Restore page')" @click="onClickRestore(trashPage)">
+									<NcButton
+										:aria-label="t('collectives', 'Restore page')"
+										:disabled="!networkOnline"
+										@click="onClickRestore(trashPage)">
 										<template #icon>
 											<RestoreIcon :size="20" />
 										</template>
 										{{ t('collectives', 'Restore') }}
 									</NcButton>
 									<NcActions :force-menu="true">
-										<NcActionButton :close-after-click="true" @click="onClickDelete(trashPage)">
+										<NcActionButton
+											:close-after-click="true"
+											:disabled="!networkOnline"
+											@click="onClickDelete(trashPage)">
 											<template #icon>
 												<DeleteIcon :size="20" />
 											</template>
@@ -111,6 +117,13 @@ export default {
 		DeleteIcon,
 		RestoreIcon,
 		PageIcon,
+	},
+
+	props: {
+		networkOnline: {
+			type: Boolean,
+			required: true,
+		},
 	},
 
 	setup() {

--- a/src/components/PageList/SubpageList.vue
+++ b/src/components/PageList/SubpageList.vue
@@ -19,6 +19,7 @@
 			:can-edit="currentCollectiveCanEdit"
 			:has-visible-subpages="hasVisibleSubpages"
 			:filtered-view="filteredView"
+			:network-online="networkOnline"
 			@click.native="show('details')" />
 		<div class="page-list-indent">
 			<DraggableElement
@@ -68,6 +69,11 @@ export default {
 		filteredView: {
 			type: Boolean,
 			default: false,
+		},
+
+		networkOnline: {
+			type: Boolean,
+			required: true,
 		},
 	},
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -13,7 +13,11 @@
 				<CollectivesIcon />
 			</template>
 			<template #action>
-				<NcButton :aria-label="t('collectives', 'Create new collective')" :variant="buttonVariant" @click="newCollective">
+				<NcButton
+					:aria-label="t('collectives', 'Create new collective')"
+					:variant="buttonVariant"
+					:disabled="!networkOnline"
+					@click="newCollective">
 					{{ t('collectives', 'New collective') }}
 				</NcButton>
 			</template>
@@ -27,6 +31,7 @@ import { emit } from '@nextcloud/event-bus'
 import { NcAppContent, NcButton, NcEmptyContent } from '@nextcloud/vue'
 import { mapState } from 'pinia'
 import CollectivesIcon from '../components/Icon/CollectivesIcon.vue'
+import { useNetworkState } from '../composables/useNetworkState.js'
 import { useCollectivesStore } from '../stores/collectives.js'
 
 export default {
@@ -37,6 +42,11 @@ export default {
 		NcButton,
 		CollectivesIcon,
 		NcEmptyContent,
+	},
+
+	setup() {
+		const { networkOnline } = useNetworkState()
+		return { networkOnline }
 	},
 
 	data() {


### PR DESCRIPTION
* Editing page title
* Emoji picker next to page title
* Collectives folder selection
* Restore/delete in collectives trash
* Restore/delete in page trash
* New collective buttons
* New page button
* Most actions in collectives and page actions menus

Fixes: #2042

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="484" height="271" alt="image" src="https://github.com/user-attachments/assets/98204678-abbd-44ec-8e58-d843a940e49c" /> | <img width="505" height="286" alt="image" src="https://github.com/user-attachments/assets/97a53a10-eaae-45cc-b467-3127009af77b" />
<img width="562" height="438" alt="image" src="https://github.com/user-attachments/assets/71d444fd-baa1-47fb-b1fe-87482340b572" /> | <img width="556" height="441" alt="image" src="https://github.com/user-attachments/assets/374107c9-954c-4d81-b83e-666d03ff14bd" />
<img width="520" height="565" alt="image" src="https://github.com/user-attachments/assets/ffa6cb92-4204-4b31-9438-ed15b72df8c3" /> | <img width="520" height="567" alt="image" src="https://github.com/user-attachments/assets/00c4231f-2555-46b9-ac09-aeb532eb733e" />
<img width="523" height="669" alt="image" src="https://github.com/user-attachments/assets/8b7e48f8-85e9-4590-83a7-3d7f9661c428" /> | <img width="523" height="667" alt="image" src="https://github.com/user-attachments/assets/a59d0ccf-df9f-4336-9386-99da1a0526c0" />
<img width="400" height="667" alt="image" src="https://github.com/user-attachments/assets/55745f02-0341-411b-bc69-74bb728a21de" /> | <img width="417" height="670" alt="image" src="https://github.com/user-attachments/assets/0f27ee7d-b287-499d-b6f2-6b465f1c3908" />
<img width="589" height="297" alt="image" src="https://github.com/user-attachments/assets/f37a0305-7ab6-40a6-8c70-df62430d0448" /> | <img width="589" height="306" alt="image" src="https://github.com/user-attachments/assets/f28ef67a-486c-4912-a60c-28453e45bd3e" />
<img width="493" height="231" alt="image" src="https://github.com/user-attachments/assets/d5126c70-875f-4aaa-91a4-69a04ae1dddb" /> | <img width="477" height="243" alt="image" src="https://github.com/user-attachments/assets/56ea9981-9f59-40dc-a686-8f7a5129c58d" />
<img width="1363" height="636" alt="image" src="https://github.com/user-attachments/assets/9dbf9a8c-6eb9-4170-8452-639e212a0a1b" /> | <img width="1378" height="631" alt="image" src="https://github.com/user-attachments/assets/a37f22f3-990b-4f93-8057-0179d715ded2" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
