### PR TITLE
Perf: Optimize pages loading (Listeners approach)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ In your Nextcloud instance, simply navigate to **»Apps«**, find the
 **»Teams«** and **»Collectives«** apps and enable them.
 
 	]]></description>
-	<version>4.2.0</version>
+	<version>4.2.1</version>
 	<licence>agpl</licence>
 	<author>CollectiveCloud Team</author>
 	<namespace>Collectives</namespace>
@@ -59,6 +59,7 @@ In your Nextcloud instance, simply navigate to **»Apps«**, find the
 	<repair-steps>
 		<post-migration>
 			<step>OCA\Collectives\Migration\MigrateTemplates</step>
+			<step>OCA\Collectives\Migration\PopulatePageCollectiveId</step>
 		</post-migration>
 		<live-migration>
 			<step>OCA\Collectives\Migration\GenerateSlugs</step>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -23,6 +23,7 @@ use OCA\Collectives\Listeners\BeforeTemplateRenderedListener;
 use OCA\Collectives\Listeners\CircleDestroyedListener;
 use OCA\Collectives\Listeners\CircleEditingEventListener;
 use OCA\Collectives\Listeners\CollectivesReferenceListener;
+use OCA\Collectives\Listeners\NodeDeletedListener;
 use OCA\Collectives\Listeners\NodeRenamedListener;
 use OCA\Collectives\Listeners\NodeWrittenListener;
 use OCA\Collectives\Listeners\ShareDeletedListener;
@@ -52,6 +53,7 @@ use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\Dashboard\IAPIWidgetV2;
 use OCP\Files\Config\IMountProviderCollection;
+use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\Files\Events\Node\NodeRenamedEvent;
 use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\Files\IMimeTypeLoader;
