### PR TITLE
fix: Repair command to copy encryption keys to new path

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -74,6 +74,7 @@ In your Nextcloud instance, simply navigate to **»Apps«**, find the
 		<command>OCA\Collectives\Command\IndexCollectives</command>
 		<command>OCA\Collectives\Command\PageTrashCleanup</command>
 		<command>OCA\Collectives\Command\PurgeObsoletePages</command>
+		<command>OCA\Collectives\Command\RepairUserFolderEncryptionKeys</command>
 	</commands>
 	<settings>
 		<admin>OCA\Collectives\Settings\Admin</admin>

--- a/lib/Command/RepairUserFolderEncryptionKeys.php
+++ b/lib/Command/RepairUserFolderEncryptionKeys.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Command;
+
+use OCA\Collectives\Service\UserFolderEncryptionKeyRepairResult;
+use OCA\Collectives\Service\UserFolderEncryptionKeyRepairService;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RepairUserFolderEncryptionKeys extends Command {
+	public function __construct(
+		private readonly UserFolderEncryptionKeyRepairService $repairService,
+		private readonly IUserManager $userManager,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('collectives:repair:user-folder-encryption-keys')
+			->setDescription('Repair collectives encryption key paths for changed or mismatched collectives user folders')
+			->addOption('dry-run', null, InputOption::VALUE_NONE, 'Only report what would be changed')
+			->addOption('user-id', 'u', InputOption::VALUE_REQUIRED, 'Only repair paths related to the collectives folder used by a specific user');
+		parent::configure();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$dryRun = (bool)$input->getOption('dry-run');
+		$userId = $input->getOption('user-id');
+
+		if (!is_string($userId) && $userId !== null) {
+			$output->writeln('<error>Invalid --user-id value</error>');
+			return self::FAILURE;
+		}
+
+		if ($userId !== null && $this->userManager->get($userId) === null) {
+			$output->writeln('<error>User not found: ' . $userId . '</error>');
+			return self::FAILURE;
+		}
+
+		$output->writeln('<info>Scanning collectives encryption key paths …</info>');
+
+		$result = $this->repairService->repair(
+			$dryRun,
+			$userId,
+			function (string $level, string $message) use ($output): void {
+				if ($level === 'warning') {
+					$output->writeln('<comment>' . $message . '</comment>');
+					return;
+				}
+
+				if ($output->isVerbose()) {
+					$output->writeln($message);
+				}
+			},
+		);
+
+		$output->writeln($this->formatSummary($result));
+
+		return $result->hasWarnings() ? self::FAILURE : self::SUCCESS;
+	}
+
+	private function formatSummary(UserFolderEncryptionKeyRepairResult $result): string {
+		if ($result->getTargetPaths() === 0) {
+			return '<info>No collectives user folder paths found for the selected users.</info>';
+		}
+
+		$verb = $result->isDryRun() ? 'would create' : 'created';
+		$fileVerb = $result->isDryRun() ? 'would copy' : 'copied';
+
+		return sprintf(
+			'<info>Processed %d target path(s), found %d source key tree(s), %s %d director%s, %s %d missing key file(s), skipped %d existing file(s).</info>',
+			$result->getTargetPaths(),
+			$result->getSourceTreesFound(),
+			$verb,
+			$result->getCreatedDirectories(),
+			$result->getCreatedDirectories() === 1 ? 'y' : 'ies',
+			$fileVerb,
+			$result->getCopiedFiles(),
+			$result->getExistingFilesSkipped(),
+		);
+	}
+}

