### PR TITLE
enh(nav): delay closing by one second

### DIFF
--- a/src/components/CollectiveContainer.vue
+++ b/src/components/CollectiveContainer.vue
@@ -147,7 +147,7 @@ export default {
 		...mapActions(useVersionsStore, ['selectVersion']),
 
 		async initCollective() {
-			this.closeNav()
+			setTimeout(() => this.closeNav(), 1000)
 			this.show('details')
 
 			this.loadPending = true


### PR DESCRIPTION

This way the animation works and it becomes more obvious what is happening.

Also a click on another collective does not break the whole page layout
but smoothly transitions.

Addresses the finding from user testing that 4/4 users did not understand
what happened with the list after they created a collective.

https://github.com/user-attachments/assets/05e0e026-37df-4ea9-9a34-6fcde43a810b