### PR TITLE
enh: improve full text search

### DIFF
--- a/lib/BackgroundJob/IndexCollectives.php
+++ b/lib/BackgroundJob/IndexCollectives.php
@@ -58,7 +58,7 @@ class IndexCollectives extends TimedJob {
 		try {
 			$folder = $this->collectiveFolderManager->getRootFolder()->get((string)$collective->getId());
 			$folderMtime = $folder->getMTime();
-			$maxIndexedMtime = $this->fileMapper->getMaxMtimeByCircle($collective->getCircleId());
+			$maxIndexedMtime = $this->fileMapper->getMaxMtimeByCollective($collective->getId());
 
 			return $maxIndexedMtime === null || $folderMtime > $maxIndexedMtime;
 		} catch (NotFoundException|InvalidPathException) {

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -448,7 +448,7 @@ class PageController extends OCSController {
 		$pageInfos = $this->handleErrorResponse(function () use ($collectiveId, $searchString): array {
 			$uid = $this->getUid();
 			$collective = $this->collectiveService->getCollective($collectiveId, $uid);
-			$results = $this->indexedSearchService->searchCollective($collective, $searchString, 100);
+			$results = $this->indexedSearchService->searchCollective($collective, $searchString);
 			$pages = [];
 			foreach ($results as $value) {
 				$pages[] = $this->service->find($collectiveId, $value['file_id'], $uid);

--- a/lib/Controller/PublicPageController.php
+++ b/lib/Controller/PublicPageController.php
@@ -653,7 +653,7 @@ class PublicPageController extends CollectivesPublicOCSController {
 			$owner = $this->getCollectiveShare()->getOwner();
 			$collectiveId = $this->getCollectiveShare()->getCollectiveId();
 			$collective = $this->collectiveService->getCollective($collectiveId, $owner);
-			$results = $this->indexedSearchService->searchCollective($collective, $searchString, 100);
+			$results = $this->indexedSearchService->searchCollective($collective, $searchString);
 			$pages = [];
 			foreach ($results as $value) {
 				if (0 !== $sharePageId = $this->getCollectiveShare()->getPageId()) {

--- a/lib/Migration/Version040301Date20260427000000.php
+++ b/lib/Migration/Version040301Date20260427000000.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version040301Date20260427000000 extends SimpleMigrationStep {
+
+	public function __construct(
+		private readonly IDBConnection $connection,
+	) {
+	}
+
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('collectives_s_docs')) {
+			$this->connection->truncateTable('collectives_s_docs', false);
+		}
+		if ($schema->hasTable('collectives_s_words')) {
+			$this->connection->truncateTable('collectives_s_words', false);
+		}
+		if ($schema->hasTable('collectives_s_files')) {
+			$this->connection->truncateTable('collectives_s_files', false);
+		}
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$this->migrateWordsTable($schema);
+		$this->migrateDocsTable($schema);
+		$this->migrateFilesTable($schema);
+
+		return $schema;
+	}
+
+	private function migrateWordsTable(ISchemaWrapper $schema): void {
+		if (!$schema->hasTable('collectives_s_words')) {
+			return;
+		}
+
+		$table = $schema->getTable('collectives_s_words');
+
+		if (!$table->hasColumn('collective_id')) {
+			$table->addColumn('collective_id', Types::BIGINT, ['notnull' => true, 'default' => 0]);
+		}
+
+		if ($table->hasColumn('circle_unique_id')) {
+			$table->dropColumn('circle_unique_id');
+		}
+
+		if ($table->hasIndex('s_words_circle_term')) {
+			$table->dropIndex('s_words_circle_term');
+			$table->addUniqueIndex(['collective_id', 'term'], 's_words_collective_term');
+		}
+
+		if ($table->hasIndex('s_words_circle')) {
+			$table->dropIndex('s_words_circle');
+			$table->addIndex(['collective_id'], 's_words_collective');
+		}
+
+		if (!$table->hasColumn('stem')) {
+			$table->addColumn('stem', Types::STRING, [
+				'notnull' => false,
+				'length' => 50,
+				'default' => null,
+			]);
+			$table->addIndex(['collective_id', 'stem'], 's_words_collective_stem');
+		}
+	}
+
+	private function migrateDocsTable(ISchemaWrapper $schema): void {
+		if (!$schema->hasTable('collectives_s_docs')) {
+			return;
+		}
+
+		$table = $schema->getTable('collectives_s_docs');
+
+		if (!$table->hasColumn('collective_id')) {
+			$table->addColumn('collective_id', Types::BIGINT, ['notnull' => true, 'default' => 0]);
+		}
+
+		if ($table->hasColumn('circle_unique_id')) {
+			$table->dropColumn('circle_unique_id');
+		}
+
+		if ($table->hasIndex('s_uniq_docs')) {
+			$table->dropIndex('s_uniq_docs');
+			$table->addUniqueIndex(['collective_id', 'word_id', 'file_id'], 's_uniq_docs');
+		}
+
+		if ($table->hasIndex('s_docs_circle_word')) {
+			$table->dropIndex('s_docs_circle_word');
+			$table->addIndex(['collective_id', 'word_id'], 's_docs_collective_word');
+		}
+
+		if ($table->hasIndex('s_docs_circle_file')) {
+			$table->dropIndex('s_docs_circle_file');
+			$table->addIndex(['collective_id', 'file_id'], 's_docs_collective_file');
+		}
+	}
+
+	private function migrateFilesTable(ISchemaWrapper $schema): void {
+		if (!$schema->hasTable('collectives_s_files')) {
+			return;
+		}
+
+		$table = $schema->getTable('collectives_s_files');
+
+		if (!$table->hasColumn('collective_id')) {
+			$table->addColumn('collective_id', Types::BIGINT, ['notnull' => true, 'default' => 0]);
+		}
+
+		if ($table->hasColumn('circle_unique_id')) {
+			$table->dropColumn('circle_unique_id');
+		}
+	}
+}

--- a/lib/Search/FileSearch/Db/SearchDoc.php
+++ b/lib/Search/FileSearch/Db/SearchDoc.php
@@ -14,8 +14,8 @@ use OCP\AppFramework\Db\Entity;
 /**
  * @method int getId()
  * @method void setId(int $value)
- * @method string getCircleUniqueId()
- * @method void setCircleUniqueId(string $value)
+ * @method int getCollectiveId()
+ * @method void setCollectiveId(int $value)
  * @method int getWordId()
  * @method void setWordId(int $value)
  * @method int getFileId()
@@ -24,7 +24,7 @@ use OCP\AppFramework\Db\Entity;
  * @method void setHitCount(int $value)
  */
 class SearchDoc extends Entity {
-	protected ?string $circleUniqueId = null;
+	protected ?int $collectiveId = null;
 	protected ?string $wordId = null;
 	protected ?int $fileId = null;
 	protected ?int $hitCount = null;

--- a/lib/Search/FileSearch/Db/SearchDocMapper.php
+++ b/lib/Search/FileSearch/Db/SearchDocMapper.php
@@ -25,30 +25,32 @@ class SearchDocMapper extends QBMapper {
 		parent::__construct($db, 'collectives_s_docs', SearchDoc::class);
 	}
 
-	public function insertDoc(string $circleUniqueId, int $wordId, int $fileId, int $hitCount): SearchDoc {
+	public function insertDoc(int $collectiveId, int $wordId, int $fileId, int $hitCount): SearchDoc {
 		$doc = new SearchDoc();
-		$doc->setCircleUniqueId($circleUniqueId);
+		$doc->setCollectiveId($collectiveId);
 		$doc->setWordId($wordId);
 		$doc->setFileId($fileId);
 		$doc->setHitCount($hitCount);
 		return $this->insert($doc);
 	}
 
-	public function deleteByCircle(string $circleUniqueId): void {
+	public function deleteByCollective(int $collectiveId): void {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->tableName)
-			->where($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleUniqueId)));
+			->where($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId)));
 		$qb->executeStatement();
 	}
 
-	public function findDocumentsByWords(string $circleUniqueId, array $wordIds, int $limit): array {
+	public function findDocumentsByWords(int $collectiveId, array $wordIds, int $limit): array {
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('file_id')
-			->selectAlias($qb->func()->sum('hit_count'), 'total_hits')
-			->from($this->tableName)
-			->where($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleUniqueId)))
-			->andWhere($qb->expr()->in('word_id', $qb->createNamedParameter($wordIds, IQueryBuilder::PARAM_INT_ARRAY)))
-			->groupBy('file_id')
+		$qb->select('d.file_id')
+			->selectAlias($qb->func()->sum('d.hit_count'), 'total_hits')
+			->selectAlias($qb->createFunction('MIN(w.term)'), 'matched_term')
+			->from($this->tableName, 'd')
+			->innerJoin('d', 'collectives_s_words', 'w', $qb->expr()->eq('d.word_id', 'w.id'))
+			->where($qb->expr()->eq('d.collective_id', $qb->createNamedParameter($collectiveId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->in('d.word_id', $qb->createNamedParameter($wordIds, IQueryBuilder::PARAM_INT_ARRAY)))
+			->groupBy('d.file_id')
 			->orderBy('total_hits', 'DESC')
 			->setMaxResults($limit);
 
@@ -56,11 +58,11 @@ class SearchDocMapper extends QBMapper {
 		return $result->fetchAll();
 	}
 
-	public function findByCircleAndFileId(string $circleUniqueId, int $fileId): array {
+	public function findByCollectiveAndFileId(int $collectiveId, int $fileId): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from($this->tableName)
-			->where($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleUniqueId)))
+			->where($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId)))
 			->andWhere($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId)));
 
 		return $this->findEntities($qb);

--- a/lib/Search/FileSearch/Db/SearchFile.php
+++ b/lib/Search/FileSearch/Db/SearchFile.php
@@ -14,8 +14,8 @@ use OCP\AppFramework\Db\Entity;
 /**
  * @method int getId()
  * @method void setId(int $value)
- * @method string getCircleUniqueId()
- * @method void setCircleUniqueId(string $value)
+ * @method int getCollectiveId()
+ * @method void setCollectiveId(int $value)
  * @method int getFileId()
  * @method void setFileId(int $value)
  * @method string getPath()
@@ -26,7 +26,7 @@ use OCP\AppFramework\Db\Entity;
  * @method void setLanguage(string $value)
  */
 class SearchFile extends Entity {
-	protected ?string $circleUniqueId = null;
+	protected ?int $collectiveId = null;
 	protected ?int $fileId = null;
 	protected ?string $path = null;
 	protected ?int $mtime = null;

--- a/lib/Search/FileSearch/Db/SearchFileMapper.php
+++ b/lib/Search/FileSearch/Db/SearchFileMapper.php
@@ -25,9 +25,9 @@ class SearchFileMapper extends QBMapper {
 		parent::__construct($db, 'collectives_s_files', SearchFile::class);
 	}
 
-	public function insertFile(string $circleUniqueId, int $fileId, string $path, int $mtime, ?string $language = null): SearchFile {
+	public function insertFile(int $collectiveId, int $fileId, string $path, int $mtime, ?string $language = null): SearchFile {
 		$file = new SearchFile();
-		$file->setCircleUniqueId($circleUniqueId);
+		$file->setCollectiveId($collectiveId);
 		$file->setFileId($fileId);
 		$file->setPath($path);
 		$file->setMtime($mtime);
@@ -35,11 +35,11 @@ class SearchFileMapper extends QBMapper {
 		return $this->insert($file);
 	}
 
-	public function findByCircleAndFileId(string $circleUniqueId, int $fileId): ?SearchFile {
+	public function findByCollectiveAndFileId(int $collectiveId, int $fileId): ?SearchFile {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from($this->tableName)
-			->where($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleUniqueId)))
+			->where($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId)))
 			->andWhere($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId)));
 
 		try {
@@ -49,11 +49,11 @@ class SearchFileMapper extends QBMapper {
 		}
 	}
 
-	public function getMaxMtimeByCircle(string $circleUniqueId): ?int {
+	public function getMaxMtimeByCollective(int $collectiveId): ?int {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select($qb->func()->max('mtime'))
 			->from($this->tableName)
-			->where($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleUniqueId)));
+			->where($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId)));
 
 		$result = $qb->executeQuery();
 		$mtime = $result->fetchOne();
