### PR TITLE
fix(session): don't log an error when refreshing an outdated session

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
 	// dot (so we have a quick overview in the logs while the tests are running)
 	// github (to have annotations in the PR)
 	// locally we just want the html report with the traces
-	reporter: process.env.CI ? [['blob'], ['dot'], ['github']] : 'html',
+	reporter: process.env.CI ? [['blob'], ['line'], ['github']] : 'html',
 	use: {
 		// Base URL to use in actions like `await page.goto('./')`.
 		baseURL: process.env.baseURL ?? 'http://localhost:8089/index.php/',

--- a/src/stores/sessions.js
+++ b/src/stores/sessions.js
@@ -26,8 +26,8 @@ export const useSessionsStore = defineStore('sessions', {
 		async updateSession() {
 			try {
 				await api.updateSession(this.session.collectiveId, this.session.token)
-			} catch (e) {
-				console.error('Session update failed, creating a new one', e)
+			} catch {
+				console.warn('Session update failed, creating a new one')
 				this.createSession()
 			}
 		},


### PR DESCRIPTION
This is expected behaviour, e.g. when the tab was in background for longer.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
