### PR TITLE
fix(TextEditor): make sure editor grows vertically

### DIFF
--- a/playwright/e2e/page-content.spec.ts
+++ b/playwright/e2e/page-content.spec.ts
@@ -26,6 +26,25 @@ test.describe('Page content', () => {
 		await runOcc(['app:disable', 'whiteboard'])
 	})
 
+	test('editor container grows vertically', async ({ user, page, collective, editor }) => {
+		const collectivePage = await collective.createPage({ title: 'Page', user, page })
+		await collectivePage.open(true)
+
+		editor.setMode(true)
+		await expect(editor.getContent()).toBeVisible()
+		await expect(editor.menubar).toBeVisible()
+
+		const containerBox = (await page.locator('.page-scroll-container').boundingBox())!
+		const menubarBox = (await editor.menubar.boundingBox())!
+		const contentBox = (await editor.getContent().boundingBox())!
+		const suggestionsContainerBox = (await editor.suggestionsContainer.boundingBox())!
+
+		const expectedContentHeight = containerBox.height - menubarBox.height - suggestionsContainerBox.height
+
+		// Allow up to 2px tolerance for borders etc.
+		expect(Math.abs(expectedContentHeight - contentBox.height)).toBeLessThan(2)
+	})
+
 	test('link to page from link menu', async ({ user, page, collective, editor }) => {
 		const sourcePage = await collective.createPage({ title: 'Source page', user, page })
 		const targetPage = await collective.createPage({ title: 'Target page', user, page })

--- a/playwright/support/sections/EditorSection.ts
+++ b/playwright/support/sections/EditorSection.ts
@@ -11,6 +11,8 @@ export class EditorSection {
 	public isEdit: boolean
 	public readonly editor: Locator
 	public readonly reader: Locator
+	public readonly menubar: Locator
+	public readonly suggestionsContainer: Locator
 	public readonly smartPicker: Locator
 	public readonly smartPickerSearch: Locator
 
@@ -18,6 +20,8 @@ export class EditorSection {
 		this.isEdit = false
 		this.editor = this.page.locator('[data-cy-collectives="editor"]')
 		this.reader = this.page.locator('[data-cy-collectives="reader"]')
+		this.menubar = this.editor.getByRole('region')
+		this.suggestionsContainer = this.page.locator('.container-suggestions')
 		this.smartPicker = this.page.getByRole('dialog')
 		this.smartPickerSearch = this.smartPicker.getByPlaceholder('Search', { exact: true })
 	}

--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -234,10 +234,15 @@ export default {
 .collectives-text-container {
 	display: flex;
 	flex-direction: column;
+	flex-grow: 1;
 
 	// Give editor some minimum scroll height on empty/short content
 	// Important on landing page when landing page widgets cover full height
 	min-height: 50vh;
+}
+
+[data-collectives-el="reader"], [data-collectives-el="editor"] {
+	flex-grow: 1;
 }
 
 [data-collectives-el="reader"] {


### PR DESCRIPTION
#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1920" height="928" alt="image" src="https://github.com/user-attachments/assets/e8ed6b05-fd44-43a5-8d3d-69b9da387793" /> | <img width="1920" height="928" alt="image" src="https://github.com/user-attachments/assets/c77292bb-34eb-4ff1-a06e-9942e134b721" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