@@ -62,11 +62,11 @@ class SearchFileMapper extends QBMapper {
 		return $mtime ? (int)$mtime : null;
 	}
 
-	public function getLanguagesByCircle(string $circleUniqueId): array {
+	public function getLanguagesByCollective(int $collectiveId): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->selectDistinct('language')
 			->from($this->tableName)
-			->where($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleUniqueId)))
+			->where($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId)))
 			->andWhere($qb->expr()->isNotNull('language'));
 
 		$result = $qb->executeQuery();
@@ -76,17 +76,17 @@ class SearchFileMapper extends QBMapper {
 		return $languages;
 	}
 
-	public function deleteByCircle(string $circleUniqueId): void {
+	public function deleteByCollective(int $collectiveId): void {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->tableName)
-			->where($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleUniqueId)));
+			->where($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId)));
 		$qb->executeStatement();
 	}
 
-	public function deleteByCircleAndFileId(string $circleUniqueId, int $fileId): void {
+	public function deleteByCollectiveAndFileId(int $collectiveId, int $fileId): void {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->tableName)
-			->where($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleUniqueId)))
+			->where($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId)))
 			->andWhere($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId)));
 		$qb->executeStatement();
 	}

--- a/lib/Search/FileSearch/Db/SearchWord.php
+++ b/lib/Search/FileSearch/Db/SearchWord.php
@@ -14,18 +14,21 @@ use OCP\AppFramework\Db\Entity;
 /**
  * @method int getId()
  * @method void setId(int $value)
- * @method string getCircleUniqueId()
- * @method void setCircleUniqueId(string $value)
+ * @method int getCollectiveId()
+ * @method void setCollectiveId(int $value)
  * @method string getTerm()
  * @method void setTerm(string $value)
+ * @method string getStem()
+ * @method void setStem(string $value)
  * @method int getNumHits()
  * @method void setNumHits(int $value)
  * @method int getNumFiles()
  * @method void setNumFiles(int $value)
  */
 class SearchWord extends Entity {
-	protected ?string $circleUniqueId = null;
+	protected ?int $collectiveId = null;
 	protected ?string $term = null;
+	protected ?string $stem = null;
 	protected ?int $numHits = null;
 	protected ?int $numFiles = null;
 }

