### PR TITLE
fix(EditButton): rename "Done" to "Preview"

### DIFF
--- a/cypress/e2e/collective-page-mode.spec.js
+++ b/cypress/e2e/collective-page-mode.spec.js
@@ -28,7 +28,7 @@ describe('Collective page mode', function() {
 				.should('not.be.visible')
 		})
 
-		it('Opens view mode per default', function() {
+		it('Opens preview mode per default', function() {
 			cy.seedCollectivePageMode('Our Garden', 0)
 			cy.visit('/apps/collectives/Our Garden')
 			// make sure the page list loaded properly

--- a/cypress/e2e/page-anchor-links.spec.js
+++ b/cypress/e2e/page-anchor-links.spec.js
@@ -29,7 +29,7 @@ describe('Page anchor links', function() {
 		const heading = 'Heading 7'
 		const headingAnchor = 'h-heading-7'
 
-		it('In view mode', function() {
+		it('In preview mode', function() {
 			cy.visit(`/apps/collectives/Anchor Links/Page#${headingAnchor}`)
 			cy.getReadOnlyEditor()
 				.find('h2')

--- a/cypress/e2e/page-details.spec.js
+++ b/cypress/e2e/page-details.spec.js
@@ -81,8 +81,8 @@ describe('Page details', function() {
 					.click()
 			}
 
-			// Switch back to view mode
-			cy.switchToViewMode()
+			// Switch back to preview mode
+			cy.switchToPreviewMode()
 				.contains('Second-Level Heading')
 
 			// TODO: Remove first selector once we only support nc33+

--- a/cypress/e2e/page-list.spec.js
+++ b/cypress/e2e/page-list.spec.js
@@ -259,7 +259,7 @@ describe('Page list', function() {
 			cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
 			cy.getEditorContent(true)
 				.type('text')
-			cy.switchToViewMode()
+			cy.switchToPreviewMode()
 
 			// Trash page
 			cy.openPageMenu('Day 1')

--- a/cypress/e2e/pages-links.spec.js
+++ b/cypress/e2e/pages-links.spec.js
@@ -159,7 +159,7 @@ describe('Page link handling', function() {
 		})
 	}
 
-	describe('Link handling to viewer in view mode', function() {
+	describe('Link handling to viewer in preview mode', function() {
 		it('Opens link with absolute path to image in Nextcloud in viewer', function() {
 			const href = `/index.php/f/${imageId}`
 			testLinkToViewer(href, { fileName: 'test.png', viewerFileElement: 'img' })
@@ -196,7 +196,7 @@ describe('Page link handling', function() {
 		})
 	})
 
-	describe('Link handling to collectives in view mode', function() {
+	describe('Link handling to collectives in preview mode', function() {
 		it('Opens link with slugified URL to page in this collective in same tab', function() {
 			const href = `${baseUrl}/index.php/apps/collectives/Link-Testing-${linkTestingCollectiveId}/Link-Target-${linkTargetPageId}`
 			testLinkToSameTab(href, {
@@ -337,7 +337,7 @@ describe('Page link handling', function() {
 		})
 	})
 
-	describe('Link handling to Nextcloud in view mode', function() {
+	describe('Link handling to Nextcloud in preview mode', function() {
 		it('Opens link with URL to another Nextcloud app in new tab', function() {
 			const href = `${baseUrl}/index.php/apps/contacts`
 			testLinkToNewTab(href)
@@ -361,7 +361,7 @@ describe('Page link handling', function() {
 		})
 	})
 
-	describe('Link handling to external in view mode', function() {
+	describe('Link handling to external in preview mode', function() {
 		it('Opens link to external website in new tab', function() {
 			const href = 'https://github.com/'
 			testLinkToNewTab(href)
@@ -423,7 +423,7 @@ describe('Page link handling', function() {
 				.click()
 			cy.get('@clipBoardWriteText').should('have.been.calledOnce')
 		})
-		it('Public share in view mode: opens link with absolute path to page in this collective in same tab', function() {
+		it('Public share in preview mode: opens link with absolute path to page in this collective in same tab', function() {
 			cy.logout()
 			cy.visit(`${shareUrl}/Link Source`)
 			const href = '/index.php/apps/collectives/Link%20Testing/Link%20Target'
@@ -443,7 +443,7 @@ describe('Page link handling', function() {
 				expectedPathname: `/index.php/apps/collectives/p/\\w+/Link-Testing-${linkTestingCollectiveId}/Link-Target-${linkTargetPageId}`,
 			})
 		})
-		it('Public share in view mode: opens link to external website in new tab', function() {
+		it('Public share in preview mode: opens link to external website in new tab', function() {
 			cy.logout()
 			cy.visit(`${shareUrl}/Link Source`)
 			const href = 'https://github.com/'
@@ -494,7 +494,7 @@ describe('Page link preview handling', function() {
 		cy.contains('.app-content-list-item a', 'Link Target')
 	})
 
-	it('Shows previews in view and edit mode', function() {
+	it('Shows previews in preview and edit mode', function() {
 		cy.getEditorContent()
 			.find('.widget-custom a.collective-page')
 			.should('have.length', 4)
@@ -544,7 +544,7 @@ describe('Page link preview handling', function() {
 		cy.get('@clipBoardWriteText').should('have.been.calledOnce')
 	})
 
-	it('Public share: Shows previews in view and edit mode', function() {
+	it('Public share: Shows previews in preview and edit mode', function() {
 		cy.logout()
 		cy.visit(`${shareUrl}/Link Source`)
 

--- a/cypress/e2e/pages.spec.js
+++ b/cypress/e2e/pages.spec.js
@@ -106,7 +106,7 @@ describe('Pages', function() {
 	})
 
 	describe('Editing a page', function() {
-		it('Supports page content editing and switching to read mode', function() {
+		it('Supports page content editing and switching to preview mode', function() {
 			cy.openPage('Day 1')
 
 			cy.log('Inserting an image')
@@ -135,8 +135,8 @@ describe('Pages', function() {
 			// Wait 1 second to prevent race condition when switching mode
 			cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
 
-			// Switch back to view mode
-			cy.switchToViewMode()
+			// Switch back to preview mode
+			cy.switchToPreviewMode()
 
 			cy.getEditor()
 				.should('not.be.visible')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -96,12 +96,12 @@ Cypress.Commands.add('getEditorContent', (edit = false) => {
 })
 
 /**
- * Switch page mode to view or edit
+ * Switch page mode to preview or edit
  */
-Cypress.Commands.add('switchToViewMode', () => {
+Cypress.Commands.add('switchToPreviewMode', () => {
 	Cypress.log()
 	cy.get('button.titleform-button')
-		.should('contain', 'Done')
+		.should('contain', 'Preview')
 		.click()
 	cy.getReadOnlyEditor()
 		.should('be.visible')

--- a/src/apis/collectives/collectives.js
+++ b/src/apis/collectives/collectives.js
@@ -143,7 +143,7 @@ export function updateCollectiveSharePermissions(collectiveId, level) {
  * @param {number} collectiveId - id of the collective to update
  * @param {number} mode - pageMode to use.
  *
- * Possible modes: pageModes.MODE_VIEW or pageModes.MODE_EDIT
+ * Possible modes: pageModes.MODE_PREVIEW or pageModes.MODE_EDIT
  */
 export function updateCollectivePageMode(collectiveId, mode) {
 	return axios.put(

--- a/src/components/Nav/CollectiveSettings.vue
+++ b/src/components/Nav/CollectiveSettings.vue
@@ -122,11 +122,11 @@
 			<div class="edit-mode">
 				<NcCheckboxRadioSwitch
 					v-model="pageMode"
-					:value="String(pageModes.MODE_VIEW)"
-					:loading="loading('updateCollectivePageMode_' + String(pageModes.MODE_VIEW))"
-					name="page_mode_view"
+					:value="String(pageModes.MODE_PREVIEW)"
+					:loading="loading('updateCollectivePageMode_' + String(pageModes.MODE_PREVIEW))"
+					name="page_mode_preview"
 					type="radio">
-					{{ t('collectives', 'View') }}
+					{{ t('collectives', 'Preview') }}
 				</NcCheckboxRadioSwitch>
 				<NcCheckboxRadioSwitch
 					v-model="pageMode"

--- a/src/components/Page/EditButton.vue
+++ b/src/components/Page/EditButton.vue
@@ -11,13 +11,13 @@
 			:aria-label="description"
 			class="titleform-button"
 			:class="{ mobile: mobile }"
-			variant="primary"
+			:variant="variant"
 			@click="handleClick()">
 			<template #icon>
 				<NcLoadingIcon
 					v-if="showLoadingIcon"
 					:size="20" />
-				<CheckIcon v-else-if="isTextEdit" :size="20" />
+				<EyeOutlineIcon v-else-if="isTextEdit" :size="20" />
 				<PencilIcon v-else :size="20" />
 			</template>
 			{{ buttonTitle }}
@@ -28,7 +28,7 @@
 <script>
 import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
 import { mapActions, mapState } from 'pinia'
-import CheckIcon from 'vue-material-design-icons/Check.vue'
+import EyeOutlineIcon from 'vue-material-design-icons/EyeOutline.vue'
 import PencilIcon from 'vue-material-design-icons/PencilOutline.vue'
 import { usePagesStore } from '../../stores/pages.js'
 import { useRootStore } from '../../stores/root.js'
@@ -37,7 +37,7 @@ export default {
 	name: 'EditButton',
 
 	components: {
-		CheckIcon,
+		EyeOutlineIcon,
 		NcButton,
 		NcLoadingIcon,
 		PencilIcon,
@@ -59,7 +59,11 @@ export default {
 		},
 
 		title() {
-			return this.isTextEdit ? t('collectives', 'Done') : t('collectives', 'Edit')
+			return this.isTextEdit ? t('collectives', 'Preview') : t('collectives', 'Edit')
+		},
+
+		variant() {
+			return this.isTextEdit ? 'secondary' : 'primary'
 		},
 
 		buttonTitle() {
@@ -72,11 +76,11 @@ export default {
 	},
 
 	methods: {
-		...mapActions(usePagesStore, ['setTextEdit', 'setTextView']),
+		...mapActions(usePagesStore, ['setTextEdit', 'setTextPreview']),
 
 		handleClick() {
 			if (this.isTextEdit) {
-				this.setTextView()
+				this.setTextPreview()
 			} else {
 				this.setTextEdit()
 			}

--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -117,8 +117,8 @@ export default {
 	},
 
 	beforeMount() {
-		// Change back to default view mode
-		this.setTextView()
+		// Change back to default preview mode
+		this.setTextPreview()
 
 		this.load('editor')
 		this.load('pageContent')
@@ -148,7 +148,7 @@ export default {
 	methods: {
 		...mapActions(useRootStore, ['load', 'done']),
 		...mapActions(useVersionsStore, ['getVersions']),
-		...mapActions(usePagesStore, ['setTextEdit', 'setTextView', 'touchPage']),
+		...mapActions(usePagesStore, ['setTextEdit', 'setTextPreview', 'touchPage']),
 
 		restoreAttachment(name) {
 			// inspired by the fixedEncodeURIComponent function suggested in

--- a/src/constants.js
+++ b/src/constants.js
@@ -41,7 +41,7 @@ export const shareTypes = {
 
 // Page modes
 export const pageModes = {
-	MODE_VIEW: 0,
+	MODE_PREVIEW: 0,
 	MODE_EDIT: 1,
 }
 

--- a/src/stores/pages.js
+++ b/src/stores/pages.js
@@ -376,9 +376,9 @@ export const usePagesStore = defineStore('pages', {
 			}
 		},
 
-		getTextMode: (state) => state.textMode[state.currentPageId] ?? pageModes.MODE_VIEW,
+		getTextMode: (state) => state.textMode[state.currentPageId] ?? pageModes.MODE_PREVIEW,
 		isTextEdit: (state) => state.getTextMode === pageModes.MODE_EDIT,
-		isTextView: (state) => state.getTextMode === pageModes.MODE_VIEW,
+		isTextPreview: (state) => state.getTextMode === pageModes.MODE_PREVIEW,
 
 		isCollapsed(state) {
 			// Default to 'true' if unset
@@ -488,7 +488,7 @@ export const usePagesStore = defineStore('pages', {
 		},
 
 		setTextEdit() { set(this.textMode, this.currentPageId, pageModes.MODE_EDIT) },
-		setTextView() { set(this.textMode, this.currentPageId, pageModes.MODE_VIEW) },
+		setTextPreview() { set(this.textMode, this.currentPageId, pageModes.MODE_PREVIEW) },
 
 		toggleCollapsed(pageId) {
 			// Default to 'false' if unset


### PR DESCRIPTION
"Done" missleads users who think they have to press it to save the page or to save changes to the page title.

Also make the button secondary if in edit mode, as switching to preview mode is not an important action.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/3abb5891-e399-4eee-a74b-cf9c16e7a14d" /> | <img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/1f420a1b-c1ab-4f53-99e0-6fb6fb565a9b" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/3e2056ee-c84f-4c76-ba19-6ade28197782" /> | <img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/1ad489fc-2498-4083-851e-d7d17f9cb90d" />
<img width="1350" height="1026" alt="image" src="https://github.com/user-attachments/assets/988176b4-fafa-4d04-91fd-2f945a77e31f" /> | <img width="1350" height="1026" alt="image" src="https://github.com/user-attachments/assets/5f0b6a68-3381-49f0-b8e5-c8a47686f40a" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
