### PR TITLE
fix(FileListInfo): strip attachments folder from collectives path

### DIFF
--- a/src/views/FileListInfo.vue
+++ b/src/views/FileListInfo.vue
@@ -59,9 +59,13 @@ export default {
 
 	computed: {
 		collectivesLink() {
-			const collectivesPath = this.internalPath.startsWith(collectivesFolder)
+			let collectivesPath = this.internalPath.startsWith(collectivesFolder)
 				? this.internalPath.slice(collectivesFolder.length)
 				: ''
+
+			// strip `/.attachments.<fileId>` suffix if present
+			collectivesPath = collectivesPath.replace(/\/\.attachments\.\d+$/, '')
+
 			return generateUrl('/apps/collectives' + collectivesPath)
 		},
 	},


### PR DESCRIPTION
When opening an attachment via "Show in Files" action, the Files app opens the `.attachments.<fileId>` folder. Until now, the "Open in Collectives" button then pointed to a broken Collectives link as `.attachments.<fileId>` became part of the Collectives link.

Fixes: #2371

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
