### PR TITLE
perf: Replace getById call by getFirstNodeById

### DIFF
--- a/lib/Db/PageGarbageCollector.php
+++ b/lib/Db/PageGarbageCollector.php
@@ -23,7 +23,7 @@ class PageGarbageCollector {
 		$purgeCount = 0;
 		$rootFolder = $this->folderManager->getRootFolder();
 		foreach ($this->pageMapper->getAll() as $page) {
-			if ($rootFolder->getById($page->getFileId()) === []) {
+			if ($rootFolder->getFirstNodeById($page->getFileId()) === null) {
 				$purgeCount++;
 				$this->pageLinkMapper->deleteByPageId($page->getFileId());
 				$this->pageMapper->delete($page);

--- a/lib/Fs/NodeHelper.php
+++ b/lib/Fs/NodeHelper.php
@@ -38,12 +38,12 @@ class NodeHelper {
 	 * @throws NotFoundException
 	 */
 	public function getFileById(Folder $folder, int $id): File {
-		$file = $folder->getById($id);
+		$file = $folder->getFirstNodeById($id);
 
-		if (count($file) <= 0 || !($file[0] instanceof File)) {
+		if (!($file instanceof File)) {
 			throw new NotFoundException('File not found: ' . $id);
 		}
-		return $file[0];
+		return $file;
 	}
 
 	public static function generateFilename(Folder $folder, string $filename, string $suffix = ''): string {

--- a/lib/Migration/GenerateSlugs.php
+++ b/lib/Migration/GenerateSlugs.php
@@ -111,7 +111,7 @@ class GenerateSlugs implements IRepairStep {
 		$rootFolder = $this->collectiveFolderManager->getRootFolder();
 
 		while ($row = $result->fetch()) {
-			$pageFile = $rootFolder->getById($row['file_id'])[0];
+			$pageFile = $rootFolder->getFirstNodeById($row['file_id']);
 			if (!($pageFile instanceof File) || NodeHelper::isLandingPage($pageFile)) {
 				continue;
 			}

--- a/lib/Search/PageContentProvider.php
+++ b/lib/Search/PageContentProvider.php
@@ -84,9 +84,9 @@ class PageContentProvider implements IProvider {
 				continue;
 			}
 			foreach ($results as $fileId => $fileData) {
-				$fileEntries = $collectiveRoot->getById($fileId);
-				if (!empty($fileEntries)) {
-					$pages[$fileId] = $fileEntries[0];
+				$fileEntry = $collectiveRoot->getFirstNodeById($fileId);
+				if ($fileEntry !== null) {
+					$pages[$fileId] = $fileEntry;
 					$collectiveMap[$fileId] = $collective;
 				}
 			}

--- a/lib/Service/CollectiveShareService.php
+++ b/lib/Service/CollectiveShareService.php
@@ -57,21 +57,20 @@ class CollectiveShareService {
 
 		$userFolder = $this->userFolderHelper->get($userId);
 		try {
-			$path = $userFolder->get($collectiveName);
-			if (!($path instanceof Folder)) {
+			$node = $userFolder->get($collectiveName);
+			if (!($node instanceof Folder)) {
 				throw new FilesNotFoundException();
 			}
 			if ($nodeId !== 0) {
-				$nodes = $path->getById($nodeId);
-				if (count($nodes) <= 0) {
+				$node = $node->getFirstNodeById($nodeId);
+				if ($node === null) {
 					throw new FilesNotFoundException();
 				}
-				$path = $nodes[0];
 			}
 		} catch (FilesNotFoundException $e) {
 			throw new NotFoundException('Wrong path, collective folder doesn\'t exist', 0, $e);
 		}
-		$share->setNode($path);
+		$share->setNode($node);
 
 		try {
 			$share->getNode()->lock(ILockingProvider::LOCK_SHARED);

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -27,7 +27,6 @@ use OCP\Files\InvalidPathException;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException as FilesNotFoundException;
 use OCP\Files\NotPermittedException as FilesNotPermittedException;
-use OCP\IConfig;
 use OCP\IUserManager;
 use OCP\Lock\LockedException;
 use OCP\Server;
@@ -48,7 +47,6 @@ class PageService {
 		private readonly CollectiveServiceBase $collectiveService,
 		private readonly UserFolderHelper $userFolderHelper,
 		private readonly IUserManager $userManager,
-		private readonly IConfig $config,
 		ContainerInterface $container,
 		private readonly SessionService $sessionService,
 		private readonly SluggerInterface $slugger,
@@ -144,7 +142,7 @@ class PageService {
 	 */
 	public function isPageInPageFolder(int $collectiveId, int $parentId, int $pageId, string $userId): void {
 		$folder = $this->getFolder($collectiveId, $parentId, $userId);
-		if (!isset($folder->getById($pageId)[0])) {
+		if ($folder->getFirstNodeById($pageId) === null) {
 			throw new NotFoundException('Page ' . $pageId . ' is not a child of ' . $parentId);
 		}
 	}
@@ -636,9 +634,8 @@ class PageService {
 		$collectiveFolder = $parentId
 			? $this->getFolder($collectiveId, $parentId, $userId)
 			: $this->getCollectiveFolder($collectiveId, $userId);
-		$pageFile = $collectiveFolder->getById($fileId);
-		if (isset($pageFile[0]) && $pageFile[0] instanceof File) {
-			$pageFile = $pageFile[0];
+		$pageFile = $collectiveFolder->getFirstNodeById($fileId);
+		if ($pageFile instanceof File) {
 			return $this->findByFile($collectiveId, $pageFile, $userId);
 		}
 		throw new NotFoundException('Failed to get page by file ID ' . $fileId . ' in collective ' . $collectiveId);

--- a/tests/Unit/Fs/NodeHelperTest.php
+++ b/tests/Unit/Fs/NodeHelperTest.php
@@ -73,10 +73,10 @@ class NodeHelperTest extends TestCase {
 		$folder = $this->getMockBuilder(Folder::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$folder->method('getById')
+		$folder->method('getFirstNodeById')
 			->willReturnMap([
-				[1, [$file]],
-				[2, []],
+				[1, $file],
+				[2, null],
 			]);
 
 		self::assertEquals($file, $this->helper->getFileById($folder, 1));

--- a/tests/Unit/Search/PageContentProviderTest.php
+++ b/tests/Unit/Search/PageContentProviderTest.php
@@ -46,8 +46,8 @@ class PageContentProviderTest extends TestCase {
 		$collectiveService = $this->createMock(CollectiveService::class);
 		/** @var Folder&MockObject $folder */
 		$folder = $this->createMock(Folder::class);
-		$folder->method('getById')
-			->willReturn([]);
+		$folder->method('getFirstNodeById')
+			->willReturn(null);
 		/** @var PageService&MockObject $pageService */
 		$pageService = $this->createMock(PageService::class);
 		$pageService->method('getCollectiveFolder')

--- a/tests/Unit/Service/PageServiceTest.php
+++ b/tests/Unit/Service/PageServiceTest.php
@@ -29,7 +29,6 @@ use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException as FilesNotFoundException;
-use OCP\IConfig;
 use OCP\IUserManager;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -42,7 +41,6 @@ class PageServiceTest extends TestCase {
 	private NodeHelper $nodeHelper;
 	private CollectiveServiceBase $collectiveService;
 	private Folder $collectiveFolder;
-	private IConfig $config;
 	private PageService $service;
 	private string $userId = 'jane';
 	private int $collectiveId = 1;
@@ -86,10 +84,6 @@ class PageServiceTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->config = $this->getMockBuilder(IConfig::class)
-			->disableOriginalConstructor()
-			->getMock();
-
 		$container = $this->getMockBuilder(ContainerInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -113,7 +107,6 @@ class PageServiceTest extends TestCase {
 			$this->collectiveService,
 			$userFolderHelper,
 			$userManager,
-			$this->config,
 			$container,
 			$sessionService,
 			$slugger,


### PR DESCRIPTION
We only use the first node anyway and getFirstNodeById is faster

### 📝 Summary

* Resolves: # <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