--- a/lib/Service/UserFolderEncryptionKeyRepairResult.php
+++ b/lib/Service/UserFolderEncryptionKeyRepairResult.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Service;
+
+class UserFolderEncryptionKeyRepairResult {
+	private int $targetPaths = 0;
+	private int $sourceTreesFound = 0;
+	private int $createdDirectories = 0;
+	private int $copiedFiles = 0;
+	private int $existingFilesSkipped = 0;
+
+	/**
+	 * @var list<string>
+	 */
+	private array $warnings = [];
+
+	public function __construct(
+		private readonly bool $dryRun,
+	) {
+	}
+
+	public function isDryRun(): bool {
+		return $this->dryRun;
+	}
+
+	public function addTargetPath(): void {
+		$this->targetPaths++;
+	}
+
+	public function getTargetPaths(): int {
+		return $this->targetPaths;
+	}
+
+	public function addSourceTree(): void {
+		$this->sourceTreesFound++;
+	}
+
+	public function getSourceTreesFound(): int {
+		return $this->sourceTreesFound;
+	}
+
+	public function addCreatedDirectory(): void {
+		$this->createdDirectories++;
+	}
+
+	public function getCreatedDirectories(): int {
+		return $this->createdDirectories;
+	}
+
+	public function addCopiedFile(): void {
+		$this->copiedFiles++;
+	}
+
+	public function getCopiedFiles(): int {
+		return $this->copiedFiles;
+	}
+
+	public function addExistingFileSkipped(): void {
+		$this->existingFilesSkipped++;
+	}
+
+	public function getExistingFilesSkipped(): int {
+		return $this->existingFilesSkipped;
+	}
+
+	public function addWarning(string $warning): void {
+		$this->warnings[] = $warning;
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	public function getWarnings(): array {
+		return $this->warnings;
+	}
+
+	public function hasWarnings(): bool {
+		return $this->warnings !== [];
+	}
+}

--- a/lib/Service/UserFolderEncryptionKeyRepairService.php
+++ b/lib/Service/UserFolderEncryptionKeyRepairService.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Service;
+
+use OC\Files\Filesystem;
+use OC\Files\View;
+use OCP\IAppConfig;
+use OCP\Files\FileInfo;
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+
+class UserFolderEncryptionKeyRepairService {
+	public function __construct(
+		private readonly IAppConfig $appConfig,
+		private readonly IConfig $config,
+		private readonly IUserManager $userManager,
+		private readonly IFactory $l10nFactory,
+		private readonly View $rootView,
+	) {
+	}
+
+	public function repair(bool $dryRun = false, ?string $userId = null, ?callable $report = null): UserFolderEncryptionKeyRepairResult {
+		$result = new UserFolderEncryptionKeyRepairResult($dryRun);
+		$targetUserFolderPaths = $this->getTargetUserFolderPaths($userId);
+		$sourceUserFolderPaths = $this->getSourceUserFolderPaths($targetUserFolderPaths);
+		$availableSourcePaths = [];
+
+		foreach ($sourceUserFolderPaths as $sourceUserFolderPath) {
+			$sourcePath = $this->getKeyTreePath($sourceUserFolderPath);
+			if (!$this->rootView->file_exists($sourcePath) || !$this->rootView->is_dir($sourcePath)) {
+				continue;
+			}
+
+			$availableSourcePaths[$sourceUserFolderPath] = $sourcePath;
+			$result->addSourceTree();
+		}
+
+		foreach ($targetUserFolderPaths as $targetUserFolderPath) {
+			$result->addTargetPath();
+			$targetPath = $this->getKeyTreePath($targetUserFolderPath);
+
+			foreach ($availableSourcePaths as $sourceUserFolderPath => $sourcePath) {
+				if ($sourceUserFolderPath === $targetUserFolderPath) {
+					continue;
+				}
+
+				$this->mergeMissingTree(
+					$sourcePath,
+					$targetPath,
+					$result,
+					$report,
+				);
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	private function getTargetUserFolderPaths(?string $userId): array {
+		$userFolderPaths = [];
+		$defaultUserFolderPath = $this->appConfig->getValueString('collectives', 'default_user_folder', '');
+
+		$addPath = function (IUser $user) use (&$userFolderPaths, $defaultUserFolderPath): void {
+			$userFolderPath = $this->getEffectiveUserFolderPath($user, $defaultUserFolderPath);
+			if ($userFolderPath === null) {
+				return;
+			}
+
+			$userFolderPaths[$userFolderPath] = $userFolderPath;
+		};
+
+		if ($userId !== null) {
+			$user = $this->userManager->get($userId);
+			if ($user !== null) {
+				$addPath($user);
+			}
+			return array_values($userFolderPaths);
+		}
+
+		$this->userManager->callForSeenUsers($addPath);
+		return array_values($userFolderPaths);
+	}
+
+	/**
+	 * @param list<string> $targetUserFolderPaths
+	 * @return list<string>
+	 */
+	private function getSourceUserFolderPaths(array $targetUserFolderPaths): array {
+		$sourceUserFolderPaths = [];
+
+		foreach ($targetUserFolderPaths as $userFolderPath) {
+			$sourceUserFolderPaths[$userFolderPath] = $userFolderPath;
+			$aliasedPath = $this->toggleHiddenMountSegment($userFolderPath);
+			if ($aliasedPath !== null) {
+				$sourceUserFolderPaths[$aliasedPath] = $aliasedPath;
+			}
+		}
+
+		return array_values($sourceUserFolderPaths);
+	}
+
+	private function getKeyTreePath(string $userFolderPath): string {
+		$keyStorageRoot = $this->config->getAppValue('core', 'encryption_key_storage_root', '');
+		return Filesystem::normalizePath($keyStorageRoot . '/files_encryption/keys/files' . $userFolderPath);
+	}
+
+	private function getEffectiveUserFolderPath(IUser $user, string $defaultUserFolderPath): ?string {
+		$userFolderPath = $this->config->getUserValue($user->getUID(), 'collectives', 'user_folder', $defaultUserFolderPath);
+		if ($userFolderPath !== '') {
+			return $userFolderPath;
+		}
+
+		$userLang = $this->l10nFactory->getUserLanguage($user);
+		$l10n = $this->l10nFactory->get('collectives', $userLang);
+		$translatedFolderName = $l10n->t('Collectives');
+		if ($translatedFolderName === '') {
+			return null;
+		}
+
+		return DIRECTORY_SEPARATOR . '.' . $translatedFolderName;
+	}
+
+	private function toggleHiddenMountSegment(string $userFolderPath): ?string {
+		if (!str_starts_with($userFolderPath, DIRECTORY_SEPARATOR)) {
+			return null;
+		}
+
+		$trimmedPath = trim($userFolderPath, DIRECTORY_SEPARATOR);
+		if ($trimmedPath === '') {
+			return null;
+		}
+
+		$segments = explode(DIRECTORY_SEPARATOR, $trimmedPath);
+		$mountSegmentIndex = count($segments) - 1;
+		$mountSegment = $segments[$mountSegmentIndex];
+		if ($mountSegment === '' || $mountSegment === '.') {
+			return null;
+		}
+
+		if (str_starts_with($mountSegment, '.')) {
+			$mountSegment = substr($mountSegment, 1);
+		} else {
+			$mountSegment = '.' . $mountSegment;
+		}
+
+		if ($mountSegment === '') {
+			return null;
+		}
+
+		$segments[$mountSegmentIndex] = $mountSegment;
+		return DIRECTORY_SEPARATOR . implode(DIRECTORY_SEPARATOR, $segments);
+	}
+
+	private function mergeMissingTree(
+		string $sourcePath,
+		string $targetPath,
+		UserFolderEncryptionKeyRepairResult $result,
+		?callable $report,
+	): void {
+		if ($this->rootView->file_exists($targetPath) && !$this->rootView->is_dir($targetPath)) {
+			$this->warning(
+				'Skipping collectives encryption key repair because target is not a directory: ' . $targetPath,
+				$result,
+				$report,
+			);
+			return;
+		}
+
+		if (!$this->rootView->file_exists($targetPath)) {
+			if ($result->isDryRun()) {
+				$result->addCreatedDirectory();
+				$this->report($report, 'info', 'Would create ' . $targetPath);
+			} elseif ($this->rootView->mkdir($targetPath)) {
+				$result->addCreatedDirectory();
+				$this->report($report, 'info', 'Creating ' . $targetPath);
+			} else {
+				$this->warning(
+					'Failed to create collectives encryption key directory: ' . $targetPath,
+					$result,
+					$report,
+				);
+				return;
+			}
+		}
+
+		foreach ($this->rootView->getDirectoryContent($sourcePath) as $node) {
+			$targetChildPath = Filesystem::normalizePath($targetPath . '/' . $node->getName());
+			if ($node->getType() === FileInfo::TYPE_FOLDER) {
+				$this->mergeMissingTree($node->getPath(), $targetChildPath, $result, $report);
+				continue;
+			}
+
+			if ($this->rootView->file_exists($targetChildPath)) {
+				$result->addExistingFileSkipped();
+				continue;
+			}
+
+			if ($result->isDryRun()) {
+				$result->addCopiedFile();
+				$this->report($report, 'info', 'Would copy ' . $node->getPath() . ' -> ' . $targetChildPath);
+				continue;
+			}
+
+			if ($this->rootView->copy($node->getPath(), $targetChildPath)) {
+				$result->addCopiedFile();
+				$this->report($report, 'info', 'Copying ' . $node->getPath() . ' -> ' . $targetChildPath);
+			} else {
+				$this->warning(
+					'Failed to copy collectives encryption key file from ' . $node->getPath() . ' to ' . $targetChildPath,
+					$result,
+					$report,
+				);
+			}
+		}
+	}
+
+	private function warning(string $message, UserFolderEncryptionKeyRepairResult $result, ?callable $report): void {
+		$result->addWarning($message);
+		$this->report($report, 'warning', $message);
+	}
+
+	private function report(?callable $report, string $level, string $message): void {
+		if ($report !== null) {
+			$report($level, $message);
+		}
+	}
+}


### PR DESCRIPTION
workaround for https://github.com/nextcloud/collectives/issues/2326

 It has a repair command for the hidden/non-hidden Collectives mount regression when server-side encryption is enabled. It scans the effective Collectives user folder, checks the corresponding alias path, and copies only missing encryption keys into the currently used path