### PR TITLE
fix(PageInfoBar): make pixel-perfect with Text menubar again

### DIFF
--- a/src/components/Page/PageInfoBar.vue
+++ b/src/components/Page/PageInfoBar.vue
@@ -153,14 +153,15 @@ page-info-bar {
 	z-index: 10021;
 	background-color: var(--color-main-background-translucent);
 	backdrop-filter: var(--background-blur);
-	height: var(--default-clickable-area);
 	border-bottom: 1px solid var(--color-border);
+	padding-block: var(--default-grid-baseline);
 	margin-inline: calc((100% - var(--text-editor-max-width, var(--text-editor-max-width-default))) / 2);
 }
 </style>
 
 <style scoped lang="scss">
 .infobar {
+	height: var(--default-clickable-area);
 	width: 100%;
 	display: flex;
 	padding-block: var(--default-grid-baseline);

--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -242,6 +242,7 @@ export default {
 }
 
 [data-collectives-el="reader"], [data-collectives-el="editor"] {
+	display: flex;
 	flex-grow: 1;
 }
 


### PR DESCRIPTION
Fixes menubar being slightly higher than infobar after https://github.com/nextcloud/text/pull/8311.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
