### PR TITLE
feat(settings): allow to set default_user_folder via admin settings

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -75,6 +75,9 @@ In your Nextcloud instance, simply navigate to **»Apps«**, find the
 		<command>OCA\Collectives\Command\PageTrashCleanup</command>
 		<command>OCA\Collectives\Command\PurgeObsoletePages</command>
 	</commands>
+	<settings>
+		<admin>OCA\Collectives\Settings\Admin</admin>
+	</settings>
 	<navigations>
 		<navigation>
 			<name>Collectives</name>

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Settings;
+
+use OCA\Collectives\AppInfo\Application;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IAppConfig;
+use OCP\Settings\ISettings;
+use OCP\Util;
+
+class Admin implements ISettings {
+	public function __construct(
+		private readonly IAppConfig $appConfig,
+		private readonly IInitialState $initialState,
+	) {
+	}
+
+	public function getForm(): TemplateResponse {
+		$parameters = [
+			'default_user_folder' => $this->appConfig->getValueString('collectives', 'default_user_folder', ''),
+		];
+		$this->initialState->provideInitialState('adminSettings', $parameters);
+
+		Util::addStyle(Application::APP_NAME, Application::APP_NAME . '-settings-admin');
+		Util::addScript(Application::APP_NAME, Application::APP_NAME . '-settings-admin');
+		return new TemplateResponse(Application::APP_NAME, 'settings-admin', renderAs: '');
+	}
+
+	public function getSection(): string {
+		return 'additional';
+	}
+
+	public function getPriority(): int {
+		return 90;
+	}
+}

--- a/playwright/e2e/admin-settings.spec.ts
+++ b/playwright/e2e/admin-settings.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { User } from '@nextcloud/e2e-test-server'
+import type { Locator } from '@playwright/test'
+
+import { login } from '@nextcloud/e2e-test-server/playwright'
+import { expect, test } from '@playwright/test'
+
+test.describe('Admin settings', () => {
+	let defaultUserFolderInput: Locator
+	let defaultUserFolderHelperText: Locator
+
+	test.beforeEach(async ({ page }) => {
+		const admin: User = {
+			userId: 'admin',
+			password: 'admin',
+			language: 'en-US',
+		}
+		await login(page.request, admin)
+		await page.goto('/index.php/settings/admin/additional')
+		defaultUserFolderInput = page.getByRole('textbox', { name: 'Default user folder' })
+		defaultUserFolderHelperText = page.locator('#defaultUserFolder-helper-text')
+		await expect(defaultUserFolderInput).toBeVisible()
+		await expect(defaultUserFolderHelperText).not.toBeVisible()
+	})
+
+	test('Default user folder warns about invalid values', async () => {
+		expect(await defaultUserFolderInput.inputValue()).toEqual('')
+		await defaultUserFolderInput.fill('invalid')
+		await expect(defaultUserFolderHelperText).toBeVisible()
+
+		await defaultUserFolderInput.fill('/')
+		await expect(defaultUserFolderHelperText).toBeVisible()
+
+		await defaultUserFolderInput.fill('/inv%alid')
+		await expect(defaultUserFolderHelperText).toBeVisible()
+	})
+
+	test('Default user folder allows valid path', async ({ page }) => {
+		await defaultUserFolderInput.fill('/abc')
+		await expect(defaultUserFolderHelperText).not.toBeVisible()
+		const requestPromise = page.waitForRequest(/default_user_folder/)
+		await defaultUserFolderInput.blur()
+		await requestPromise
+	})
+
+	test('Default user folder allows empty string', async ({ page }) => {
+		await defaultUserFolderInput.fill('')
+		await expect(defaultUserFolderHelperText).not.toBeVisible()
+		const requestPromise = page.waitForRequest(/default_user_folder/)
+		await defaultUserFolderInput.blur()
+		await requestPromise
+	})
+})

