### PR TITLE
Added meaningful message in error toast for collective name too long

### DIFF
--- a/src/components/Nav/NewCollectiveModal.vue
+++ b/src/components/Nav/NewCollectiveModal.vue
@@ -235,7 +235,7 @@ export default {
 
 	watch: {
 		newCollectiveName(val) {
-			if (!val || this.newCollectiveName.length < 3) {
+			if (val && this.newCollectiveName.length < 3) {
 				this.setNameIsTooShortDebounced()
 				this.setNameIsTooLongDebounced.clear()
 				this.nameIsTooShort = true


### PR DESCRIPTION
### 📝 Summary

* Fixes: #1833

Updated the error toast to now show proper error when name of a collective is longer than 255 characters.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="308" height="128" alt="image" src="https://github.com/user-attachments/assets/a2d45cec-0690-4e3f-ae3d-7883563d64a9" />| <img width="753" height="98" alt="image" src="https://github.com/user-attachments/assets/4dd0ff01-4ad5-425b-ad1c-23512e93ec66" />


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint`)