### PR TITLE
fix(reader): set default width, required for read-only shares

### DIFF
--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -240,6 +240,13 @@ export default {
 	min-height: 50vh;
 }
 
+[data-collectives-el="reader"] {
+	// Set default width for reader, required for read-only shares on Nextcloud <= 32
+	:deep(.editor__content) {
+		max-width: var(--text-editor-max-width, var(--text-editor-max-width-default));
+	}
+}
+
 .page-content-skeleton {
 	padding-block-start: var(--default-clickable-area);
 }


### PR DESCRIPTION
In read-only shares on Nextcloud <= 32, `--text-editor-max-width` is unset as no session editor gets loaded. So we need a default value for the reader width in these cases.

Fixes: #2290

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
