### PR TITLE
fix: Catch exceptions at Circle::getInitiator during mountpoint setup

### DIFF
--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -12,6 +12,7 @@ namespace OCA\Collectives\Mount;
 use OC\Files\Cache\Cache;
 use OCA\Collectives\Db\Collective;
 use OCA\Collectives\Fs\UserFolderHelper;
+use OCA\Collectives\Service\CircleException;
 use OCA\Collectives\Service\CollectiveHelper;
 use OCA\Collectives\Service\MissingDependencyException;
 use OCA\Collectives\Service\NotFoundException;
@@ -50,7 +51,7 @@ class MountProvider implements IMountProvider {
 
 		try {
 			$collectives = $this->collectiveHelper->getCollectivesForUser($user->getUID(), true, false);
-		} catch (QueryException|MissingDependencyException|NotFoundException|NotPermittedException $e) {
+		} catch (QueryException|MissingDependencyException|NotFoundException|NotPermittedException|CircleException $e) {
 			$this->log($e);
 			return $folders;
 		}

--- a/lib/Service/CircleException.php
+++ b/lib/Service/CircleException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Service;
+
+class CircleException extends ServiceException {
+}

--- a/lib/Service/CircleHelper.php
+++ b/lib/Service/CircleHelper.php
@@ -285,10 +285,9 @@ class CircleHelper {
 			$member = $circle->getInitiator();
 		} catch (CircleNotFoundException $e) {
 			throw new NotFoundException($e->getMessage(), 0, $e);
-		} catch (RequestBuilderException|
-			FederatedItemException $e) {
-				throw new NotPermittedException($e->getMessage(), 0, $e);
-			}
+		} catch (RequestBuilderException|FederatedItemException $e) {
+			throw new NotPermittedException($e->getMessage(), 0, $e);
+		}
 
 		return $member->getLevel();
 	}

--- a/lib/Service/CollectiveHelper.php
+++ b/lib/Service/CollectiveHelper.php
@@ -22,6 +22,7 @@ class CollectiveHelper {
 	}
 
 	/**
+	 * @throws CircleException
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 * @throws MissingDependencyException
@@ -36,7 +37,11 @@ class CollectiveHelper {
 			$cid = $c->getCircleId();
 			$circle = $circles[$cid];
 			$c->setName($circle->getSanitizedName());
-			$c->setLevel($getLevel ? $circle->getInitiator()->getLevel(): 0);
+			try {
+				$c->setLevel($getLevel ? $circle->getInitiator()->getLevel(): 0);
+			} catch (\Exception $e) {
+				throw new CircleException($e->getMessage(), 0, $e);
+			}
 			if ($getUserSettings) {
 				// TODO: merge queries for collective and user settings into one?
 				$settings = $this->collectiveUserSettingsMapper->findByCollectiveAndUser($c->getId(), $userId);
@@ -50,6 +55,7 @@ class CollectiveHelper {
 	}
 
 	/**
+	 * @throws CircleException
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 * @throws MissingDependencyException
@@ -63,7 +69,11 @@ class CollectiveHelper {
 			$cid = $c->getCircleId();
 			$circle = $circles[$cid];
 			$c->setName($circle->getSanitizedName());
-			$c->setLevel($circle->getInitiator()->getLevel());
+			try {
+				$c->setLevel($circle->getInitiator()->getLevel());
+			} catch (\Exception $e) {
+				throw new CircleException($e->getMessage(), 0, $e);
+			}
 		}
 		return $collectives;
 	}


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/collectives/pull/2229 and adapted

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
