### PR TITLE
fix(PageInfoBar): Do not show versionsLink for public shares

### DIFF
--- a/src/components/Page/PageInfoBar.vue
+++ b/src/components/Page/PageInfoBar.vue
@@ -6,11 +6,11 @@
 <template>
 	<div class="text-menubar">
 		<component
-			:is="canEdit ? 'a' : 'div'"
+			:is="versionsLink ? 'a' : 'div'"
 			v-if="currentPage.lastUserId"
 			class="infobar-item infobar-lastupdate"
 			:title="versionsLinkTitle"
-			@click="canEdit ? emitSidebar('versions') : undefined">
+			@click="versionsLink ? emitSidebar('versions') : undefined">
 			<div class="item-text">
 				<LastUserBubble
 					:last-user-id="currentPage.lastUserId"
@@ -52,9 +52,11 @@
 import { emit } from '@nextcloud/event-bus'
 import { n, t } from '@nextcloud/l10n'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
+import { mapState } from 'pinia'
 import ArrowBottomLeftIcon from 'vue-material-design-icons/ArrowBottomLeft.vue'
 import PaperclipIcon from 'vue-material-design-icons/Paperclip.vue'
 import LastUserBubble from '../LastUserBubble.vue'
+import { useRootStore } from '../../stores/root.js'
 
 export default {
 	name: 'PageInfoBar',
@@ -93,8 +95,14 @@ export default {
 	},
 
 	computed: {
+		...mapState(useRootStore, ['isPublic']),
+
+		versionsLink() {
+			return this.canEdit && !this.isPublic
+		},
+
 		versionsLinkTitle() {
-			return this.canEdit
+			return this.versionsLink
 				? t('collectives', 'Open version history')
 				: ''
 		},


### PR DESCRIPTION
### 📝 Summary

* Completes fix for #2169  <!-- related github issue -->

<!-- Write a summary of your change and some reasoning if needed -->

- Last edited information should not be a link if I can not open the versions sidebar
- Beside checking for canEdit, should also check if !isPublic (public shares have no versions sidebar)


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing <del>and the changes are covered with tests</del>
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) <del>has been updated or</del> is not required
