### PR TITLE
docs: update link to Transifex project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Documentation for developers can be found at [DEVELOPING.md](DEVELOPING.md).
 
 ## Translations
 
-Collectives translations are managed as part of the [Nextcloud project on Transifex](https://www.transifex.com/nextcloud/nextcloud/).
+Collectives translations are managed as part of the [Nextcloud project on Transifex](https://explore.transifex.com/nextcloud/nextcloud/).
 
 ## Licence
 


### PR DESCRIPTION
### 📝 Summary

I tried to click the link in the README but the project wasn't found, so I searched for the project on my own and replaced it with what I found, as you can see it's a subtle change.

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