--- a/lib/Search/FileSearch/Db/SearchWordMapper.php
+++ b/lib/Search/FileSearch/Db/SearchWordMapper.php
@@ -27,8 +27,8 @@ class SearchWordMapper extends QBMapper {
 		parent::__construct($db, 'collectives_s_words', SearchWord::class);
 	}
 
-	public function upsert(string $circleUniqueId, string $term, int $numHits, int $numFiles): SearchWord {
-		$word = $this->findByCircleAndTerm($circleUniqueId, $term);
+	public function upsert(int $collectiveId, string $term, string $stem, int $numHits, int $numFiles): SearchWord {
+		$word = $this->findByCollectiveAndTerm($collectiveId, $term);
 
 		if ($word !== null) {
 			$word->setNumHits($word->getNumHits() + $numHits);
@@ -37,25 +37,26 @@ class SearchWordMapper extends QBMapper {
 		}
 
 		$word = new SearchWord();
-		$word->setCircleUniqueId($circleUniqueId);
+		$word->setCollectiveId($collectiveId);
 		$word->setTerm($term);
+		$word->setStem($stem);
 		$word->setNumHits($numHits);
 		$word->setNumFiles($numFiles);
 		return $this->insert($word);
 	}
 
-	public function deleteByCircle(string $circleUniqueId): void {
+	public function deleteByCollective(int $collectiveId): void {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->tableName)
-			->where($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleUniqueId)));
+			->where($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId)));
 		$qb->executeStatement();
 	}
 
