### PR TITLE
fix(MountProvider): handle errors in resolveNameConflicts() gracefully

### DIFF
--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -102,13 +102,17 @@ class MountProvider implements IMountProvider {
 
 		$mounts = [];
 
-		try {
-			// Get user folder setting to determine user mount point path
-			$userFolderSetting = $this->userFolderHelper->getUserFolderSetting($user->getUID());
+		// Get user folder setting to determine user mount point path
+		$userFolderSetting = $this->userFolderHelper->getUserFolderSetting($user->getUID());
 
+		try {
 			// Delete or rename existing node to avoid conflicts
 			$this->resolveNameConflict($user, trim($userFolderSetting, '/'));
+		} catch (\Exception $e) {
+			$this->log($e);
+		}
 
+		try {
 			// Create the collectives root mount point with empty storage
 			// The empty storage ensures only mount points exist here, no actual files
 			$userMountPoint = '/' . $user->getUID() . '/files' . $userFolderSetting;


### PR DESCRIPTION
We don't want errors in `resolveNameConflicts()` to break mounting the Collectives folder.

Fixes: #2264
Fixes: #2324

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
