### PR TITLE
Fix clear stale pageId when navigating by slug

### DIFF
--- a/src/CollectivesApp.vue
+++ b/src/CollectivesApp.vue
@@ -85,6 +85,7 @@ export default {
 				this.rootStore.collectiveParam = val.params.collective
 				this.rootStore.collectiveId = val.params.collectiveId ? parseInt(val.params.collectiveId) : null
 				this.rootStore.pageParam = val.params.page
+				if (!val.params.pageId) this.rootStore.pageId = null
 				this.rootStore.pageId = val.params.pageId ? parseInt(val.params.pageId) : null
 				this.rootStore.shareTokenParam = val.params.token
 				this.rootStore.fileIdQuery = val.query.fileId ? parseInt(val.query.fileId) : ''


### PR DESCRIPTION
clear stale pageId when navigating by slug

### 📝 Summary

* Could Resolves: #2438 
### This is completely untested ( Collectives is not available on https://github.com/szaimen/nextcloud-easy-test), This has been worked around with vibe coding suggestion with AI. As it is a one liner it is simple to review the logic and dismiss this code if it is found not working.

Here the reasonning of the AI.

# 🚨 The real problem is *before* this code runs

`currentPageIds` depends entirely on:

- `rootStore.pageId`
- `rootStore.pageParam`

Those values are set in your `$route` watcher:

```js
this.rootStore.pageParam = val.params.page
this.rootStore.pageId = val.params.pageId ? parseInt(val.params.pageId) : null
```

Here’s the key flaw:

### When navigating via slug (`pageParam`), `pageId` does NOT get cleared  
So `pageId` stays stuck on the previous page.

Then this condition in `currentPageIds` becomes wrong:

```js
if (!rootStore.pageId && !rootStore.pageParam)
```

Because:

- `pageParam` *does* change
- but `pageId` stays stale
- so the condition never triggers
- and the resolver thinks you’re still on the old page

This is why the sharing menu breaks on non‑landing pages.

---

The correct fix is to ensure that `pageId` is cleared when the route does not include a numeric `pageId`.

That’s why the one‑liner goes here:

```js
this.rootStore.pageParam = val.params.page

// Fix: clear stale pageId when navigating by slug
if (!val.params.pageId) this.rootStore.pageId = null

this.rootStore.pageId = val.params.pageId ? parseInt(val.params.pageId) : null
```

This ensures:

- `currentPageIds` receives correct values
- `currentPage` resolves correctly
- `isLandingPage` becomes accurate
- `shareUrl` is computed correctly
- the sharing menu works everywhere

---

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