-	public function findByCircleAndTerm(string $circleUniqueId, string $term): ?SearchWord {
+	public function findByCollectiveAndTerm(int $collectiveId, string $term): ?SearchWord {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from($this->tableName)
-			->where($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleUniqueId)))
+			->where($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId)))
 			->andWhere($qb->expr()->eq('term', $qb->createNamedParameter($term)));
 
 		try {
@@ -65,11 +66,21 @@ class SearchWordMapper extends QBMapper {
 		}
 	}
 
-	public function findByCircleAndPrefix(string $circleUniqueId, string $prefix, int $limit = 20): array {
+	public function findByCollectiveAndStem(int $collectiveId, string $stem): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from($this->tableName)
-			->where($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleUniqueId)))
+			->where($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId)))
+			->andWhere($qb->expr()->eq('stem', $qb->createNamedParameter($stem)));
+
+		return $this->findEntities($qb);
+	}
+
+	public function findByCollectiveAndPrefix(int $collectiveId, string $prefix, int $limit): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->tableName)
+			->where($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId)))
 			->andWhere($qb->expr()->like('term', $qb->createNamedParameter($prefix . '%')))
 			->orderBy('num_hits', 'DESC')
 			->setMaxResults($limit);
@@ -77,24 +88,24 @@ class SearchWordMapper extends QBMapper {
 		return $this->findEntities($qb);
 	}
 
