### PR TITLE
fix(psalm): implement getLastActivity() in CollectivePageTrashItem

### DIFF
--- a/lib/Trash/CollectivePageTrashItem.php
+++ b/lib/Trash/CollectivePageTrashItem.php
@@ -39,4 +39,8 @@ class CollectivePageTrashItem extends TrashItem {
 	public function getTitle(): string {
 		return $this->getCollectiveMountPoint() . '/' . $this->getOriginalLocation();
 	}
+
+	public function getLastActivity(): int {
+		return parent::getLastActivity();
+	}
 }

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -901,7 +901,6 @@ namespace OCA\Files_Trashbin\Trash {
 		public function getOriginalLocation(): string {}
 		public function getDeletedTime(): int {}
 		public function getTrashPath(): string {}
-		public function getTrashPath(): string {}
 		public function getUser(): IUser {}
 		public function getEtag() {}
 		public function getSize($includeMounts = true) {}


### PR DESCRIPTION
Psalm cannot reliably infer the method through stub-based inheritance when the real `OCP\Files\FileInfo` interface declares it. Explicit override satisfies the `UnimplementedInterfaceMethod` check.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
