### PR TITLE
fix(navigation): delay closing only when switching collectives

### DIFF
--- a/src/components/CollectiveContainer.vue
+++ b/src/components/CollectiveContainer.vue
@@ -113,7 +113,7 @@ export default {
 		'currentCollective.id': function(val) {
 			this.clearFilterTags()
 			if (val) {
-				this.initCollective()
+				this.initCollective({ closeNavDelay: true })
 			}
 		},
 
@@ -136,7 +136,7 @@ export default {
 	},
 
 	mounted() {
-		this.initCollective()
+		this.initCollective({})
 		this.slugUrl()
 	},
 
@@ -146,8 +146,12 @@ export default {
 		...mapActions(useTagsStore, ['clearFilterTags']),
 		...mapActions(useVersionsStore, ['selectVersion']),
 
-		async initCollective() {
-			setTimeout(() => this.closeNav(), 1000)
+		async initCollective({ closeNavDelay = false }) {
+			if (closeNavDelay && !this.isPublic) {
+				setTimeout(() => this.closeNav(), 1000)
+			} else {
+				this.closeNav()
+			}
 			this.show('details')
 
 			this.loadPending = true


### PR DESCRIPTION
We don't want delayed closing when opening a collective in a new tab or in public collectives.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