-	public function decrementCounts(string $circleUniqueId, string $wordId, int $hitCount): void {
+	public function decrementCounts(int $collectiveId, string $wordId, int $hitCount): void {
 		$qb = $this->db->getQueryBuilder();
 
 		$hitCountParam = $qb->createNamedParameter($hitCount, IQueryBuilder::PARAM_INT);
 		$qb->update($this->tableName)
 			->set('num_hits', $qb->func()->greatest($qb->createFunction("num_hits - $hitCountParam"), $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
 			->set('num_files', $qb->func()->greatest($qb->createFunction('num_files - 1'), $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
-			->where($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleUniqueId)))
+			->where($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId)))
 			->andWhere($qb->expr()->eq('id', $qb->createNamedParameter($wordId)));
 		$qb->executeStatement();
 
-		$this->deleteOrphanedWords($circleUniqueId);
+		$this->deleteOrphanedWords($collectiveId);
 	}
 
-	private function deleteOrphanedWords(string $circleUniqueId): void {
+	private function deleteOrphanedWords(int $collectiveId): void {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->tableName)
-			->where($qb->expr()->eq('circle_unique_id', $qb->createNamedParameter($circleUniqueId)))
+			->where($qb->expr()->eq('collective_id', $qb->createNamedParameter($collectiveId)))
 			->andWhere($qb->expr()->orX(
 				$qb->expr()->lte('num_hits', $qb->createNamedParameter(0)),
 				$qb->expr()->lte('num_files', $qb->createNamedParameter(0))

--- a/lib/Search/FileSearch/FileIndexer.php
+++ b/lib/Search/FileSearch/FileIndexer.php
@@ -33,36 +33,36 @@ class FileIndexer {
 	) {
 	}
 
-	public function indexFolder(Folder $folder, string $circleUniqueId, bool $incremental = false): void {
+	public function indexFolder(Folder $folder, int $collectiveId, bool $incremental = false): void {
 
 		if (!$incremental) {
-			$this->deleteIndexByCircle($circleUniqueId);
+			$this->deleteIndexByCollective($collectiveId);
 		}
 
 		$files = $this->getDirectoryFiles($folder, true);
 
 		foreach ($files as $file) {
-			$this->indexFile($file, $circleUniqueId, $incremental);
+			$this->indexFile($file, $collectiveId, $incremental);
 		}
 	}
 
-	private function deleteIndexByCircle(string $circleUniqueId): void {
-		$this->wordMapper->deleteByCircle($circleUniqueId);
-		$this->docMapper->deleteByCircle($circleUniqueId);
-		$this->fileMapper->deleteByCircle($circleUniqueId);
+	private function deleteIndexByCollective(int $collectiveId): void {
+		$this->wordMapper->deleteByCollective($collectiveId);
+		$this->docMapper->deleteByCollective($collectiveId);
+		$this->fileMapper->deleteByCollective($collectiveId);
 	}
 
-	private function indexFile(File $file, string $circleUniqueId, bool $incremental): void {
+	private function indexFile(File $file, int $collectiveId, bool $incremental): void {
 
 		if ($incremental) {
-			$existingFile = $this->fileMapper->findByCircleAndFileId($circleUniqueId, $file->getId());
+			$existingFile = $this->fileMapper->findByCollectiveAndFileId($collectiveId, $file->getId());
 
 			if ($existingFile && $existingFile->getMtime() >= $file->getMTime()) {
 				return;
 			}
 
 			if ($existingFile) {
-				$this->deleteFileFromIndex($circleUniqueId, $file->getId());
+				$this->deleteFileFromIndex($collectiveId, $file->getId());
 			}
 		}
 
@@ -73,28 +73,30 @@ class FileIndexer {
 		}
 
 		$language = $this->languageDetector->detect(mb_substr($content, 0, self::LANGUAGE_DETECTION_LIMIT));
-		$tokens = $this->tokenizer->tokenize($content);
+		$tokens = $this->tokenizer->tokenize($content, $language);
 
-		$stems = [];
+		$termCounts = [];
+		$termStems = [];
 		foreach ($tokens as $token) {
-			$stems[] = $this->stemmer->stem($token, $language);
+			$term = mb_substr($token, 0, 50);
+			$termCounts[$term] = ($termCounts[$term] ?? 0) + 1;
+			$termStems[$term] = $this->stemmer->stem($token, $language);
 		}
 
-		$terms = array_count_values($stems);
-		unset($content, $tokens, $stems);
+		unset($content, $tokens);
 
-		foreach ($terms as $term => $hitCount) {
+		foreach ($termCounts as $term => $hitCount) {
 			try {
-				$term = mb_substr((string)$term, 0, 50);
-				$word = $this->wordMapper->upsert($circleUniqueId, $term, $hitCount, 1);
-				$this->docMapper->insertDoc($circleUniqueId, $word->getId(), $file->getId(), $hitCount);
+				/** @psalm-suppress RedundantCast */
+				$word = $this->wordMapper->upsert($collectiveId, (string)$term, $termStems[$term], $hitCount, 1);
+				$this->docMapper->insertDoc($collectiveId, $word->getId(), $file->getId(), $hitCount);
 			} catch (\Exception) {
 				continue;
 			}
 		}
 
 		try {
-			$this->fileMapper->insertFile($circleUniqueId, $file->getId(), $file->getInternalPath(), $file->getMTime(), $language);
+			$this->fileMapper->insertFile($collectiveId, $file->getId(), $file->getInternalPath(), $file->getMTime(), $language);
 		} catch (\Exception) {
 		}
 	}
@@ -117,20 +119,25 @@ class FileIndexer {
 				continue;
 			}
 
+			if (str_starts_with($node->getParent()->getName(), '.attachments.')
+				|| $node->getParent()->getName() === '.templates') {
+				continue;
+			}
+
 			$files[] = $node;
 		}
 
 		return array_merge($files, ...$filesRecursive);
 	}
 
-	private function deleteFileFromIndex(string $circleUniqueId, int $fileId): void {
-		$docs = $this->docMapper->findByCircleAndFileId($circleUniqueId, $fileId);
+	private function deleteFileFromIndex(int $collectiveId, int $fileId): void {
+		$docs = $this->docMapper->findByCollectiveAndFileId($collectiveId, $fileId);
 
 		foreach ($docs as $doc) {
-			$this->wordMapper->decrementCounts($circleUniqueId, $doc->getWordId(), $doc->getHitCount());
+			$this->wordMapper->decrementCounts($collectiveId, $doc->getWordId(), $doc->getHitCount());
 			$this->docMapper->delete($doc);
 		}
 
-		$this->fileMapper->deleteByCircleAndFileId($circleUniqueId, $fileId);
+		$this->fileMapper->deleteByCollectiveAndFileId($collectiveId, $fileId);
 	}
 }

--- a/lib/Search/FileSearch/FileSearcher.php
+++ b/lib/Search/FileSearch/FileSearcher.php
@@ -17,9 +17,9 @@ use OCA\Collectives\Search\FileSearch\Tokenizer\ClauseTokenizer;
 use OCA\Collectives\Search\FileSearch\Tokenizer\WordTokenizer;
 
 class FileSearcher {
-	private const DEFAULT_LIMIT = 15;
+	private const SEARCH_LIMIT = 50;
 	private const FUZZY_PREFIX_LENGTH = 3;
-	private const FUZZY_MAX_DISTANCE = 1;
+	public const FUZZY_MAX_DISTANCE = 1;
 
 	public function __construct(
 		private readonly SearchWordMapper $wordMapper,
@@ -31,39 +31,82 @@ class FileSearcher {
 	) {
 	}
 
-	public function search(string $circleId, string $query, int $limit = self::DEFAULT_LIMIT): array {
-		$tokens = $this->tokenizer->tokenize($query);
-		$languages = $this->fileMapper->getLanguagesByCircle($circleId) ?: [null];
+	private function mergeResults(array $results, array $newResults): array {
+		$existingFileIds = array_column($results, 'file_id');
+		foreach ($newResults as $result) {
+			if (!in_array($result['file_id'], $existingFileIds)) {
+				$results[] = $result;
+			}
+		}
+		return $results;
+	}
 
-		$stems = [];
+	public function search(int $collectiveId, string $query): array {
+		$tokens = $this->tokenizer->tokenize($query);
+		if (empty($tokens)) {
+			return [];
+		}
+
+		// step 1: exact match on term
+		$exactWordIds = [];
+		foreach ($tokens as $token) {
+			$exactWord = $this->wordMapper->findByCollectiveAndTerm($collectiveId, $token);
+			if ($exactWord !== null) {
+				$exactWordIds[] = $exactWord->getId();
+			}
+		}
+
+		$results = !empty($exactWordIds)
+			? $this->docMapper->findDocumentsByWords($collectiveId, $exactWordIds, self::SEARCH_LIMIT)
+			: [];
+
+		$remainingLimit = self::SEARCH_LIMIT - count($results);
+		if ($remainingLimit <= 0) {
+			return $results;
+		}
+
+		// step 2: prefix match on term
+		$prefixWordIds = [];
+		foreach ($tokens as $token) {
+			$prefixWords = $this->wordMapper->findByCollectiveAndPrefix($collectiveId, $token, $remainingLimit);
+			foreach ($prefixWords as $word) {
+				if (!in_array($word->getId(), $exactWordIds)) {
+					$prefixWordIds[] = $word->getId();
+				}
+			}
+		}
+
+		$prefixWordIds = array_unique($prefixWordIds);
+		$prefixResults = !empty($prefixWordIds)
+			? $this->docMapper->findDocumentsByWords($collectiveId, $prefixWordIds, $remainingLimit)
+			: [];
+		$results = $this->mergeResults($results, $prefixResults);
+
+		$remainingLimit = self::SEARCH_LIMIT - count($results);
+		if ($remainingLimit <= 0) {
+			return $results;
+		}
+
+		// step 3: stem match with fuzzy fallback
+		$languages = $this->fileMapper->getLanguagesByCollective($collectiveId) ?: [null];
+		$stemWordIds = [];
 		foreach ($tokens as $token) {
 			foreach ($languages as $language) {
-				$stems[] = $this->stemmer->stem($token, $language);
-			}
-		}
-		$stems = array_unique($stems);
-
-		if (empty($stems)) {
-			return [];
-		}
-
-		$wordIds = [];
-		foreach ($stems as $stem) {
-			$word = $this->wordMapper->findByCircleAndTerm($circleId, $stem);
-			$words = $word ? [$word] : $this->fuzzySearchWord($circleId, $stem);
-
-			foreach ($words as $word) {
-				$wordIds[] = $word->getId();
+				$stem = $this->stemmer->stem($token, $language);
+				$stemWords = $this->wordMapper->findByCollectiveAndStem($collectiveId, $stem)
+					?: $this->fuzzySearchWord($collectiveId, $token);
+				foreach ($stemWords as $word) {
+					$stemWordIds[] = $word->getId();
+				}
 			}
 		}
 
-		$wordIds = array_unique($wordIds);
+		$stemWordIds = array_unique($stemWordIds);
+		$stemResults = !empty($stemWordIds)
+			? $this->docMapper->findDocumentsByWords($collectiveId, $stemWordIds, $remainingLimit)
+			: [];
 
-		if (empty($wordIds)) {
-			return [];
-		}
-
-		return $this->docMapper->findDocumentsByWords($circleId, $wordIds, $limit);
+		return $this->mergeResults($results, $stemResults);
 	}
 
 	public function rankByBigrams(string $query, array $files): array {
@@ -99,13 +142,13 @@ class FileSearcher {
 		return array_map(fn ($item) => $item['file'], $scored);
 	}
 
-	private function fuzzySearchWord(string $circleId, string $term): array {
+	private function fuzzySearchWord(int $collectiveId, string $term): array {
 		if (mb_strlen($term) < self::FUZZY_PREFIX_LENGTH) {
 			return [];
 		}
 
 		$prefix = mb_substr($term, 0, self::FUZZY_PREFIX_LENGTH);
-		$candidates = $this->wordMapper->findByCircleAndPrefix($circleId, $prefix);
+		$candidates = $this->wordMapper->findByCollectiveAndPrefix($collectiveId, $prefix, self::SEARCH_LIMIT);
 
 		$matches = [];
 		foreach ($candidates as $candidate) {

--- a/lib/Search/FileSearch/LanguageDetector/LanguageDetector.php
+++ b/lib/Search/FileSearch/LanguageDetector/LanguageDetector.php
@@ -12,14 +12,19 @@ namespace OCA\Collectives\Search\FileSearch\LanguageDetector;
 use LanguageDetection\Language;
 
 class LanguageDetector {
+
+	public function __construct(
+		private readonly Language $detector,
+	) {
+	}
+
 	public function detect(string $text): ?string {
 		if (trim($text) === '') {
 			return null;
 		}
 
 		try {
-			$detector = new Language();
-			$result = (string)$detector->detect($text);
+			$result = (string)$this->detector->detect($text);
 			return $result !== '' ? $result : null;
 		} catch (\Exception) {
 			return null;

--- a/lib/Search/FileSearch/Tokenizer/AbstractTokenizer.php
+++ b/lib/Search/FileSearch/Tokenizer/AbstractTokenizer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Search\FileSearch\Tokenizer;
+
+abstract class AbstractTokenizer {
+	public static function normalize(string $text): string {
+		/*
+		 * strip HTML tags
+		 * use a regex as strip_tags() is too greedy
+		 * and strips content between <!-- --> comments and other edge cases
+		 */
+		$text = preg_replace('/<[a-zA-Z\/][^>]*>/', '', $text) ?? $text;
+
+		/*
+		 * normalize mentions to make them searchable
+		 * e.g. @[name](mention://user/name) -> @name
+		 */
+		$text = preg_replace('/@\[([^\]]+)\]\(mention:\/\/[^)]+\)/', '@$1', $text) ?? $text;
+
+		return $text;
+	}
+
+	protected function getStopWords(string $language): array {
+		$file = __DIR__ . '/StopWords/' . $language . '.php';
+		if (file_exists($file)) {
+			return require $file;
+		}
+		return [];
+	}
+}

--- a/lib/Search/FileSearch/Tokenizer/ClauseTokenizer.php
+++ b/lib/Search/FileSearch/Tokenizer/ClauseTokenizer.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 namespace OCA\Collectives\Search\FileSearch\Tokenizer;
 
 class ClauseTokenizer extends WordTokenizer {
-	public function tokenize($text, array $stopwords = []): array {
-		$words = parent::tokenize($text, $stopwords);
+	public function tokenize($text, ?string $language = null): array {
+		$words = parent::tokenize($text, $language);
 
 		$tokens = [];
 		$lastWord = '';

--- a/lib/Search/FileSearch/Tokenizer/StopWords/de.php
+++ b/lib/Search/FileSearch/Tokenizer/StopWords/de.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+return [
+	'ab', 'aber', 'alle', 'allem', 'allen', 'aller', 'alles', 'als', 'also', 'am', 'an', 'auch', 'auf', 'aus',
+	'bei', 'bin',
+	'da', 'dann', 'das', 'dass', 'dem', 'den', 'der', 'des', 'die', 'dies', 'diese', 'diesem', 'diesen', 'dieser', 'dieses', 'dir', 'du', 'durch',
+	'ein', 'eine', 'einem', 'einen', 'einer', 'eines', 'er', 'es',
+	'für',
+	'haben', 'hat', 'hatte', 'hier',
+	'ich', 'ihm', 'ihn', 'ihnen', 'ihr', 'ihre', 'im', 'in', 'ist',
+	'ja',
+	'kann', 'kein', 'keine',
+	'man', 'mehr', 'mein', 'meine', 'mir', 'mit', 'muss',
+	'nach', 'nicht', 'noch', 'nun', 'nur',
+	'ob', 'oder',
+	'sehr', 'sich', 'sie', 'sind', 'so',
+	'über', 'um', 'und', 'uns', 'unser', 'unter',
+	'vom', 'von', 'vor',
+	'war', 'was', 'wenn', 'werden', 'wie', 'wir', 'wird', 'wo',
+	'zu', 'zum', 'zur',
+];

--- a/lib/Search/FileSearch/Tokenizer/StopWords/en.php
+++ b/lib/Search/FileSearch/Tokenizer/StopWords/en.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+return [
+	'a', 'all', 'also', 'an', 'and', 'any', 'are', 'as', 'at',
+	'be', 'been', 'being', 'but', 'by',
+	'can', 'could',
+	'did', 'do', 'does',
+	'each',
+	'for', 'from',
+	'had', 'has', 'have', 'he', 'her', 'him', 'his', 'how',
+	'i', 'if', 'in', 'into', 'is', 'it', 'its',
+	'just',
+	'may', 'me', 'might', 'my',
+	'no', 'nor', 'not',
+	'of', 'on', 'one', 'only', 'or', 'our', 'out',
+	'shall', 'she', 'should', 'so', 'some',
+	'than', 'that', 'the', 'their', 'them', 'then', 'there', 'these', 'they', 'this', 'those', 'to',
+	'up', 'us',
+	'was', 'we', 'were', 'what', 'when', 'where', 'which', 'who', 'will', 'with', 'would',
+	'yet', 'you', 'your',
+];

--- a/lib/Search/FileSearch/Tokenizer/WordTokenizer.php
+++ b/lib/Search/FileSearch/Tokenizer/WordTokenizer.php
@@ -9,15 +9,17 @@ declare(strict_types=1);
 
 namespace OCA\Collectives\Search\FileSearch\Tokenizer;
 
-class WordTokenizer {
+class WordTokenizer extends AbstractTokenizer {
 	private const MIN_LENGTH = 2;
 	private const MAX_LENGTH = 50;
 	private const PATTERN = '/[^\p{L}\p{N}\p{Pc}\p{Pd}@]+/u';
 
-	public function tokenize(string $text, array $stopwords = []): array {
+	public function tokenize(string $text, ?string $language = null): array {
+		$text = self::normalize($text);
 		$text = mb_strtolower($text);
 		$words = preg_split(self::PATTERN, $text, -1, PREG_SPLIT_NO_EMPTY);
 
+		$stopwords = $language !== null ? $this->getStopWords($language) : [];
 		$words = array_diff($words, $stopwords);
 
 		return array_filter($words, function ($word) {

--- a/lib/Search/PageContentProvider.php
+++ b/lib/Search/PageContentProvider.php
@@ -13,6 +13,7 @@ use Exception;
 use OCA\Collectives\Db\Collective;
 use OCA\Collectives\Model\PageInfo;
 use OCA\Collectives\Search\FileSearch\FileSearchException;
+use OCA\Collectives\Search\FileSearch\Tokenizer\WordTokenizer;
 use OCA\Collectives\Service\CollectiveHelper;
 use OCA\Collectives\Service\CollectiveService;
 use OCA\Collectives\Service\PageService;
@@ -88,11 +89,13 @@ class PageContentProvider implements IProvider {
 					continue;
 				}
 
-				$pages[$fileId] = $fileEntry;
+				$pages[$fileId] = ['file' => $fileEntry, 'matched_term' => $fileData['matched_term']];
 				$collectiveMap[$fileId] = $collective;
 			}
 		}
 
+		$pageData = $pages;
+		$pages = array_map(fn ($p) => $p['file'], $pages);
 		$pages = $this->indexedSearchService->rankByBigrams($query->getTerm(), $pages);
 
 		$pageSearchResults = [];
@@ -105,14 +108,19 @@ class PageContentProvider implements IProvider {
 
 			$descriptionSuffix = $pageInfo->getFilePath()
 				? ' - ' . $pageInfo->getFilePathString()
-				: '';
+				: ' - ' . $pageInfo->getTitle();
 			$description = $this->l10n->t('In collective %1$s', [$this->collectiveService->getCollectiveNameWithEmoji($collective)])
 				. $descriptionSuffix;
 
 			$content = $page->getContent();
+			$normalizedContent = WordTokenizer::normalize($content);
+
+			$pos = mb_stripos($normalizedContent, $pageData[$page->getId()]['matched_term'] ?? $query->getTerm());
+			$pos = $pos !== false ? $pos : 0;
+
 			$pageSearchResults[] = new SearchResultEntry(
 				'',
-				mb_substr($content, mb_stripos($content, $query->getTerm()), 200),
+				mb_substr($normalizedContent, $pos, 200),
 				$description,
 				$this->urlGenerator->linkToRouteAbsolute('collectives.start.index') . $this->pageService->getPageLink($collective->getUrlPath(), $pageInfo),
 				'icon-collectives-page'

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -36,11 +36,11 @@ class SearchService {
 			throw new FileSearchException('Collectives search service could not find folder for collective.', 0, $e);
 		}
 
-		$this->indexer->indexFolder($collectiveFolder, $collective->getCircleId(), $incremental);
+		$this->indexer->indexFolder($collectiveFolder, $collective->getId(), $incremental);
 	}
 
-	public function searchCollective(Collective $collective, string $query, int $maxResults = 15): array {
-		return $this->searcher->search($collective->getCircleId(), $query, $maxResults);
+	public function searchCollective(Collective $collective, string $query): array {
+		return $this->searcher->search($collective->getId(), $query);
 	}
 
 	public function rankByBigrams(string $query, array $files): array {


### PR DESCRIPTION
This PR improves the existing full text search implementation with several enhancements.

### Changes

- Store original terms alongside their stems to enable exact match ranking over stem matches
- Search now uses a three-step ranking: 1. exact match, 2. prefix match, 3. stem match with fuzzy fallback
- Added stop words for `de` and `en` to reduce search index size
- Skip `.attachments` and `.templates` directories when indexing
- Use `collective_id` (integer) instead of `circle_unique_id` (string) to reduce search index size
- Normalize mentions (e.g. `@[name](mention://user/name)` becomes `@name`) to make them searchable https://github.com/nextcloud/collectives/issues/2299
- Strip HTML tags before indexing to avoid noise
- Use the actual matched term to calculate the snippet position in search results

### Migration

On migration, all existing index data is truncated before schema change, to ensure the index includes both terms and stems after the next indexing.