### PR TITLE
fix: validate template access when create public page

### DIFF
--- a/lib/Controller/PublicPageController.php
+++ b/lib/Controller/PublicPageController.php
@@ -233,6 +233,9 @@ class PublicPageController extends CollectivesPublicOCSController {
 			$collectiveId = $this->getCollectiveShare()->getCollectiveId();
 			if (0 !== $sharePageId = $this->getCollectiveShare()->getPageId()) {
 				$this->checkPageShareAccess($collectiveId, $sharePageId, $parentId, $owner);
+				if ($templateId) {
+					$this->checkPageShareAccess($collectiveId, $sharePageId, $templateId, $owner);
+				}
 			}
 			$pageInfo = $this->service->create($collectiveId, $parentId, $title, $templateId, $owner);
 			$this->decoratePageInfo($collectiveId, $sharePageId, $owner, $pageInfo);

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -153,6 +153,23 @@ class PageService {
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 */
+	private function isInTemplateFolder(int $collectiveId, int $pageId, string $userId): bool {
+		$collectiveFolder = $this->getCollectiveFolder($collectiveId, $userId);
+		try {
+			$templateFolder = $collectiveFolder->get(TemplateService::TEMPLATE_FOLDER);
+		} catch (FilesNotFoundException) {
+			return false;
+		}
+
+		return ($templateFolder instanceof Folder)
+			&& $templateFolder->getFirstNodeById($pageId) !== null;
+	}
+
+	/**
+	 * @throws MissingDependencyException
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 */
 	private function getChildPageIds(int $collectiveId, File $file, string $userId): array {
 		if (!NodeHelper::isIndexPage($file)) {
 			return [];
@@ -706,9 +723,14 @@ class PageService {
 		$safeTitle = $this->nodeHelper->sanitiseFilename($title, $defaultTitle ?: self::DEFAULT_PAGE_TITLE);
 		$filename = NodeHelper::generateFilename($folder, $safeTitle, PageInfo::SUFFIX);
 
-		return $templateId
-			? $this->copy($collectiveId, $templateId, $parentId, $safeTitle, 0, $userId)
-			: $this->newPage($collectiveId, $folder, $filename, $userId, $title, $content);
+		if ($templateId) {
+			if (!$this->isInTemplateFolder($collectiveId, $templateId, $userId)) {
+				throw new NotFoundException('Template ' . $templateId . ' not found in collective ' . $collectiveId);
+			}
+			return $this->copy($collectiveId, $templateId, $parentId, $safeTitle, 0, $userId);
+		}
+
+		return $this->newPage($collectiveId, $folder, $filename, $userId, $title, $content);
 	}
 
 	/**

--- a/lib/Service/TemplateService.php
+++ b/lib/Service/TemplateService.php
@@ -16,7 +16,7 @@ use OCP\Files\NotFoundException as FilesNotFoundException;
 use OCP\Files\NotPermittedException as FilesNotPermittedException;
 
 class TemplateService {
-	private const TEMPLATE_FOLDER = '.templates';
+	public const TEMPLATE_FOLDER = '.templates';
 	private const TEMPLATE_INDEX_CONTENT = '## This folder contains template files for the collective';
 	private const DEFAULT_TEMPLATE_TITLE = 'New Template';
 

--- a/tests/Integration/features/bootstrap/FeatureContext.php
+++ b/tests/Integration/features/bootstrap/FeatureContext.php
@@ -172,6 +172,22 @@ class FeatureContext implements Context {
 	}
 
 	/**
+	 * @When user :user fails to create page :page with parentPath :parentPath using page :sourcePage as template in :collective
+	 *
+	 * @throws GuzzleException
+	 */
+	public function userFailsToCreateFromNonTemplate(string $user, string $page, string $parentPath, string $sourcePage, string $collective): void {
+		$this->setCurrentUser($user);
+		$collectiveId = $this->collectiveIdByName($collective);
+		$parentId = $this->getParentId($collectiveId, $parentPath);
+		$sourcePageId = $this->pageIdByName($collectiveId, $sourcePage);
+
+		$formData = new TableNode([['title', $page], ['templateId', $sourcePageId]]);
+		$this->sendOcsCollectivesRequest('POST', 'collectives/' . $collectiveId . '/pages/' . $parentId, $formData);
+		$this->assertStatusCode(404);
+	}
+
+	/**
 	 * @When user :user creates template :template in :collective
 	 * @When user :user :fails to create template :template in :collective
 	 *

--- a/tests/Integration/features/bootstrap/FeatureContext.php
+++ b/tests/Integration/features/bootstrap/FeatureContext.php
@@ -1443,6 +1443,24 @@ class FeatureContext implements Context {
 	}
 
 	/**
+	 * @When anonymous fails to create page :page with parentPath :parentPath from template :template in public page share :pageShare in collective :collective with owner :owner
+	 *
+	 * @throws GuzzleException
+	 */
+	public function anonymousFailsToCreatePublicPagePageFromTemplate(string $page, string $parentPath, string $template, string $pageShare, string $collective, string $owner): void {
+		$this->setCurrentUser($owner);
+		$collectiveId = $this->collectiveIdByName($collective);
+		$pageShareId = $this->pageIdByName($collectiveId, $pageShare);
+		$token = $this->getShareToken($collectiveId, $pageShareId);
+		$parentId = $this->getParentId($collectiveId, $parentPath);
+		$templateId = $this->templateIdByName($collectiveId, $template);
+
+		$formData = new TableNode([['title', $page], ['templateId', $templateId]]);
+		$this->sendOcsCollectivesRequest('POST', 'p/collectives/' . $token . '/pages/' . $parentId, $formData, null, [], false);
+		$this->assertStatusCode(403);
+	}
+
+	/**
 	 * @When anonymous moves page :page to :newtitle with parentPath :parentPath in public collective :collective with owner :owner
 	 * @When anonymous :fails to move page :page to :newtitle with parentPath :parentPath in public collective :collective with owner :owner
 	 *

--- a/tests/Integration/features/publicPageShare.feature
+++ b/tests/Integration/features/publicPageShare.feature
@@ -51,6 +51,11 @@ Feature: publicPageShare
   Scenario: Fail to trash page in editable shared page
     Then anonymous fails to trash page "subpage" in public page share "sharefolderpage" in collective "BehatPublicPageCollective" with owner "jane"
 
+  Scenario: Fail to create page from template in editable shared page
+    When user "jane" creates template "newtemplate" in "BehatPublicPageCollective"
+    Then anonymous fails to create page "anotherpage" with parentPath "sharefolderpage/Readme.md" from template "newtemplate" in public page share "sharefolderpage" in collective "BehatPublicPageCollective" with owner "jane"
+
+
   Scenario: Fail to create page in editable shared page if share owner misses editing permissions
     When user "jane" sets "share" level in collective "BehatPublicPageCollective" to "Member"
     And user "john" creates public page share for page "sharefolderpage" in "BehatPublicPageCollective"

--- a/tests/Integration/features/templates.feature
+++ b/tests/Integration/features/templates.feature
@@ -25,5 +25,8 @@ Feature: templates
     When user "jane" deletes template "newtemplate2" from "BehatTemplatesCollective"
     Then user "jane" fails to see templateName "newtemplate2" in "BehatTemplatesCollective"
 
+  Scenario: Creating page from non-template fails
+    Then user "jane" fails to create page "anotherpage2" with parentPath "Readme.md" using page "anotherpage" as template in "BehatTemplatesCollective"
+
   Scenario: Trash and delete collective and team
     Then user "jane" trashes and deletes collective "BehatTemplatesCollective"


### PR DESCRIPTION
### 📝 Summary

* Resolves: # <!-- related github issue -->

Add access check for the `templateId` parameter in the `create` method of `PublicPageController` to ensure proper access rights when creating a page from a template.


### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