--- a/src/settings-admin.ts
+++ b/src/settings-admin.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createApp } from 'vue'
+import AdminSettings from './views/AdminSettings.vue'
+
+const app = createApp(AdminSettings)
+app.mount('#collectives-admin-settings')

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -1,0 +1,59 @@
+<!--
+  * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  * SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcSettingsSection
+		:name="t('collectives', 'Collectives default user folder')"
+		:description="t('collectives', 'The default path where collectives are mounted in user home directory')">
+		<NcTextField
+			id="defaultUserFolder"
+			v-model="defaultUserFolder"
+			name="defaultUserFolder"
+			:label="t('collectives', 'Default user folder')"
+			:error="defaultUserFolderError"
+			:helperText="defaultUserFolderHint"
+			@keydown.enter="saveDefaultUserFolder"
+			@blur="saveDefaultUserFolder" />
+	</NcSettingsSection>
+</template>
+
+<script setup lang="ts">
+import { showSuccess } from '@nextcloud/dialogs'
+import { loadState } from '@nextcloud/initial-state'
+import { t } from '@nextcloud/l10n'
+import { computed, ref } from 'vue'
+import NcSettingsSection from '@nextcloud/vue/components/NcSettingsSection'
+import NcTextField from '@nextcloud/vue/components/NcTextField'
+
+const adminSettings = loadState<{ default_user_folder: string }>('collectives', 'adminSettings')
+let originalDefaultUserFolder = adminSettings.default_user_folder
+const defaultUserFolder = ref(adminSettings.default_user_folder)
+
+const defaultUserFolderError = computed(() => {
+	return defaultUserFolder.value !== ''
+		&& !/^\/[a-zA-Z0-9-_/]+$/.test(defaultUserFolder.value)
+})
+
+const defaultUserFolderHint = computed(() => {
+	return defaultUserFolderError.value
+		? t('collectives', 'Empty string or path starting with "/" is expected')
+		: ''
+})
+
+/**
+ * Saves the default_user_folder setting to the server
+ */
+async function saveDefaultUserFolder() {
+	if (defaultUserFolderError.value || originalDefaultUserFolder === defaultUserFolder.value) {
+		return
+	}
+	globalThis.OCP.AppConfig.setValue('collectives', 'default_user_folder', defaultUserFolder.value, {
+		success() {
+			originalDefaultUserFolder = defaultUserFolder.value
+			showSuccess(t('collectives', 'Saved default user folder'))
+		},
+	})
+}
+</script>

--- a/src/vue.d.ts
+++ b/src/vue.d.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare module '*.vue' {
+	import Vue from 'vue'
+	export default Vue
+}

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+?>
+
+<div id="collectives-admin-settings"></div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
 
 {
 	"extends": "@vue/tsconfig",
-	"include": ["src/**.ts", "*.ts", "playwright/**/*.ts"],
+	"include": ["src/**.ts", "*.ts", "src/**.vue", "playwright/**/*.ts"],
 	"compilerOptions": {
 		"allowJs": true,
 		"target": "ESNext",

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,11 +4,12 @@
  */
 
 import { createAppConfig } from '@nextcloud/vite-config'
-import { VitePWA } from 'vite-plugin-pwa'
 import { join, resolve } from 'path'
+import { VitePWA } from 'vite-plugin-pwa'
 
 export default createAppConfig(
 	{
+		'settings-admin': resolve(join('src', 'settings-admin.ts')),
 		init: resolve(join('src', 'init.js')),
 		main: resolve(join('src', 'main.js')),
 		reference: resolve(join('src', 'reference.js')),
@@ -55,8 +56,8 @@ export default createAppConfig(
 							},
 						],
 						globPatterns: [
-							 "../css/*.css",
-							 "*.mjs",
+							'../css/*.css',
+							'*.mjs',
 						],
 						maximumFileSizeToCacheInBytes: 5242880,
 					},


### PR DESCRIPTION
Fixes: #2382

#### 🖼️ Screenshots

| 🏡 After |
|---|
| <img width="1443" height="294" alt="image" src="https://github.com/user-attachments/assets/0d6040cd-d47f-427c-88fb-59b67f0fd339" /> |

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
