### PR TITLE
feat: Bring back team overview

### DIFF
--- a/src/components/Nav/CollectiveMembersModal.vue
+++ b/src/components/Nav/CollectiveMembersModal.vue
@@ -10,18 +10,15 @@
 		@close="onClose">
 		<div class="modal-collective-members">
 			<h2 class="modal-collective-members__name">
+				{{ t('collectives', 'Members of collective {name}', { name: collective.name }, { escape: false }) }}
 				<a
 					v-if="showTeamLink"
 					class="team-link"
 					:href="teamUrl"
 					:title="t('collectives', 'Go to team overview')"
 					target="_blank">
-					{{ t('collectives', 'Members of collective {name}', { name: collective.name }, { escape: false }) }}
 					<OpenInNewIcon :size="20" />
 				</a>
-				<template v-else>
-					{{ t('collectives', 'Members of collective {name}', { name: collective.name }, { escape: false }) }}
-				</template>
 			</h2>
 			<MemberPicker
 				:show-current="true"
@@ -131,6 +128,7 @@ export default {
 	height: 550px;
 	max-height: 80vh;
 
+	// Rules are mostly copied from NcDialog:
 	&__name {
 		font-size: 21px;
 		text-align: center;
@@ -138,7 +136,7 @@ export default {
 		min-height: var(--default-clickable-area);
 		overflow-wrap: break-word;
 		margin-block: 0 12px;
-		margin-inline: 0;
+		padding-inline: var(--default-clickable-area);
 
 		&:hover .team-link,
 		&:hover .material-design-icon {
@@ -150,13 +148,11 @@ export default {
 
 .team-link {
 	color: var(--color-main-text);
-	text-decoration: none;
 
 	.material-design-icon {
 		display: inline;
 		vertical-align: middle;
 		color: var(--color-text-maxcontrast);
-		white-space: nowrap;
 	}
 
 	&:focus-visible {


### PR DESCRIPTION
### 📝 Summary

Initially I wanted to open a ticket to remove the Teams overview from the collectives landing page and move it into the members modal, because I too think that it causes too much confusion there and belongs in the members modal. My wish came partially true in 8c9e829f165ff5ae03e0c5c324d20ff0ab4201be but now there is no direct link from the collective to its corresponding team overview, which I personally found to be useful.

This PR brings back the link to the team overview that was removed in 8c9e829f165ff5ae03e0c5c324d20ff0ab4201be , but places it in the members modal next to the name of the collective. This is more intuitive then having it on the landing page: I am already in the members overview and am offered to go "deeper" into the team configuration.  The link icon is generally understood as leading to a new page/modal. 

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="633" height="155" alt="image" src="https://github.com/user-attachments/assets/1f8c2a96-fd41-4fbb-8b22-97253d01714a" /> | <img width="647" height="155" alt="image" src="https://github.com/user-attachments/assets/664de87f-3048-4cb9-99a9-4481dafa01e3" />

#### Notes

The usage of the OpenInNewIcon follows the design of [the Teams dashboard widget](https://github.com/nextcloud/circles/blob/master/src/views/DashboardTeamsWidget.vue):

<img width="250"  alt="image" src="https://github.com/user-attachments/assets/f8da6c3b-6970-4a54-97df-feb1e8d064df" />


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) <del>has been updated or</del> is not required