@@ -75,6 +77,7 @@ class Application extends App implements IBootstrap {
 	public function register(IRegistrationContext $context): void {
 		require_once(__DIR__ . '/../../vendor/autoload.php');
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
+		$context->registerEventListener(NodeDeletedEvent::class, NodeDeletedListener::class);
 		$context->registerEventListener(NodeRenamedEvent::class, NodeRenamedListener::class);
 		$context->registerEventListener(NodeWrittenEvent::class, NodeWrittenListener::class);
 		$context->registerEventListener(CircleDestroyedEvent::class, CircleDestroyedListener::class);

--- a/lib/Command/GenerateSlugs.php
+++ b/lib/Command/GenerateSlugs.php
@@ -12,10 +12,12 @@ namespace OCA\Collectives\Command;
 use OCA\Collectives\Fs\NodeHelper;
 use OCA\Collectives\Model\PageInfo;
 use OCA\Collectives\Service\CircleHelper;
+use OCA\Collectives\Service\MissingDependencyException;
 use OCA\Collectives\Service\NotFoundException;
 use OCA\Collectives\Service\NotPermittedException;
 use OCA\Collectives\Service\PageService;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\NotFoundException as FilesNotFoundException;
 use OCP\IDBConnection;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -98,7 +100,7 @@ class GenerateSlugs extends Command {
 		while ($rowCollective = $resultCollectives->fetch()) {
 			try {
 				$circle = $this->circleHelper->getCircle($rowCollective['circle_unique_id'], null, true);
-				$pageInfos = $this->pageService->findAll($rowCollective['id'], $circle->getOwner()->getUserId());
+				$pageInfos = $this->findAllPages((int)$rowCollective['id'], $circle->getOwner()->getUserId());
 			} catch (NotFoundException|NotPermittedException) {
 				// Ignore exceptions from CircleManager (e.g. due to cruft collective without circle)
 				continue;
@@ -120,5 +122,19 @@ class GenerateSlugs extends Command {
 		}
 
 		$resultCollectives->closeCursor();
+	}
+
+	/**
+	 * @throws MissingDependencyException
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 */
+	private function findAllPages(int $collectiveId, string $userId): array {
+		$folder = $this->pageService->getCollectiveFolder($collectiveId, $userId);
+		try {
+			return $this->pageService->getPagesFromFolder($collectiveId, $folder, $userId, true, true);
+		} catch (FilesNotFoundException $e) {
+			throw new NotFoundException($e->getMessage(), 0, $e);
+		}
 	}
 }

--- a/lib/Db/FileCacheMapper.php
+++ b/lib/Db/FileCacheMapper.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Db;
+
+use OCA\Collectives\Model\FileInfo;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+class FileCacheMapper {
+	private const BATCH_SIZE = 1000;
+
+	public function __construct(
+		private readonly IDBConnection $db,
+	) {
+	}
+
+	/**
+	 * Query filecache for file data by file IDs
+	 *
+	 * @param int[] $fileIds
+	 * @return array<int, FileInfo> Indexed by fileId
+	 */
+	public function findByFileIds(array $fileIds): array {
+		if (empty($fileIds)) {
+			return [];
+		}
+
+		$fileInfos = [];
+		foreach (array_chunk($fileIds, self::BATCH_SIZE) as $chunk) {
+			$qb = $this->db->getQueryBuilder();
+			$qb->select('fileid', 'storage', 'parent', 'path', 'name', 'mimetype', 'mimepart', 'size', 'mtime', 'storage_mtime', 'etag', 'encrypted', 'permissions', 'checksum', 'unencrypted_size')
+				->from('filecache')
+				->where($qb->expr()->in('fileid', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)));
+
+			$result = $qb->executeQuery();
+			while ($row = $result->fetch()) {
+				$fileInfo = new FileInfo(
+					fileId: (int)$row['fileid'],
+					storage: (int)$row['storage'],
+					path: (string)$row['path'],
+					parent: (int)$row['parent'],
+					name: (string)$row['name'],
+					mimetype: (int)$row['mimetype'],
+					mimepart: (int)$row['mimepart'],
+					size: (int)$row['size'],
+					mtime: (int)$row['mtime'],
+					storage_mtime: (int)$row['storage_mtime'],
+					encrypted: (int)$row['encrypted'],
+					unencrypted_size: (int)$row['unencrypted_size'],
+					etag: (string)$row['etag'],
+					permissions: (int)$row['permissions'],
+					checksum: $row['checksum'] !== null ? (string)$row['checksum'] : null,
+				);
+				$fileInfos[$fileInfo->fileId] = $fileInfo;
+			}
+			$result->closeCursor();
+		}
+
+		return $fileInfos;
+	}
+}

--- a/lib/Db/Page.php
+++ b/lib/Db/Page.php
@@ -17,6 +17,8 @@ use OCP\DB\Types;
 /**
  * @method int getId()
  * @method void setId(int $value)
+ * @method int getCollectiveId()
+ * @method void setCollectiveId(int $value)
  * @method int getFileId()
  * @method void setFileId(int $value)
  * @method string getSlug()
@@ -36,6 +38,7 @@ use OCP\DB\Types;
  */
 class Page extends Entity implements JsonSerializable {
 	protected ?int $fileId = null;
+	protected ?int $collectiveId = null;
 	protected ?string $slug = null;
 	protected ?string $lastUserId = null;
 	protected ?string $emoji = null;
@@ -51,6 +54,7 @@ class Page extends Entity implements JsonSerializable {
 	public function jsonSerialize(): array {
 		return [
 			'id' => $this->id,
+			'collectiveId' => $this->collectiveId,
 			'fileId' => $this->fileId,
 			'slug' => $this->slug,
 			'lastUserId' => $this->lastUserId,

--- a/lib/Db/PageLinkMapper.php
+++ b/lib/Db/PageLinkMapper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Collectives\Db;
 
 use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 class PageLinkMapper {
@@ -30,6 +31,36 @@ class PageLinkMapper {
 			->where($qb->expr()->eq('page_id', $qb->createNamedParameter($pageId)));
 		$result = $qb->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
 		return array_values($result);
+	}
+
+	/**
+	 * @param int[] $pageIds
+	 * @return array<int, array<int>> Indexed by page_id, values are arrays of linked_page_ids
+	 * @throws Exception
+	 */
+	public function findByPageIds(array $pageIds): array {
+		if (empty($pageIds)) {
+			return [];
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('page_id', 'linked_page_id')
+			->from(self::TABLE_NAME)
+			->where($qb->expr()->in('page_id', $qb->createNamedParameter($pageIds, IQueryBuilder::PARAM_INT_ARRAY)));
+
+		$result = $qb->executeQuery();
+		$linkedPagesByPageId = [];
+		while ($row = $result->fetch()) {
+			$pageId = (int)$row['page_id'];
+			$linkedPageId = (int)$row['linked_page_id'];
+			if (!isset($linkedPagesByPageId[$pageId])) {
+				$linkedPagesByPageId[$pageId] = [];
+			}
+			$linkedPagesByPageId[$pageId][] = $linkedPageId;
+		}
+		$result->closeCursor();
+
+		return $linkedPagesByPageId;
 	}
 
 	/**

--- a/lib/Db/PageMapper.php
+++ b/lib/Db/PageMapper.php
@@ -113,6 +113,26 @@ class PageMapper extends QBMapper {
 	/**
 	 * @return Page[]
 	 */
+	public function findByCollectiveId(int $collectiveId, bool $trashed = false): array {
+		$qb = $this->db->getQueryBuilder();
+		$andX = [
+			$qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId, IQueryBuilder::PARAM_INT)),
+		];
+		// fixme: change index to use timestamp as well?
+		if ($trashed) {
+			$andX[] = $qb->expr()->isNotNull('trash_timestamp');
+		} else {
+			$andX[] = $qb->expr()->isNull('trash_timestamp');
+		}
+		$qb->select('*')
+			->from($this->tableName)
+			->where($qb->expr()->andX(...$andX));
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * @return Page[]
+	 */
 	public function getAll(): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')

--- a/lib/Fs/NodeHelper.php
+++ b/lib/Fs/NodeHelper.php
@@ -10,12 +10,14 @@ declare(strict_types=1);
 namespace OCA\Collectives\Fs;
 
 use OCA\Collectives\Model\PageInfo;
+use OCA\Collectives\Mount\CollectiveStorage;
 use OCA\Collectives\Service\NotFoundException;
 use OCA\Collectives\Service\NotPermittedException;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\GenericFileException;
 use OCP\Files\InvalidPathException;
+use OCP\Files\Node;
 use OCP\Files\NotFoundException as FilesNotFoundException;
 use OCP\Files\NotPermittedException as FilesNotPermittedException;
 use OCP\IDBConnection;
@@ -254,15 +256,14 @@ class NodeHelper {
 
 	/**
 	 * Extract collective_id from path like "appdata_<instanceid>/collectives/<collective_id>/..."
-	 * Only processes collective pages (not trashed, not versions)
+	 * Only processes collective pages (not versions)
 	 */
 	public static function extractCollectiveIdFromPath(string $path): ?int {
-		// fixme: cover all possible cases with unit test
 		$parts = explode('/', $path);
-		if (!str_starts_with($parts[0], 'appdata_')) {
+		if (!isset($parts[0]) || !str_starts_with($parts[0], 'appdata_')) {
 			return null;
 		}
-		if ($parts[1] !== 'collectives') {
+		if (!isset($parts[1]) || $parts[1] !== 'collectives') {
 			return null;
 		}
 
@@ -275,5 +276,22 @@ class NodeHelper {
 		}
 
 		return (int)$collectiveId;
+	}
+
+	/**
+	 * Get collective ID from node if it is a markdown file belonging to a CollectiveStorage
+	 */
+	public static function getCollectiveIdFromNode(Node $node): ?int {
+		if (!($node instanceof File) || !self::isPage($node)) {
+			return null;
+		}
+
+		$storage = $node->getStorage();
+		if (!$storage->instanceOfStorage(CollectiveStorage::class)) {
+			return null;
+		}
+
+		/** @var CollectiveStorage $storage */
+		return $storage->getFolderId();
 	}
 }

--- a/lib/Fs/NodeHelper.php
+++ b/lib/Fs/NodeHelper.php
@@ -251,4 +251,29 @@ class NodeHelper {
 
 		return 0;
 	}
+
+	/**
+	 * Extract collective_id from path like "appdata_<instanceid>/collectives/<collective_id>/..."
+	 * Only processes collective pages (not trashed, not versions)
+	 */
+	public static function extractCollectiveIdFromPath(string $path): ?int {
+		// fixme: cover all possible cases with unit test
+		$parts = explode('/', $path);
+		if (!str_starts_with($parts[0], 'appdata_')) {
+			return null;
+		}
+		if ($parts[1] !== 'collectives') {
+			return null;
+		}
+
+		$collectiveId = $parts[2] ?? null;
+		if ($collectiveId === 'trash') {
+			$collectiveId = $parts[3] ?? null;
+		}
+		if (!is_numeric($collectiveId)) {
+			return null;
+		}
+
+		return (int)$collectiveId;
+	}
 }

--- a/lib/Listeners/NodeDeletedListener.php
+++ b/lib/Listeners/NodeDeletedListener.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Listeners;
+
+use OCA\Collectives\Db\PageMapper;
+use OCA\Collectives\Fs\NodeHelper;
+use OCA\Collectives\Service\PageService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\Events\Node\NodeDeletedEvent;
+
+/** @template-implements IEventListener<Event|NodeDeletedEvent> */
+class NodeDeletedListener implements IEventListener {
+	public function __construct(
+		private PageMapper $pageMapper,
+		private PageService $pageService,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof NodeDeletedEvent)) {
+			return;
+		}
+
+		if ($this->pageService->isFromCollectives()) {
+			return;
+		}
+
+		$node = $event->getNode();
+		$collectiveId = NodeHelper::getCollectiveIdFromNode($node);
+		if ($collectiveId === null) {
+			return;
+		}
+
+		$this->pageMapper->trashByFileId($node->getId());
+	}
+}

--- a/lib/Listeners/NodeRenamedListener.php
+++ b/lib/Listeners/NodeRenamedListener.php
@@ -11,17 +11,16 @@ namespace OCA\Collectives\Listeners;
 
 use OCA\Collectives\Db\PageMapper;
 use OCA\Collectives\Fs\NodeHelper;
+use OCA\Collectives\Service\PageService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\NodeRenamedEvent;
-use OCP\Files\File;
-use Symfony\Component\String\Slugger\SluggerInterface;
 
 /** @template-implements IEventListener<Event|NodeRenamedEvent> */
 class NodeRenamedListener implements IEventListener {
 	public function __construct(
-		private PageMapper $pageMapper,
-		private SluggerInterface $slugger,
+		private readonly PageService $pageService,
+		private readonly PageMapper $pageMapper,
 	) {
 	}
 
@@ -29,20 +28,24 @@ class NodeRenamedListener implements IEventListener {
 		if (!($event instanceof NodeRenamedEvent)) {
 			return;
 		}
-		$source = $event->getSource();
+
+		if ($this->pageService->isFromCollectives()) {
+			return;
+		}
+
 		$target = $event->getTarget();
-
-		if (!($source instanceof File && $target instanceof File)) {
+		$targetCollectiveId = NodeHelper::getCollectiveIdFromNode($target);
+		if ($targetCollectiveId === null) {
+			$this->pageMapper->trashByFileId($target->getId());
 			return;
 		}
 
-		$page = $this->pageMapper->findByFileId($target->getId());
-		if ($page === null) {
-			return;
+		// File moved into a collective or between collectives - update collectiveId
+		$source = $event->getSource();
+		$title = null;
+		if ($source->getName() !== $target->getName()) {
+			$title = NodeHelper::getTitleFromFile($target);
 		}
-
-		$title = NodeHelper::getTitleFromFile($target);
-		$page->setSlug($this->slugger->slug($title)->toString());
-		$this->pageMapper->update($page);
+		$this->pageService->updatePage($targetCollectiveId, $target->getId(), null, null, null, $title);
 	}
 }

--- a/lib/Listeners/NodeRenamedListener.php
+++ b/lib/Listeners/NodeRenamedListener.php
@@ -11,16 +11,22 @@ namespace OCA\Collectives\Listeners;
 
 use OCA\Collectives\Db\PageMapper;
 use OCA\Collectives\Fs\NodeHelper;
+use OCA\Collectives\Mount\CollectiveStorage;
 use OCA\Collectives\Service\PageService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\NodeRenamedEvent;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\Node;
+use Psr\Log\LoggerInterface;
 
 /** @template-implements IEventListener<Event|NodeRenamedEvent> */
 class NodeRenamedListener implements IEventListener {
 	public function __construct(
 		private readonly PageService $pageService,
 		private readonly PageMapper $pageMapper,
+		private readonly LoggerInterface $logger,
 	) {
 	}
 
@@ -34,18 +40,107 @@ class NodeRenamedListener implements IEventListener {
 		}
 
 		$target = $event->getTarget();
-		$targetCollectiveId = NodeHelper::getCollectiveIdFromNode($target);
+		$source = $event->getSource();
+
+		if ($target instanceof Folder) {
+			$this->handleFolderRenamed($source, $target);
+			return;
+		}
+
+		if ($target instanceof File) {
+			$this->handleFileRenamed($source, $target);
+		}
+	}
+
+	private function handleFolderRenamed(Node $source, Folder $target): void {
+		$sourceCollectiveId = ($source instanceof Folder) ? $this->getCollectiveIdFromFolder($source) : null;
+		$targetCollectiveId = $this->getCollectiveIdFromFolder($target);
+
 		if ($targetCollectiveId === null) {
+			// Folder moved out of collective - trash all pages
+			$this->trashFolderPages($target);
+			return;
+		}
+
+		// Folder moved into or between collectives - process all files recursively
+		$this->processFilesInFolder($target, $targetCollectiveId, $sourceCollectiveId);
+	}
+
+	private function handleFileRenamed(Node $source, File $target): void {
+		$targetCollectiveId = NodeHelper::getCollectiveIdFromNode($target);
+
+		if ($targetCollectiveId === null) {
+			// File moved out of collective - trash the page
 			$this->pageMapper->trashByFileId($target->getId());
 			return;
 		}
 
 		// File moved into a collective or between collectives - update collectiveId
-		$source = $event->getSource();
 		$title = null;
 		if ($source->getName() !== $target->getName()) {
 			$title = NodeHelper::getTitleFromFile($target);
 		}
-		$this->pageService->updatePage($targetCollectiveId, $target->getId(), null, null, null, $title);
+		$userId = $target->getOwner()?->getUID();
+		$this->pageService->updatePage($targetCollectiveId, $target->getId(), $userId, title: $title);
+	}
+
+	private function getCollectiveIdFromFolder(Folder $folder): ?int {
+		// Check if folder belongs to a CollectiveStorage
+		$storage = $folder->getStorage();
+		if ($storage->instanceOfStorage(CollectiveStorage::class)) {
+			/** @var CollectiveStorage $storage */
+			return $storage->getFolderId();
+		}
+
+		// Fallback: Try to get collective ID from folder's internal path
+		$internalPath = $folder->getInternalPath();
+		if ($internalPath !== null) {
+			return NodeHelper::extractCollectiveIdFromPath($internalPath);
+		}
+
+		return null;
+	}
+
+	private function trashFolderPages(Folder $folder): void {
+		try {
+			$nodes = $folder->getDirectoryListing();
+			foreach ($nodes as $node) {
+				if ($node instanceof File && NodeHelper::isPage($node)) {
+					$this->pageMapper->trashByFileId($node->getId());
+				} elseif ($node instanceof Folder) {
+					$this->trashFolderPages($node);
+				}
+			}
+		} catch (\Exception $e) {
+			$this->logger->error('Collectives App Error: ' . $e->getMessage(),
+				['exception' => $e]
+			);
+		}
+	}
+
+	private function processFilesInFolder(Folder $folder, int $targetCollectiveId, ?int $sourceCollectiveId): void {
+		try {
+			$nodes = $folder->getDirectoryListing();
+			foreach ($nodes as $node) {
+				if (str_starts_with($node->getName(), '.')) {
+					// Skip hidden files/folders
+					continue;
+				}
+
+				if ($node instanceof File && NodeHelper::isPage($node)) {
+					// Update or create page for this file
+					$userId = $node->getOwner()?->getUID();
+					$title = NodeHelper::getTitleFromFile($node);
+					$this->pageService->updatePage($targetCollectiveId, $node->getId(), $userId, title: $title);
+				} elseif ($node instanceof Folder) {
+					// Recursively process subfolders
+					$this->processFilesInFolder($node, $targetCollectiveId, $sourceCollectiveId);
+				}
+			}
+		} catch (\Exception $e) {
+			$this->logger->error('Collectives App Error: ' . $e->getMessage(),
+				['exception' => $e]
+			);
+		}
 	}
 }

--- a/lib/Listeners/NodeWrittenListener.php
+++ b/lib/Listeners/NodeWrittenListener.php
@@ -12,11 +12,12 @@ namespace OCA\Collectives\Listeners;
 use OCA\Collectives\Db\CollectiveMapper;
 use OCA\Collectives\Db\PageLinkMapper;
 use OCA\Collectives\Fs\MarkdownHelper;
-use OCA\Collectives\Mount\CollectiveStorage;
+use OCA\Collectives\Fs\NodeHelper;
+use OCA\Collectives\Service\PageService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\NodeWrittenEvent;
-use OCP\Files\File;
+use OCP\Files\Node;
 use OCP\IConfig;
 
 /** @template-implements IEventListener<Event|NodeWrittenEvent> */
@@ -25,6 +26,7 @@ class NodeWrittenListener implements IEventListener {
 		private IConfig $config,
 		private PageLinkMapper $pageLinkMapper,
 		private CollectiveMapper $collectiveMapper,
+		private PageService $pageService,
 	) {
 	}
 
@@ -32,19 +34,32 @@ class NodeWrittenListener implements IEventListener {
 		if (!($event instanceof NodeWrittenEvent)) {
 			return;
 		}
+
 		$node = $event->getNode();
-		$storage = $node->getStorage();
-		if (!($node instanceof File)
-			|| $node->getMimeType() !== 'text/markdown'
-			|| !$node->getStorage()->instanceOfStorage(CollectiveStorage::class)) {
+		$collectiveId = NodeHelper::getCollectiveIdFromNode($node);
+		if ($collectiveId === null) {
 			return;
 		}
 
-		/** @var CollectiveStorage $storage */
-		$collectiveId = $storage->getFolderId();
-		$collective = $this->collectiveMapper->idToCollective($collectiveId);
+		$fileId = $node->getId();
+		$this->updatePageLinks($collectiveId, $node, $fileId);
 
+		if ($this->pageService->isFromCollectives()) {
+			return;
+		}
+
+		$this->updateCollectivePage($node, $collectiveId, $fileId);
+	}
+
+	private function updatePageLinks(int $collectiveId, Node $node, int $fileId): void {
+		$collective = $this->collectiveMapper->idToCollective($collectiveId);
 		$linkedPageIds = MarkdownHelper::getLinkedPageIds($collective, $node->getContent(), $this->config->getSystemValue('trusted_domains', []));
-		$this->pageLinkMapper->updateByPageId($node->getId(), $linkedPageIds);
+		$this->pageLinkMapper->updateByPageId($fileId, $linkedPageIds);
+	}
+
+	private function updateCollectivePage(Node $node, int $collectiveId, int $fileId): void {
+		$title = NodeHelper::getTitleFromFile($node);
+		$userId = $node->getOwner()->getUID();
+		$this->pageService->updatePage($collectiveId, $fileId, $userId, null, null, $title);
 	}
 }

--- a/lib/Migration/PopulatePageCollectiveId.php
+++ b/lib/Migration/PopulatePageCollectiveId.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Migration;
+
+use OCA\Collectives\Fs\NodeHelper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IAppConfig;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class PopulatePageCollectiveId implements IRepairStep {
+	private const BATCH_SIZE = 1000;
+
+	public function __construct(
+		private IAppConfig $config,
+		private IDBConnection $connection,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Populate collective_id for existing pages';
+	}
+
+	public function run(IOutput $output): void {
+		if ($this->config->getValueBool('collectives', 'migrated_collective_id')) {
+			$output->info('collective_id already populated');
+			return;
+		}
+
+		$output->info('Populating collective_id for pages ...');
+
+		$fileIds = $this->getFileIdsWithoutCollectiveId();
+		$output->startProgress(count($fileIds));
+
+		if (empty($fileIds)) {
+			$output->finishProgress();
+			$output->info('No pages need updating');
+			$this->config->setValueBool('collectives', 'migrated_collective_id', true);
+			return;
+		}
+
+		foreach (array_chunk($fileIds, self::BATCH_SIZE) as $chunk) {
+			$this->processBatch($chunk, $output);
+		}
+
+		$output->finishProgress();
+		$output->info('done');
+
+		$this->config->setValueBool('collectives', 'migrated_collective_id', true);
+	}
+
+	/**
+	 * Get all file_ids that have null collective_id
+	 *
+	 * @return list<int>
+	 */
+	private function getFileIdsWithoutCollectiveId(): array {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('file_id')
+			->from('collectives_pages')
+			->where($qb->expr()->isNull('collective_id'));
+
+		$result = $qb->executeQuery();
+		$fileIds = [];
+		while ($row = $result->fetch()) {
+			$fileIds[] = (int)$row['file_id'];
+		}
+		$result->closeCursor();
+
+		return $fileIds;
+	}
+
+	/**
+	 * @param list<int> $fileIds
+	 */
+	private function processBatch(array $fileIds, IOutput $output): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select(['fileid', 'path'])
+			->from('filecache')
+			->where($qb->expr()->in('fileid', $qb->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)));
+
+		$result = $qb->executeQuery();
+		while ($row = $result->fetch()) {
+			$fileId = (int)$row['fileid'];
+			$collectiveId = NodeHelper::extractCollectiveIdFromPath($row['path']);
+			if (!$collectiveId) {
+				$output->warning("Could not extract collective_id for file_id $fileId with path {$row['path']}");
+				continue;
+			}
+
+			$this->updatePage($fileId, $collectiveId);
+		}
+	}
+
+	private function updatePage(int $fileId, int $collectiveId): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('collectives_pages')
+			->set('collective_id', $qb->createParameter('collective_id'))
+			->where($qb->expr()->eq('file_id', $qb->createParameter('file_id')));
+
+		$qb->setParameter('file_id', $fileId, IQueryBuilder::PARAM_INT)
+			->setParameter('collective_id', $collectiveId, IQueryBuilder::PARAM_INT)
+			->executeStatement();
+	}
+}

--- a/lib/Migration/Version030401Date20250331000000.php
+++ b/lib/Migration/Version030401Date20250331000000.php
@@ -31,8 +31,8 @@ class Version030401Date20250331000000 extends SimpleMigrationStep {
 				$changed = true;
 			}
 
-			if (!$table->hasIndex('collectives_pages_collective_id_index')) {
-				$table->addIndex(['collective_id'], 'collectives_pages_collective_id_index');
+			if (!$table->hasIndex('collectives_pages_c_id_idx')) {
+				$table->addIndex(['collective_id'], 'collectives_pages_c_id_idx');
 				$changed = true;
 			}
 

--- a/lib/Migration/Version030401Date20250331000000.php
+++ b/lib/Migration/Version030401Date20250331000000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version030401Date20250331000000 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('collectives_pages')) {
+			$table = $schema->getTable('collectives_pages');
+			$changed = false;
+
+			if (!$table->hasColumn('collective_id')) {
+				$table->addColumn('collective_id', Types::BIGINT, [
+					'notnull' => false,
+				]);
+				$changed = true;
+			}
+
+			if (!$table->hasIndex('collectives_pages_collective_id_index')) {
+				$table->addIndex(['collective_id'], 'collectives_pages_collective_id_index');
+				$changed = true;
+			}
+
+			if ($changed) {
+				return $schema;
+			}
+		}
+
+		return null;
+	}
+}

--- a/lib/Model/FileInfo.php
+++ b/lib/Model/FileInfo.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Model;
+
+/**
+ * Represents a file entry from the filecache table
+ */
+class FileInfo {
+	public function __construct(
+		public readonly int $fileId,
+		public readonly int $storage,
+		public readonly string $path,
+		public readonly int $parent,
+		public readonly string $name,
+		public readonly int $mimetype,
+		public readonly int $mimepart,
+		public readonly int $size,
+		public readonly int $mtime,
+		public readonly int $storage_mtime,
+		public readonly int $encrypted,
+		public readonly int $unencrypted_size,
+		public readonly string $etag,
+		public readonly int $permissions,
+		public readonly ?string $checksum,
+	) {
+	}
+
+	/**
+	 * Get the title from filename (strip .md suffix, handle index pages)
+	 */
+	public function getTitle(): string {
+		if ($this->name === PageInfo::INDEX_PAGE_TITLE . PageInfo::SUFFIX) {
+			return '';
+		}
+		return basename($this->name, PageInfo::SUFFIX);
+	}
+
+	/**
+	 * Check if this is an index page (Readme.md)
+	 */
+	public function isIndexPage(): bool {
+		return $this->name === PageInfo::INDEX_PAGE_TITLE . PageInfo::SUFFIX;
+	}
+
+	/**
+	 * Extract relative directory path within collective folder
+	 *
+	 * @param string $collectiveFolderPath Collective folder filecache path (e.g., "appdata_xxx/collectives/11")
+	 * @return string Relative path (e.g., "subfolder")
+	 */
+	public function getRelativePath(string $collectiveFolderPath): string {
+		$dirPath = dirname($this->path);
+		$prefix = $collectiveFolderPath . '/';
+
+		if (str_starts_with($dirPath, $prefix)) {
+			return substr($dirPath, strlen($prefix));
+		}
+
+		if ($dirPath === $collectiveFolderPath) {
+			return '';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Check if this file is inside a hidden folder (starting with .)
+	 *
+	 * @param string $collectiveFolderPath Collective folder filecache path
+	 * @return bool
+	 */
+	public function isInHiddenFolder(string $collectiveFolderPath): bool {
+		$relativePath = $this->getRelativePath($collectiveFolderPath);
+		if ($relativePath === '') {
+			return false;
+		}
+		foreach (explode('/', $relativePath) as $segment) {
+			if (str_starts_with($segment, '.')) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/lib/Model/PageInfo.php
+++ b/lib/Model/PageInfo.php
@@ -216,6 +216,68 @@ class PageInfo implements JsonSerializable {
 		];
 	}
 
+	public static function fromFileInfo(
+		FileInfo $fileInfo,
+		int $parentId,
+		string $filePath,
+		?string $lastUserId = null,
+		?string $lastUserDisplayName = null,
+		?string $emoji = null,
+		?string $subpageOrder = null,
+		?bool $fullWidth = false,
+		?string $slug = null,
+		?string $tags = null,
+		?array $linkedPageIds = null,
+	): self {
+		$pageInfo = new self();
+		$pageInfo->setId($fileInfo->fileId);
+		$pageInfo->setTimestamp($fileInfo->mtime);
+		$pageInfo->setSize($fileInfo->size);
+		$pageInfo->setFileName($fileInfo->name);
+		$pageInfo->setFilePath($filePath);
+
+		// Set folder name as title for all index pages except the collective landing page
+		if ($fileInfo->isIndexPage()) {
+			if ($parentId === 0) {
+				// Landing page
+				$pageInfo->setTitle(Server::get(IFactory::class)->get('collectives')->t('Landing page'));
+			} else {
+				// Index page - use parent folder name as title
+				$pageInfo->setTitle(basename($filePath));
+			}
+		} else {
+			$pageInfo->setTitle($fileInfo->getTitle());
+		}
+
+		if ($lastUserId !== null) {
+			$pageInfo->setLastUserId($lastUserId);
+		}
+		if ($lastUserDisplayName !== null) {
+			$pageInfo->setLastUserDisplayName($lastUserDisplayName);
+		}
+		if ($emoji !== null) {
+			$pageInfo->setEmoji($emoji);
+		}
+		if ($fullWidth !== null) {
+			$pageInfo->setFullWidth($fullWidth);
+		}
+		if ($subpageOrder !== null) {
+			$pageInfo->setSubpageOrder($subpageOrder);
+		}
+		if ($slug !== null) {
+			$pageInfo->setSlug($slug);
+		}
+		if ($tags !== null) {
+			$pageInfo->setTags($tags);
+		}
+		if ($linkedPageIds !== null) {
+			$pageInfo->setLinkedPageIds($linkedPageIds);
+		}
+		$pageInfo->setParentId($parentId);
+
+		return $pageInfo;
+	}
+
 	/**
 	 * @throws InvalidPathException
 	 * @throws NotFoundException

--- a/lib/Service/CollectiveService.php
+++ b/lib/Service/CollectiveService.php
@@ -244,6 +244,7 @@ class CollectiveService extends CollectiveServiceBase {
 
 			$page = new Page();
 			$page->setFileId($file->getId());
+			$page->setCollectiveId($collective->getId());
 			$page->setLastUserId($userId);
 			$this->pageMapper->updateOrInsert($page);
 		} catch (FilesNotFoundException|InvalidPathException $e) {

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -295,6 +295,7 @@ class PageService {
 	private function updatePage(int $collectiveId, int $fileId, string $userId, ?string $emoji = null, ?bool $fullWidth = null, ?string $slug = null, ?string $tags = null): void {
 		$page = new Page();
 		$page->setFileId($fileId);
+		$page->setCollectiveId($collectiveId);
 		$page->setLastUserId($userId);
 		if ($emoji !== null) {
 			$page->setEmoji($emoji);

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -11,13 +11,16 @@ namespace OCA\Collectives\Service;
 
 use Exception;
 use OCA\Collectives\Db\Collective;
+use OCA\Collectives\Db\FileCacheMapper;
 use OCA\Collectives\Db\Page;
 use OCA\Collectives\Db\PageLinkMapper;
 use OCA\Collectives\Db\PageMapper;
 use OCA\Collectives\Db\TagMapper;
 use OCA\Collectives\Fs\NodeHelper;
 use OCA\Collectives\Fs\UserFolderHelper;
+use OCA\Collectives\Model\FileInfo;
 use OCA\Collectives\Model\PageInfo;
+use OCA\Collectives\Mount\CollectiveFolderManager;
 use OCA\Collectives\Trash\PageTrashBackend;
 use OCA\NotifyPush\Queue\IQueue;
 use OCP\App\IAppManager;
@@ -39,13 +42,15 @@ class PageService {
 	private ?IQueue $pushQueue = null;
 	private ?Collective $collective = null;
 	private ?PageTrashBackend $trashBackend = null;
-	private ?array $allPageInfos = null;
+	private bool $fromCollectives = false;
 
 	public function __construct(
 		private readonly IAppManager $appManager,
 		private readonly PageMapper $pageMapper,
+		private readonly FileCacheMapper $fileCacheMapper,
 		private readonly NodeHelper $nodeHelper,
 		private readonly CollectiveServiceBase $collectiveService,
+		private readonly CollectiveFolderManager $collectiveFolderManager,
 		private readonly UserFolderHelper $userFolderHelper,
 		private readonly IUserManager $userManager,
 		ContainerInterface $container,
@@ -58,6 +63,20 @@ class PageService {
 			$this->pushQueue = $container->get(IQueue::class);
 		} catch (Exception) {
 		}
+	}
+
+	/**
+	 * Check if the current operation originates from Collectives
+	 */
+	public function isFromCollectives(): bool {
+		return $this->fromCollectives;
+	}
+
+	/**
+	 * Set flag to indicate that the operation originates from Collectives
+	 */
+	public function setFromCollectives(bool $value): void {
+		$this->fromCollectives = $value;
 	}
 
 	private function initTrashBackend(): void {
@@ -292,24 +311,30 @@ class PageService {
 		}
 	}
 
-	private function updatePage(int $collectiveId, int $fileId, string $userId, ?string $emoji = null, ?bool $fullWidth = null, ?string $slug = null, ?string $tags = null): void {
+	public function updatePage(int $collectiveId, int $fileId, ?string $userId = null, ?string $emoji = null, ?bool $fullWidth = null, ?string $title = null, ?string $tags = null, ?string $slug = null): Page {
 		$page = new Page();
 		$page->setFileId($fileId);
 		$page->setCollectiveId($collectiveId);
-		$page->setLastUserId($userId);
+		if ($userId !== null) {
+			$page->setLastUserId($userId);
+		}
 		if ($emoji !== null) {
 			$page->setEmoji($emoji);
 		}
 		if ($fullWidth !== null) {
 			$page->setFullWidth($fullWidth);
 		}
-		if ($slug !== null) {
+		if ($title !== null) {
+			$page->setSlug($this->slugger->slug($title)->toString());
+		} elseif ($slug !== null) {
 			$page->setSlug($slug);
 		}
 		if ($tags !== null) {
 			$page->setTags($tags);
 		}
 		$this->pageMapper->updateOrInsert($page);
+
+		return $page;
 	}
 
 	/**
@@ -343,10 +368,13 @@ class PageService {
 	 * @throws NotPermittedException
 	 */
 	private function newPage(int $collectiveId, Folder $folder, string $filename, string $userId, ?string $title, ?string $content = null): PageInfo {
+		$this->setFromCollectives(true);
 		try {
 			$newFile = $folder->newFile($filename . PageInfo::SUFFIX, $content);
 		} catch (FilesNotPermittedException $e) {
 			throw new NotPermittedException($e->getMessage(), 0, $e);
+		} finally {
+			$this->setFromCollectives(false);
 		}
 
 		$pageInfo = new PageInfo();
@@ -355,9 +383,8 @@ class PageService {
 				$this->getParentPageId($newFile),
 				$userId,
 				$this->userManager->getDisplayName($userId));
-			$slug = $title ? $this->slugger->slug($title)->toString() : null;
-			$this->updatePage($collectiveId, $newFile->getId(), $userId, null, null, $slug);
-			$pageInfo->setSlug($slug);
+			$page = $this->updatePage($collectiveId, $newFile->getId(), $userId, null, null, $title);
+			$pageInfo->setSlug($page->getSlug());
 		} catch (FilesNotFoundException|InvalidPathException $e) {
 			throw new NotFoundException($e->getMessage(), 0, $e);
 		}
@@ -374,12 +401,15 @@ class PageService {
 			return $folder;
 		}
 
+		$this->setFromCollectives(true);
 		try {
 			$folderName = NodeHelper::generateFilename($folder, basename($file->getName(), PageInfo::SUFFIX));
 			$subFolder = $folder->newFolder($folderName);
 			$file->move($subFolder->getPath() . '/' . PageInfo::INDEX_PAGE_TITLE . PageInfo::SUFFIX);
 		} catch (InvalidPathException|FilesNotFoundException|FilesNotPermittedException|LockedException $e) {
 			throw new NotPermittedException($e->getMessage(), 0, $e);
+		} finally {
+			$this->setFromCollectives(false);
 		}
 		return $subFolder;
 	}
@@ -494,6 +524,7 @@ class PageService {
 		return array_merge([$indexPage], $folderPageInfos, $subPageInfos);
 	}
 
+	// fixme: provide faster version findChildrenV2 that uses non-recursive single-query loading
 	/**
 	 * @throws MissingDependencyException
 	 * @throws NotFoundException
@@ -515,21 +546,110 @@ class PageService {
 	}
 
 	/**
+	 * Get all pages for a collective using non-recursive single-query loading
+	 */
+	public function getPagesForCollectiveId(int $collectiveId, Folder $folder, string $userId): array {
+		$collectiveFolderPath = $this->collectiveFolderManager->getRootPath() . '/' . $collectiveId;
+
+		// Get collectivePath from mount point (e.g. ".Collectives/my collective")
+		$mountParts = explode('/', $folder->getMountPoint()->getMountPoint(), 4);
+		$collectiveMountPath = (count($mountParts) >= 4) ? rtrim($mountParts[3], '/') : null;
+
+		// Load all pages for this collective in a single query
+		$pages = $this->pageMapper->findByCollectiveId($collectiveId);
+		if (empty($pages)) {
+			$indexPage = $this->newPage($collectiveId, $folder, PageInfo::INDEX_PAGE_TITLE, $userId, PageInfo::INDEX_PAGE_TITLE);
+			return [$indexPage];
+		}
+
+		$fileIds = array_map(static fn (Page $page) => $page->getFileId(), $pages);
+		$pageIds = array_map(static fn (Page $page) => $page->getId(), $pages);
+		$fileInfos = $this->fileCacheMapper->findByFileIds($fileIds);
+		$linkedPageIdsPerPageId = $this->pageLinkMapper->findByPageIds($pageIds);
+
+		// Build path-to-fileId index for parent lookup
+		$indexPageByPath = [];
+		foreach ($fileInfos as $fileInfo) {
+			if ($fileInfo->isIndexPage()) {
+				$indexPageByPath[dirname($fileInfo->path)] = $fileInfo->fileId;
+			}
+		}
+
+		// Build PageInfo objects
+		$pageInfos = [];
+		foreach ($pages as $page) {
+			$fileId = $page->getFileId();
+			if (!isset($fileInfos[$fileId])) {
+				continue;
+			}
+
+			$fileInfo = $fileInfos[$fileId];
+			if ($fileInfo->isInHiddenFolder($collectiveFolderPath)) {
+				continue;
+			}
+
+			$parentId = $this->calculateParentId($fileInfo, $indexPageByPath, $collectiveFolderPath);
+
+			$pageInfo = PageInfo::fromFileInfo(
+				$fileInfo,
+				$parentId,
+				$fileInfo->getRelativePath($collectiveFolderPath),
+				$page->getLastUserId(),
+				$page->getLastUserId() ? $this->userManager->getDisplayName($page->getLastUserId()) : null,
+				$page->getEmoji(),
+				$page->getSubpageOrder(),
+				$page->getFullWidth(),
+				$page->getSlug(),
+				$page->getTags(),
+				$linkedPageIdsPerPageId[$page->getId()] ?? []
+			);
+
+			if ($collectiveMountPath !== null) {
+				$pageInfo->setCollectivePath($collectiveMountPath);
+			}
+
+			$pageInfos[] = $pageInfo;
+		}
+
+		return $pageInfos;
+	}
+
+
+	/**
+	 * Calculate parent page ID for a file using path-based lookup
+	 *
+	 * @param FileInfo $fileInfo
+	 * @param array<string, int> $indexPageByPath Map of folder path => index page fileId
+	 * @param string $collectiveFolderPath Collective folder filecache path
+	 * @return int
+	 */
+	private function calculateParentId(FileInfo $fileInfo, array $indexPageByPath, string $collectiveFolderPath): int {
+		$fileDir = dirname($fileInfo->path);
+
+		if ($fileInfo->isIndexPage()) {
+			// Landing page (index page in collective root) has parent 0
+			if ($fileDir === $collectiveFolderPath) {
+				return 0;
+			}
+
+			// For other index pages, parent is the index page of the grandparent folder
+			$grandparentDir = dirname($fileDir);
+			return $indexPageByPath[$grandparentDir] ?? 0;
+		}
+
+		// For regular pages, parent is the index page in the same folder
+		return $indexPageByPath[$fileDir] ?? 0;
+	}
+
+	/**
 	 * @throws MissingDependencyException
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 */
 	public function findAll(int $collectiveId, string $userId): array {
-		if ($this->allPageInfos === null || $this->collective->getId() !== $collectiveId) {
-			$folder = $this->getCollectiveFolder($collectiveId, $userId);
-			try {
-				$this->allPageInfos = $this->getPagesFromFolder($collectiveId, $folder, $userId, true, true);
-			} catch (FilesNotFoundException $e) {
-				throw new NotFoundException($e->getMessage(), 0, $e);
-			}
-		}
+		$folder = $this->getCollectiveFolder($collectiveId, $userId);
 
-		return $this->allPageInfos;
+		return $this->getPagesForCollectiveId($collectiveId, $folder, $userId);
 	}
 
 	/**
@@ -824,7 +944,7 @@ class PageService {
 					if ($targetNode instanceof File && NodeHelper::isPage($targetNode)) {
 						$sourcePageInfo = $this->getPageByFile($sourceNode);
 						$tags = $copyTags ? $sourcePageInfo->getTags() : '[]';
-						$this->updatePage($collectiveId, $targetNode->getId(), $userId, $sourcePageInfo->getEmoji(), $sourcePageInfo->isFullWidth(), $sourcePageInfo->getSlug(), $tags);
+						$this->updatePage($collectiveId, $targetNode->getId(), $userId, $sourcePageInfo->getEmoji(), $sourcePageInfo->isFullWidth(), null, $tags, $sourcePageInfo->getSlug());
 					}
 				} catch (FilesNotFoundException) {
 					// Ignore if target node doesn't exist
@@ -882,6 +1002,7 @@ class PageService {
 			return null;
 		}
 
+		$this->setFromCollectives(true);
 		try {
 			if ($copy) {
 				$newNode = $node->copy($newFolder->getPath() . '/' . $newFileName . $suffix);
@@ -892,6 +1013,8 @@ class PageService {
 			throw new NotFoundException($e->getMessage(), 0, $e);
 		} catch (FilesNotPermittedException $e) {
 			throw new NotPermittedException($e->getMessage(), 0, $e);
+		} finally {
+			$this->setFromCollectives(false);
 		}
 
 		if ($newNode instanceof Folder) {
@@ -930,9 +1053,8 @@ class PageService {
 		}
 
 		$newPageInfo = $this->getPageByFile($newFile);
-		$slug = $this->slugger->slug($title ?: $newPageInfo->getTitle())->toString();
 		try {
-			$this->updatePage($collectiveId, $newFile->getId(), $userId, $pageInfo->getEmoji(), $pageInfo->isFullWidth(), $slug, $pageInfo->getTags());
+			$this->updatePage($collectiveId, $newFile->getId(), $userId, $pageInfo->getEmoji(), $pageInfo->isFullWidth(), $title ?: $newPageInfo->getTitle(), $pageInfo->getTags());
 		} catch (InvalidPathException|FilesNotFoundException $e) {
 			throw new NotFoundException($e->getMessage(), 0, $e);
 		}
@@ -962,9 +1084,8 @@ class PageService {
 		}
 
 		$newPageInfo = $this->getPageByFile($newFile);
-		$slug = $this->slugger->slug($newPageInfo->getTitle())->toString();
 		try {
-			$this->updatePage($collectiveId, $newFile->getId(), $userId, null, null, $slug);
+			$this->updatePage($collectiveId, $newFile->getId(), $userId, null, null, $newPageInfo->getTitle());
 		} catch (InvalidPathException|FilesNotFoundException $e) {
 			throw new NotFoundException($e->getMessage(), 0, $e);
 		}
@@ -1010,9 +1131,8 @@ class PageService {
 		}
 
 		$newPageInfo = $this->getPageByFile($newFile);
-		$slug = $this->slugger->slug($newPageInfo->getTitle())->toString();
 		try {
-			$this->updatePage($newCollectiveId, $newFile->getId(), $userId, $pageInfo->getEmoji(), $pageInfo->isFullWidth(), $slug, '[]');
+			$this->updatePage($newCollectiveId, $newFile->getId(), $userId, $pageInfo->getEmoji(), $pageInfo->isFullWidth(), $newPageInfo->getTitle(), '[]');
 		} catch (InvalidPathException|FilesNotFoundException $e) {
 			throw new NotFoundException($e->getMessage(), 0, $e);
 		}
@@ -1043,9 +1163,8 @@ class PageService {
 		}
 
 		$newPageInfo = $this->getPageByFile($newFile);
-		$slug = $this->slugger->slug($newPageInfo->getTitle())->toString();
 		try {
-			$this->updatePage($newCollectiveId, $newFile->getId(), $userId, null, null, $slug, '[]');
+			$this->updatePage($newCollectiveId, $newFile->getId(), $userId, null, null, $newPageInfo->getTitle(), '[]');
 		} catch (InvalidPathException|FilesNotFoundException $e) {
 			throw new NotFoundException($e->getMessage(), 0, $e);
 		}
@@ -1207,6 +1326,7 @@ class PageService {
 		$pageInfo = $this->getPageByFile($file);
 		$parentId = $this->getParentPageId($file);
 
+		$this->setFromCollectives(true);
 		try {
 			if (NodeHelper::isIndexPage($file)) {
 				// Delete folder if it's an index page without subpages
@@ -1219,6 +1339,8 @@ class PageService {
 			throw new NotFoundException($e->getMessage(), 0, $e);
 		} catch (FilesNotPermittedException $e) {
 			throw new NotPermittedException($e->getMessage(), 0, $e);
+		} finally {
+			$this->setFromCollectives(false);
 		}
 
 		$this->initTrashBackend();

--- a/tests/Integration/features/mountpoint.feature
+++ b/tests/Integration/features/mountpoint.feature
@@ -98,3 +98,11 @@ Feature: mountpoint
 
   Scenario: Trash and delete collective and team
     Then user "jane" trashes and deletes collective "BehatMountPoint"
+
+  # fixme: cover scenarios - created file -> page created with collective id
+  #  deleted file -> page deleted
+  #  copied file to same collective -> collective id set, slug generated
+  #  copied file to another collective -> collecvive id set
+  #  moved file to another collective -> update collective id
+  #  moved file to another collective with renaming -> update collective id and slug
+  #  moved out of collective -> delete page

--- a/tests/Unit/Fs/NodeHelperTest.php
+++ b/tests/Unit/Fs/NodeHelperTest.php
@@ -233,4 +233,32 @@ class NodeHelperTest extends TestCase {
 		self::assertEquals(1, NodeHelper::folderHasSubPage($parentFolder, 'File2'));
 		self::assertEquals(2, NodeHelper::folderHasSubPage($folder, 'subfolder'));
 	}
+
+	public function extractCollectiveIdFromPathProvider(): \Generator {
+		yield 'normal collective page' => ['appdata_abc123/collectives/42/page.md', 42];
+		yield 'collective page in subfolder' => ['appdata_xyz/collectives/123/subfolder/page.md', 123];
+		yield 'collective index page' => ['appdata_test/collectives/1/Readme.md', 1];
+		yield 'trashed collective page' => ['appdata_abc123/collectives/trash/99/page.md', 99];
+		yield 'trashed page in subfolder' => ['appdata_xyz/collectives/trash/456/deleted.md', 456];
+		yield 'non-appdata files path' => ['files/user/docs/page.md', null];
+		yield 'non-appdata groupfolders path' => ['__groupfolders/1/page.md', null];
+		yield 'appdata but non-collectives files' => ['appdata_abc123/files/42/page.md', null];
+		yield 'appdata but non-collectives preview' => ['appdata_abc123/preview/42/page.md', null];
+		yield 'missing collective ID (trailing slash)' => ['appdata_abc123/collectives/', null];
+		yield 'missing collective ID (no trailing slash)' => ['appdata_abc123/collectives', null];
+		yield 'trash missing ID (trailing slash)' => ['appdata_abc123/collectives/trash/', null];
+		yield 'trash missing ID (no trailing slash)' => ['appdata_abc123/collectives/trash', null];
+		yield 'non-numeric collective ID (abc)' => ['appdata_abc123/collectives/abc/page.md', null];
+		yield 'non-numeric collective ID (12_34)' => ['appdata_abc123/collectives/12_34/page.md', null];
+		yield 'non-numeric trash ID' => ['appdata_abc123/collectives/trash/abc/page.md', null];
+		yield 'empty path' => ['', null];
+		yield 'appdata only without rest' => ['appdata_only', null];
+	}
+
+	/**
+	 * @dataProvider extractCollectiveIdFromPathProvider
+	 */
+	public function testExtractCollectiveIdFromPath(string $path, ?int $expected): void {
+		self::assertEquals($expected, NodeHelper::extractCollectiveIdFromPath($path));
+	}
 }

--- a/tests/Unit/Service/PageServiceTest.php
+++ b/tests/Unit/Service/PageServiceTest.php
@@ -13,6 +13,7 @@ use OC\App\AppManager;
 use OC\Files\Mount\MountPoint;
 use OCA\Circles\Model\Member;
 use OCA\Collectives\Db\Collective;
+use OCA\Collectives\Db\FileCacheMapper;
 use OCA\Collectives\Db\Page;
 use OCA\Collectives\Db\PageLinkMapper;
 use OCA\Collectives\Db\PageMapper;
@@ -56,6 +57,8 @@ class PageServiceTest extends TestCase {
 			->getMock();
 		$this->pageMapper->method('findByFileId')
 			->willReturn(null);
+
+		$fileCacheMapper = $this->createMock(FileCacheMapper::class);
 
 		$this->nodeHelper = $this->getMockBuilder(NodeHelper::class)
 			->disableOriginalConstructor()
@@ -103,6 +106,7 @@ class PageServiceTest extends TestCase {
 		$this->service = new PageService(
 			$appManager,
 			$this->pageMapper,
+			$fileCacheMapper,
 			$this->nodeHelper,
 			$this->collectiveService,
 			$userFolderHelper,


### PR DESCRIPTION
### 📝 Summary

This PR improves pages loading by introduction of the new column `collectives_pages.collective_id` and using pages table for loading almost without touching Filesystem api. No recursion anymore, just load all pages using single `WHERE IN` query :rocket: .

#### 🖼️ Screenshots

<img width="300" alt="image" src="https://github.com/user-attachments/assets/bfdd5077-9386-45dd-930c-97f59b2ceb1a" />

🏚️ Before | 🏡 After
---|---
<img width="200" alt="image" src="https://github.com/user-attachments/assets/394f8495-45f7-4b3b-9ce3-2a1bb47765ae" /> | <img width="200" alt="image" src="https://github.com/user-attachments/assets/71c8c538-8a5f-48ba-bae9-848ec47735ca" />



### 🚧 TODO
- Migration :heavy_check_mark: :question: 
  - Do we want create composite index `collective_id, trash_timestamp` instead of just `collective_id`  :question: 
  - Create new column :heavy_check_mark: 
  - Populate new column for already existent pages :heavy_check_mark: 
 - Operations via Collective :heavy_check_mark: 
   - Create new collective -> collectiveId set for root page :heavy_check_mark:
   - Create new page -> collectiveId set for created page :heavy_check_mark: 
   - Copy page to another collective -> new collectiveId set for copied page :heavy_check_mark: 
   - Move page to another collective -> new collectiveId set for moved page :heavy_check_mark: 
 - Operations via Files :construction: 
   - Create new file inside collective folder -> a new page with collectiveId is created :heavy_check_mark:
   - Copy file to another collective -> a new page with new collectiveId and slug is created :heavy_check_mark:
   - Copy file outside of collectives folder to a collective folder -> a new page with collectiveId is created :construction: :
   - Copy folder outside of collectives folder to a collective folder -> a new pages with collectiveId are recursively created :construction: 
   - Move file outside of collectives folder to a collective folder -> a new page with collectiveId is created :heavy_check_mark: 
   - Move folder outside of collectives folder to a collective folder -> a new pages with collectiveId are recursively created :construction: 
   - Move file to another collective -> collectiveId is updated :heavy_check_mark:
   - Move file to another collective with file renaming -> collectiveId and slug are updated :heavy_check_mark: 
   - Move file to non-collective directory -> page should be trashed :heavy_check_mark:
   - Delete file -> page should be trashed :heavy_check_mark: 
   - Restore file -> page should be restored :heavy_check_mark: 
   - Directory creation -> create a new page with Readme.md -> not needed :x: 
 - Collectives loading :construction: :question:
   - Load collective by shared link  `\OCA\Collectives\Controller\PublicPageController::index` :heavy_check_mark: 
   - Load collective by shared link filtered by page  `\OCA\Collectives\Controller\PublicPageController::index` :construction: 
   - Load collective `\OCA\Collectives\Controller\PageController::index` :heavy_check_mark: 
   - Other places :question: 


### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] :hourglass_flowing_sand: Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
