### PR TITLE
fix(CollectiveSettings): allow to rename a collective as admin

### DIFF
--- a/src/components/Nav/CollectiveSettings.vue
+++ b/src/components/Nav/CollectiveSettings.vue
@@ -30,8 +30,7 @@
 				</NcEmojiPicker>
 				<NcTextField
 					v-model="newCollectiveName"
-					:disabled="!isCollectiveOwner(collective)"
-					:label="getRenameLabel"
+					:label="t('collectives', 'Name of the collective')"
 					:error="isNameTooShort"
 					:show-trailing-button="!isNameTooShort"
 					trailing-button-icon="arrowEnd"
@@ -202,16 +201,8 @@ export default {
 			'loading',
 		]),
 
-		...mapState(useCollectivesStore, ['isCollectiveOwner']),
-
 		emojiTitle() {
 			return this.collective.emoji ? t('collectives', 'Change emoji') : t('collectives', 'Add emoji')
-		},
-
-		getRenameLabel() {
-			return this.isCollectiveOwner(this.collective)
-				? t('collectives', 'Name of the collective')
-				: t('collectives', 'Renaming is limited to owners of the team')
 		},
 
 		isNameTooShort() {


### PR DESCRIPTION
Depends on https://github.com/nextcloud/circles/pull/2190

Fixes: #1716

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
