### PR TITLE
fix: display collective actions in landing page title three-dot-menu

### DIFF
--- a/src/components/Collective/CollectiveActions.vue
+++ b/src/components/Collective/CollectiveActions.vue
@@ -16,6 +16,16 @@
 			{{ t('collectives', 'Manage members') }}
 		</NcActionButton>
 		<NcActionButton
+			v-if="collectiveCanShare(collective)"
+			:close-after-click="true"
+			@click="openShareTab(collective)">
+			{{ t('collectives', 'Share link') }}
+			<template #icon>
+				<ShareVariantIcon :size="20" />
+			</template>
+		</NcActionButton>
+		<NcActionSeparator v-if="isCollectiveAdmin(collective) || collectiveCanShare(collective)" />
+		<NcActionButton
 			v-if="!isPublic && collective.canEdit"
 			:close-after-click="true"
 			:disabled="!networkOnline"
@@ -24,16 +34,6 @@
 				<PageTemplateIcon :size="18" />
 			</template>
 			{{ t('collectives', 'Manage templates') }}
-		</NcActionButton>
-		<NcActionSeparator v-if="isCollectiveAdmin(collective)" />
-		<NcActionButton
-			v-if="collectiveCanShare(collective)"
-			:close-after-click="true"
-			@click="openShareTab(collective)">
-			{{ t('collectives', 'Share link') }}
-			<template #icon>
-				<ShareVariantIcon :size="20" />
-			</template>
 		</NcActionButton>
 		<NcActionLink
 			:close-after-click="true"

--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -6,8 +6,8 @@
 <template>
 	<div>
 		<NcActions :force-menu="true" @click.native.stop>
-			<!-- Collective actions: only displayed for landing page in page list -->
-			<template v-if="displayCollectiveActions">
+			<!-- Collective actions: only displayed for landing page -->
+			<template v-if="isLandingPage">
 				<CollectiveActions :collective="currentCollective" :network-online="networkOnline" />
 				<NcActionSeparator />
 			</template>
@@ -284,10 +284,6 @@ export default {
 
 		displaySidebarAction() {
 			return this.isMobile && !this.inPageList && !this.showing('sidebar')
-		},
-
-		displayCollectiveActions() {
-			return this.inPageList && this.isLandingPage
 		},
 
 		displayLastEditedInfo() {


### PR DESCRIPTION
Fixes: #2057

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="900" height="800" alt="image" src="https://github.com/user-attachments/assets/c112169f-3082-4d91-8cce-c1c01846769d" /> | <img width="900" height="800" alt="image" src="https://github.com/user-attachments/assets/a71c7c04-9f3d-4720-b768-05c048956844" />
<img width="740" height="1000" alt="image" src="https://github.com/user-attachments/assets/7ec79f9d-6047-45b4-8abd-95871e503c7a" /> | <img width="740" height="1000" alt="image" src="https://github.com/user-attachments/assets/4071ba97-d186-4c51-a18d-a06d860304b4" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
