### PR TITLE
fix(controllers): Add User Trait to handle null sessions

### DIFF
--- a/lib/Controller/CollectiveController.php
+++ b/lib/Controller/CollectiveController.php
@@ -35,6 +35,7 @@ use Psr\Log\LoggerInterface;
  */
 class CollectiveController extends OCSController {
 	use OCSExceptionHelper;
+	use UserTrait;
 
 	public function __construct(
 		string $AppName,
@@ -44,7 +45,7 @@ class CollectiveController extends OCSController {
 		private IFactory $l10nFactory,
 		private LoggerInterface $logger,
 		private NodeHelper $nodeHelper,
-		private string $userId,
+		private ?string $userId,
 	) {
 		parent::__construct($AppName, $request);
 	}
@@ -64,7 +65,7 @@ class CollectiveController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function index(): DataResponse {
-		$collectives = $this->handleErrorResponse(fn (): array => $this->service->getCollectivesWithShares($this->userId), $this->logger);
+		$collectives = $this->handleErrorResponse(fn (): array => $this->service->getCollectivesWithShares($this->getUid()), $this->logger);
 		return new DataResponse(['collectives' => $collectives]);
 	}
 
@@ -86,7 +87,7 @@ class CollectiveController extends OCSController {
 		try {
 			[$collective, $info] = $this->handleErrorResponse(function () use ($name, $emoji): array {
 				[$collective, $info] = $this->service->createCollective(
-					$this->userId,
+					$this->getUid(),
 					$this->getUserLang(),
 					$name,
 					$emoji,
@@ -116,7 +117,7 @@ class CollectiveController extends OCSController {
 	public function update(int $id, ?string $emoji = null): DataResponse {
 		$collective = $this->handleErrorResponse(fn (): Collective => $this->service->updateCollective(
 			$id,
-			$this->userId,
+			$this->getUid(),
 			$emoji
 		), $this->logger);
 		return new DataResponse(['collective' => $collective]);
@@ -138,7 +139,7 @@ class CollectiveController extends OCSController {
 	public function editLevel(int $id, int $level): DataResponse {
 		$collective = $this->handleErrorResponse(fn (): Collective => $this->service->setPermissionLevel(
 			$id,
-			$this->userId,
+			$this->getUid(),
 			$level,
 			Collective::editPermissions
 		), $this->logger);
@@ -161,7 +162,7 @@ class CollectiveController extends OCSController {
 	public function shareLevel(int $id, int $level): DataResponse {
 		$collective = $this->handleErrorResponse(fn (): Collective => $this->service->setPermissionLevel(
 			$id,
-			$this->userId,
+			$this->getUid(),
 			$level,
 			Constants::PERMISSION_SHARE
 		), $this->logger);
@@ -184,7 +185,7 @@ class CollectiveController extends OCSController {
 	public function pageMode(int $id, int $mode): DataResponse {
 		$collective = $this->handleErrorResponse(fn (): Collective => $this->service->setPageMode(
 			$id,
-			$this->userId,
+			$this->getUid(),
 			$mode,
 		), $this->logger);
 		return new DataResponse(['collective' => $collective]);
@@ -203,7 +204,7 @@ class CollectiveController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function trash(int $id): DataResponse {
-		$collective = $this->handleErrorResponse(fn (): Collective => $this->service->trashCollective($id, $this->userId), $this->logger);
+		$collective = $this->handleErrorResponse(fn (): Collective => $this->service->trashCollective($id, $this->getUid()), $this->logger);
 		return new DataResponse(['collective' => $collective]);
 	}
 }

--- a/lib/Controller/CollectiveUserSettingsController.php
+++ b/lib/Controller/CollectiveUserSettingsController.php
@@ -24,13 +24,14 @@ use Psr\Log\LoggerInterface;
  */
 class CollectiveUserSettingsController extends OCSController {
 	use OCSExceptionHelper;
+	use UserTrait;
 
 	public function __construct(
 		string $AppName,
 		IRequest $request,
 		private CollectiveUserSettingsService $service,
 		private LoggerInterface $logger,
-		private string $userId,
+		private ?string $userId,
 	) {
 		parent::__construct($AppName, $request);
 	}
@@ -52,7 +53,7 @@ class CollectiveUserSettingsController extends OCSController {
 		$this->handleErrorResponse(function () use ($collectiveId, $pageOrder): void {
 			$this->service->setPageOrder(
 				$collectiveId,
-				$this->userId,
+				$this->getUid(),
 				$pageOrder
 			);
 		}, $this->logger);
@@ -76,7 +77,7 @@ class CollectiveUserSettingsController extends OCSController {
 		$this->handleErrorResponse(function () use ($collectiveId, $showMembers): void {
 			$this->service->setShowMembers(
 				$collectiveId,
-				$this->userId,
+				$this->getUid(),
 				$showMembers
 			);
 		}, $this->logger);
@@ -100,7 +101,7 @@ class CollectiveUserSettingsController extends OCSController {
 		$this->handleErrorResponse(function () use ($collectiveId, $showRecentPages): void {
 			$this->service->setShowRecentPages(
 				$collectiveId,
-				$this->userId,
+				$this->getUid(),
 				$showRecentPages
 			);
 		}, $this->logger);
@@ -124,7 +125,7 @@ class CollectiveUserSettingsController extends OCSController {
 		$this->handleErrorResponse(function () use ($collectiveId, $favoritePages): void {
 			$this->service->setFavoritePages(
 				$collectiveId,
-				$this->userId,
+				$this->getUid(),
 				$favoritePages
 			);
 		}, $this->logger);

--- a/lib/Controller/PageTrashController.php
+++ b/lib/Controller/PageTrashController.php
@@ -28,13 +28,14 @@ use Psr\Log\LoggerInterface;
  */
 class PageTrashController extends OCSController {
 	use OCSExceptionHelper;
+	use UserTrait;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
 		private PageService $service,
 		private LoggerInterface $logger,
-		private string $userId,
+		private ?string $userId,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -52,7 +53,7 @@ class PageTrashController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function index(int $collectiveId): DataResponse {
-		$pageInfos = $this->handleErrorResponse(fn (): array => $this->service->findAllTrash($collectiveId, $this->userId), $this->logger);
+		$pageInfos = $this->handleErrorResponse(fn (): array => $this->service->findAllTrash($collectiveId, $this->getUid()), $this->logger);
 		return new DataResponse(['pages' => $pageInfos]);
 	}
 
@@ -70,7 +71,7 @@ class PageTrashController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function restore(int $collectiveId, int $id): DataResponse {
-		$pageInfo = $this->handleErrorResponse(fn (): PageInfo => $this->service->restore($collectiveId, $id, $this->userId), $this->logger);
+		$pageInfo = $this->handleErrorResponse(fn (): PageInfo => $this->service->restore($collectiveId, $id, $this->getUid()), $this->logger);
 		return new DataResponse(['page' => $pageInfo]);
 	}
 
@@ -89,7 +90,7 @@ class PageTrashController extends OCSController {
 	#[NoAdminRequired]
 	public function delete(int $collectiveId, int $id): DataResponse {
 		$this->handleErrorResponse(function () use ($collectiveId, $id): void {
-			$this->service->delete($collectiveId, $id, $this->userId);
+			$this->service->delete($collectiveId, $id, $this->getUid());
 		}, $this->logger);
 		return new DataResponse([]);
 	}

--- a/lib/Controller/SessionController.php
+++ b/lib/Controller/SessionController.php
@@ -26,13 +26,14 @@ use Psr\Log\LoggerInterface;
  */
 class SessionController extends OCSController {
 	use OCSExceptionHelper;
+	use UserTrait;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
 		private SessionService $sessionService,
 		private LoggerInterface $logger,
-		private string $userId,
+		private ?string $userId,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -50,7 +51,7 @@ class SessionController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function create(int $collectiveId): DataResponse {
-		$session = $this->handleErrorResponse(fn (): Session => $this->sessionService->initSession($collectiveId, $this->userId), $this->logger);
+		$session = $this->handleErrorResponse(fn (): Session => $this->sessionService->initSession($collectiveId, $this->getUid()), $this->logger);
 		return new DataResponse(['token' => $session->getToken()]);
 	}
 
@@ -69,7 +70,7 @@ class SessionController extends OCSController {
 	#[NoAdminRequired]
 	public function sync(int $collectiveId, string $token): DataResponse {
 		$this->handleErrorResponse(function () use ($collectiveId, $token): void {
-			$this->sessionService->syncSession($collectiveId, $token, $this->userId);
+			$this->sessionService->syncSession($collectiveId, $token, $this->getUid());
 		}, $this->logger);
 		return new DataResponse([]);
 	}
@@ -86,7 +87,7 @@ class SessionController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function close(int $collectiveId, string $token): DataResponse {
-		$this->sessionService->closeSession($collectiveId, $token, $this->userId);
+		$this->sessionService->closeSession($collectiveId, $token, $this->getUid());
 		return new DataResponse([]);
 	}
 }

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -22,11 +22,13 @@ use OCP\IRequest;
  * - user_folder: Path where collectives are mounted in user home directory.
  */
 class SettingsController extends OCSController {
+	use UserTrait;
+
 	public function __construct(
 		string $appName,
 		IRequest $request,
 		private IConfig $config,
-		private string $userId,
+		private ?string $userId,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -77,7 +79,7 @@ class SettingsController extends OCSController {
 	#[NoAdminRequired]
 	public function getUserSetting(string $key): DataResponse {
 		$this->validateGetUserSetting($key);
-		return new DataResponse([$key => $this->config->getUserValue($this->userId, 'collectives', $key, '')]);
+		return new DataResponse([$key => $this->config->getUserValue($this->getUid(), 'collectives', $key, '')]);
 	}
 
 	/**
@@ -94,7 +96,7 @@ class SettingsController extends OCSController {
 	#[NoAdminRequired]
 	public function setUserSetting(string $key, string $value): DataResponse {
 		$this->validateSetUserSetting($key, $value);
-		$this->config->setUserValue($this->userId, 'collectives', $key, $value);
+		$this->config->setUserValue($this->getUid(), 'collectives', $key, $value);
 		return new DataResponse([$key => $value]);
 	}
 }

--- a/lib/Controller/TemplateController.php
+++ b/lib/Controller/TemplateController.php
@@ -29,6 +29,7 @@ use Psr\Log\LoggerInterface;
  */
 class TemplateController extends OCSController {
 	use OCSExceptionHelper;
+	use UserTrait;
 
 	public function __construct(
 		string $appName,
@@ -36,7 +37,7 @@ class TemplateController extends OCSController {
 		private IUserSession $userSession,
 		private TemplateService $templateService,
 		private LoggerInterface $logger,
-		private string $userId,
+		private ?string $userId,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -54,7 +55,7 @@ class TemplateController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function index(int $collectiveId): DataResponse {
-		$templateInfos = $this->handleErrorResponse(fn (): array => $this->templateService->getTemplates($collectiveId, $this->userId), $this->logger);
+		$templateInfos = $this->handleErrorResponse(fn (): array => $this->templateService->getTemplates($collectiveId, $this->getUid()), $this->logger);
 		return new DataResponse(['templates' => $templateInfos]);
 	}
 
@@ -73,7 +74,7 @@ class TemplateController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function create(int $collectiveId, string $title, int $parentId): DataResponse {
-		$templateInfo = $this->handleErrorResponse(fn (): PageInfo => $this->templateService->create($collectiveId, $parentId, $title, $this->userId), $this->logger);
+		$templateInfo = $this->handleErrorResponse(fn (): PageInfo => $this->templateService->create($collectiveId, $parentId, $title, $this->getUid()), $this->logger);
 		return new DataResponse(['template' => $templateInfo]);
 	}
 
@@ -92,7 +93,7 @@ class TemplateController extends OCSController {
 	#[NoAdminRequired]
 	public function delete(int $collectiveId, int $id): DataResponse {
 		$this->handleErrorResponse(function () use ($collectiveId, $id): void {
-			$this->templateService->delete($collectiveId, $id, $this->userId);
+			$this->templateService->delete($collectiveId, $id, $this->getUid());
 		}, $this->logger);
 		return new DataResponse([]);
 	}
@@ -112,7 +113,7 @@ class TemplateController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function rename(int $collectiveId, int $id, string $title): DataResponse {
-		$templateInfo = $this->handleErrorResponse(fn (): PageInfo => $this->templateService->rename($collectiveId, $id, $title, $this->userId), $this->logger);
+		$templateInfo = $this->handleErrorResponse(fn (): PageInfo => $this->templateService->rename($collectiveId, $id, $title, $this->getUid()), $this->logger);
 		return new DataResponse(['template' => $templateInfo]);
 	}
 
@@ -131,7 +132,7 @@ class TemplateController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function setEmoji(int $collectiveId, int $id, ?string $emoji = null): DataResponse {
-		$templateInfo = $this->handleErrorResponse(fn (): PageInfo => $this->templateService->setEmoji($collectiveId, $id, $emoji, $this->userId), $this->logger);
+		$templateInfo = $this->handleErrorResponse(fn (): PageInfo => $this->templateService->setEmoji($collectiveId, $id, $emoji, $this->getUid()), $this->logger);
 		return new DataResponse(['template' => $templateInfo]);
 	}
 }

--- a/lib/Controller/TrashController.php
+++ b/lib/Controller/TrashController.php
@@ -29,6 +29,7 @@ use Psr\Log\LoggerInterface;
  */
 class TrashController extends OCSController {
 	use OCSExceptionHelper;
+	use UserTrait;
 
 	public function __construct(
 		string $AppName,
@@ -36,7 +37,7 @@ class TrashController extends OCSController {
 		private CollectiveService $service,
 		private IUserSession $userSession,
 		private LoggerInterface $logger,
-		private string $userId,
+		private ?string $userId,
 	) {
 		parent::__construct($AppName, $request);
 	}
@@ -52,7 +53,7 @@ class TrashController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function index(): DataResponse {
-		$collectives = $this->handleErrorResponse(fn (): array => $this->service->getCollectivesTrash($this->userId), $this->logger);
+		$collectives = $this->handleErrorResponse(fn (): array => $this->service->getCollectivesTrash($this->getUid()), $this->logger);
 		return new DataResponse(['collectives' => $collectives]);
 	}
 
@@ -70,7 +71,7 @@ class TrashController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function delete(int $id, bool $circle = false): DataResponse {
-		$collective = $this->handleErrorResponse(fn (): Collective => $this->service->deleteCollective($id, $this->userId, $circle), $this->logger);
+		$collective = $this->handleErrorResponse(fn (): Collective => $this->service->deleteCollective($id, $this->getUid(), $circle), $this->logger);
 		return new DataResponse(['collective' => $collective]);
 	}
 
@@ -87,7 +88,7 @@ class TrashController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	public function restore(int $id): DataResponse {
-		$collective = $this->handleErrorResponse(fn (): Collective => $this->service->restoreCollective($id, $this->userId), $this->logger);
+		$collective = $this->handleErrorResponse(fn (): Collective => $this->service->restoreCollective($id, $this->getUid()), $this->logger);
 		return new DataResponse(['collective' => $collective]);
 	}
 }

--- a/lib/Controller/UserTrait.php
+++ b/lib/Controller/UserTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Controller;
+
+use OCP\AppFramework\OCS\OCSForbiddenException;
+
+/**
+ * Trait providing standardized user ID handling for controllers.
+ */
+trait UserTrait {
+	/**
+	 * Get the current user ID or throw an OCS exception if not authenticated.
+	 *
+	 * @return string
+	 * @throws OCSForbiddenException If user is not logged in
+	 */
+	protected function getUid(): string {
+		if ($this->userId === null) {
+			throw new OCSForbiddenException();
+		}
+		return $this->userId;
+	}
+}


### PR DESCRIPTION
### 📝 Summary

> TypeError: OCA\Collectives\Controller\PageController::__construct(): Argument #9 ($userId) must be of type string, null given

This Pull Request addresses a critical `TypeError` occurring when the user session is missing or expired. By making the `$userId` dependency nullable and implementing a centralized session validation, we ensure the application remains stable during anonymous or unauthenticated OCS API calls.

Previously, the constructor strictly required a string for the `$userId` argument. This caused a fatal error when Nextcloud's dependency injection container passed null (e.g., for expired sessions or guest access).

- Updated `$userId` type hint to `?string` in the constructor to allow safe instantiation.
- Throws an `OCSForbiddenException` if the user is not authenticated, providing a clean API response instead of a crash.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
