### PR TITLE
fix(PageInfoBar): add native tooltips to links

### DIFF
--- a/src/components/Page/PageInfoBar.vue
+++ b/src/components/Page/PageInfoBar.vue
@@ -9,6 +9,7 @@
 			:is="canEdit ? 'a' : 'div'"
 			v-if="currentPage.lastUserId"
 			class="infobar-item infobar-lastupdate"
+			:title="versionsLinkTitle"
 			@click="canEdit ? emitSidebar('versions') : undefined">
 			<div class="item-text">
 				<LastUserBubble
@@ -22,7 +23,7 @@
 			<div v-if="currentPage.lastUserId" class="infobar-seperator">
 				•
 			</div>
-			<a class="infobar-item" @click="emitSidebar('attachments')">
+			<a class="infobar-item" :title="attachmentsLinkTitle" @click="emitSidebar('attachments')">
 				<div class="item-icon">
 					<PaperclipIcon :size="18" />
 				</div>
@@ -35,7 +36,7 @@
 			<div v-if="currentPage.lastUserId || attachmentCount" class="infobar-seperator">
 				•
 			</div>
-			<a class="infobar-item" @click="emitSidebar('backlinks')">
+			<a class="infobar-item" :title="backlinksLinkTitle" @click="emitSidebar('backlinks')">
 				<div class="item-icon">
 					<ArrowBottomLeftIcon :size="18" />
 				</div>
@@ -92,6 +93,20 @@ export default {
 	},
 
 	computed: {
+		versionsLinkTitle() {
+			return this.canEdit
+				? t('collectives', 'Open version history')
+				: ''
+		},
+
+		attachmentsLinkTitle() {
+			return t('collectives', 'Open attachments')
+		},
+
+		backlinksLinkTitle() {
+			return t('collectives', 'Open backlinks')
+		},
+
 		attachmentCountString() {
 			return this.isMobile
 				? this.attachmentCount


### PR DESCRIPTION
#### 🖼️ Screenshots

🏚️ Before | 🏡 After (tooltip in screenshot, but mouse cursor not)
---|---
B | <img width="850" height="291" alt="image" src="https://github.com/user-attachments/assets/3c14c432-d096-4616-8ed7-9f4af5588ec0" />


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
