### PR TITLE
fix(vite-config): Exclude '@nextcloud/dialogs' from optimization

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,12 @@ export default createAppConfig(
 	},
 	{
 		config: {
+			optimizeDeps: {
+				// @nextcloud/dialogs ships its own Vue 3 but @vitejs/plugin-vue2
+				// sets a bare 'vue' alias that esbuild cannot resolve during dev
+				// dependency optimization. Excluding it avoids the conflict.
+				exclude: ['@nextcloud/dialogs'],
+			},
 			build: {
 				rollupOptions: {
 					// Needed for Nextcloud >= 32. In 33 it got fixed


### PR DESCRIPTION
### 📝 Summary

Exclude `@nextcloud/dialogs` from dependency optimization to fix compile error.

<!-- Write a summary of your change and some reasoning if needed -->

## Background

While `npm run build` runs fine, running `npm run serve` throws the following error:

```
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias
✘ [ERROR] Cannot read file: $HOME/dev/nextcloud-docker-dev/workspace/server/apps/collectives/vue/dist/vue.runtime.esm.js

    node_modules/@nextcloud/dialogs/dist/chunks/index-C1xmmKTZ.mjs:2:205:
      2 │ ...unref, withCtx, createCommentVNode, createElementBlock, createElementVNode, toDisplayString } from "vue";
        ╵                                                                                                       ~~~~~
```

My understanding is that the vitejs/plugin-vue2 sets an alias for vue, that will fail to resolve for the vue dependency of `@nextcloud/@dialogs`, but on the other hand I am a bit clueless regarding vite and JS dependency optimization in general, so maybe I am missing something out here.


<details><summary>Full log</summary>

```
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias
✘ [ERROR] Cannot read file: $HOME/dev/nextcloud-docker-dev/workspace/server/apps/collectives/vue/dist/vue.runtime.esm.js

    node_modules/@nextcloud/dialogs/dist/chunks/index-C1xmmKTZ.mjs:2:205:
      2 │ ...unref, withCtx, createCommentVNode, createElementBlock, createElementVNode, toDisplayString } from "vue";
        ╵                                                                                                       ~~~~~

21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x2)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x3)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x4)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x5)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x6)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x7)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x8)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x9)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x10)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x11)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x12)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x13)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x14)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x15)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x16)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x17)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x18)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x19)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x20)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x21)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x22)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x23)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x24)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x25)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x26)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x27)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x28)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x29)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x30)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x31)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x32)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x33)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x34)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x35)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x36)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x37)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x38)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x39)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x40)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x41)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x42)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x43)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x44)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x45)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x46)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x47)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x48)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x49)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x50)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x51)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x52)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x53)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x54)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x55)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x56)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x57)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x58)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x59)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x60)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x61)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x62)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x63)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x64)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x65)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x66)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x67)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x68)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x69)
21:28:03 [vite] (client) warning: rewrote vue to vue/dist/vue.runtime.esm.js but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias (x70)
$HOME/dev/nextcloud-docker-dev/workspace/server/apps/collectives/node_modules/vite/node_modules/esbuild/lib/main.js:1467
  let error = new Error(text);
              ^

Error: Error during dependency optimization:

✘ [ERROR] Cannot read file: $HOME/dev/nextcloud-docker-dev/workspace/server/apps/collectives/vue/dist/vue.runtime.esm.js

    node_modules/@nextcloud/dialogs/dist/chunks/index-C1xmmKTZ.mjs:2:205:
      2 │ ...eateElementBlock, createElementVNode, toDisplayString } from "vue";
        ╵                                                                 ~~~~~


    at failureErrorWithLog ($HOME/dev/nextcloud-docker-dev/workspace/server/apps/collectives/node_modules/vite/node_modules/esbuild/lib/main.js:1467:15)
    at $HOME/dev/nextcloud-docker-dev/workspace/server/apps/collectives/node_modules/vite/node_modules/esbuild/lib/main.js:926:25
    at $HOME/dev/nextcloud-docker-dev/workspace/server/apps/collectives/node_modules/vite/node_modules/esbuild/lib/main.js:1345:9
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5) {
  errors: [Getter/Setter],
  warnings: [Getter/Setter]
}
```

</details> 

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
