### PR TITLE
fix: catch OCSForbiddenException in public page search

### DIFF
--- a/lib/Controller/PublicPageController.php
+++ b/lib/Controller/PublicPageController.php
@@ -656,7 +656,7 @@ class PublicPageController extends CollectivesPublicOCSController {
 				if (0 !== $sharePageId = $this->getCollectiveShare()->getPageId()) {
 					try {
 						$this->checkPageShareAccess($collectiveId, $sharePageId, $value['id'], $owner);
-					} catch (NotPermittedException) {
+					} catch (NotPermittedException|OCSForbiddenException) {
 						continue;
 					}
 				}


### PR DESCRIPTION
## Bug
[Issue #2345](https://github.com/nextcloud/collectives/issues/2345) — When anonymous users search through a public page share link, the search scans the entire Collective but attempts to filter unauthorized results using checkPageShareAccess(). However, this function throws `OCSForbiddenException` instead of the expected `NotPermittedException`, causing the exception to bypass the catch block and crash the API with HTTP 403 Forbidden.

## Fix
This PR updates the exception handling in the `contentSearch` method to catch both `NotPermittedException` and `OCSForbiddenException`. This ensures that unauthorized search results are properly filtered out instead of causing the entire API call to fail.

## Testing
The fix ensures that anonymous users can search through public page shares without encountering HTTP 403 errors when some results are outside their access permissions.

Greetings, saschabuehrle