### PR TITLE
Fix: Reduce z-index for some elements to prevent conflicts with embedded calendar popup

### DIFF
--- a/src/components/CollectiveContainer.vue
+++ b/src/components/CollectiveContainer.vue
@@ -240,7 +240,8 @@ export default {
 /* Format page title in PageContainer.vue and PageVersion.vue */
 .page-title {
 	position: relative;
-	z-index: 10022;
+	// Display above text menubar, but below dialogs and calendar event popover
+	z-index: 5;
 	padding: 0 8px;
 }
 

--- a/src/components/Page/PageInfoBar.vue
+++ b/src/components/Page/PageInfoBar.vue
@@ -150,7 +150,8 @@ page-info-bar {
 	top: 0;
 	bottom: var(--default-grid-baseline);
 	width: var(--text-editor-max-width, var(--text-editor-max-width-default));
-	z-index: 10021;
+	// Display above link previews and tables, but below dialogs and calendar event popover
+	z-index: 4;
 	background-color: var(--color-main-background-translucent);
 	backdrop-filter: var(--background-blur);
 	border-bottom: 1px solid var(--color-border);

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -30,11 +30,13 @@
 	}
 }
 
+// TODO: remove once we drop Nextcloud 32 support (Nextcloud 33 has new outline)
 .editor--outline {
 	border-radius: var(--border-radius-large);
 	box-shadow: 0 1px 10px var(--color-box-shadow);
 	background-color: var(--color-main-background);
-	z-index: 10021;
+	// Display above text menubar, but below dialogs and calendar event popover
+	z-index: 5;
 }
 
 @media print {


### PR DESCRIPTION
### 📝 Summary
Reproducer:
1. install [Calendar](https://github.com/nextcloud/calendar) module
2. embedd calendar into Collective
3. create event with huge text
4. open event in embedded calendar

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="300" alt="image" src="https://github.com/user-attachments/assets/440d92e7-da35-4dfa-aac7-ea24341cffb4" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/41bbc1d5-fba4-42a3-8298-eb3a45ce00b3" />


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
