### PR TITLE
fix(MemberSearchResults): Fix infinite loading after an error occurred while adding a new member

### DIFF
--- a/src/components/Member/MemberSearchResults.vue
+++ b/src/components/Member/MemberSearchResults.vue
@@ -142,8 +142,11 @@ export default {
 
 		async onClick(item) {
 			this.$set(this.loadingItems, `${item.source}-${item.id}`, true)
-			await this.onClickSearched(item)
-			this.$delete(this.loadingItems, `${item.source}-${item.id}`)
+			try {
+				await this.onClickSearched(item)
+			} finally {
+				this.$delete(this.loadingItems, `${item.source}-${item.id}`)
+			}
 		},
 
 		generateKey(item) {


### PR DESCRIPTION
For example if the user is already part of the team the request will fail and the loading spinner will not disappear.