### PR TITLE
fix(shares): block tag management in page shares

### DIFF
--- a/lib/Controller/PublicTagController.php
+++ b/lib/Controller/PublicTagController.php
@@ -116,7 +116,11 @@ class PublicTagController extends CollectivesPublicOCSController {
 	 * @throws OCSForbiddenException
 	 */
 	private function checkEditPermissions(): void {
-		if (!$this->getCollectiveShare()->getEditable()) {
+		$collectiveShare = $this->getCollectiveShare();
+		if ($collectiveShare->getPageId() !== 0) {
+			throw new OCSForbiddenException('Tag management not available for page shares');
+		}
+		if (!$collectiveShare->getEditable()) {
 			throw new OCSForbiddenException('Not permitted to edit shared collective');
 		}
 	}

--- a/tests/Integration/features/bootstrap/FeatureContext.php
+++ b/tests/Integration/features/bootstrap/FeatureContext.php
@@ -1794,11 +1794,13 @@ class FeatureContext implements Context {
 	 * @When anonymous creates tag :tag with color :color for collective :collective with owner :owner
 	 * @When anonymous :fails to create tag :tag with color :color for collective :collective with owner :owner
 	 * @When anonymous :fails to create :existing tag :tag with color :color for collective :collective with owner :owner
+	 * @When anonymous creates tag :tag with color :color in public page share :pageShare for collective :collective with owner :owner
+	 * @When anonymous :fails to create tag :tag with color :color in public page share :pageShare for collective :collective with owner :owner
 	 */
-	public function anonymousCreatesTag(string $collective, string $tag, string $color, string $owner, ?string $fails = null, ?string $existing = null): void {
+	public function anonymousCreatesTag(string $collective, string $tag, string $color, string $owner, ?string $fails = null, ?string $existing = null, ?string $pageShare = null): void {
 		$this->setCurrentUser($owner);
 		$collectiveId = $this->collectiveIdByName($collective);
-		$token = $this->getShareToken($collectiveId);
+		$token = $this->getPublicTagShareToken($collectiveId, $pageShare);
 		$data = new TableNode([
 			['name', $tag],
 			['color', $color],
@@ -1818,11 +1820,13 @@ class FeatureContext implements Context {
 	/**
 	 * @When anonymous updates tag :tag with color :color for collective :collective with owner :owner
 	 * @When anonymous :fails to update tag :tag with color :color for collective :collective with owner :owner
+	 * @When anonymous updates tag :tag with color :color in public page share :pageShare for collective :collective with owner :owner
+	 * @When anonymous :fails to update tag :tag with color :color in public page share :pageShare for collective :collective with owner :owner
 	 */
-	public function anonymousUpdatesTag(string $collective, string $tag, string $color, string $owner, ?string $fails = null): void {
+	public function anonymousUpdatesTag(string $collective, string $tag, string $color, string $owner, ?string $fails = null, ?string $pageShare = null): void {
 		$this->setCurrentUser($owner);
 		$collectiveId = $this->collectiveIdByName($collective);
-		$token = $this->getShareToken($collectiveId);
+		$token = $this->getPublicTagShareToken($collectiveId, $pageShare);
 		$id = $this->tagIdByName($collectiveId, $tag, null, $token);
 		$data = new TableNode([
 			['name', $tag],
@@ -1839,11 +1843,13 @@ class FeatureContext implements Context {
 	/**
 	 * @When anonymous deletes tag :tag for collective :collective with owner :owner
 	 * @When anonymous :fails to delete tag :tag for collective :collective with owner :owner
+	 * @When anonymous deletes tag :tag in public page share :pageShare for collective :collective with owner :owner
+	 * @When anonymous :fails to delete tag :tag in public page share :pageShare for collective :collective with owner :owner
 	 */
-	public function anonymousDeletesTag(string $collective, string $tag, string $owner, ?string $fails = null): void {
+	public function anonymousDeletesTag(string $collective, string $tag, string $owner, ?string $fails = null, ?string $pageShare = null): void {
 		$this->setCurrentUser($owner);
 		$collectiveId = $this->collectiveIdByName($collective);
-		$token = $this->getShareToken($collectiveId);
+		$token = $this->getPublicTagShareToken($collectiveId, $pageShare);
 		$id = $this->tagIdByName($collectiveId, $tag, null, $token);
 		$this->sendOcsCollectivesRequest('DELETE', 'p/collectives/' . $token . '/tags/' . $id);
 		if ($fails !== 'fails') {
@@ -1857,11 +1863,13 @@ class FeatureContext implements Context {
 	 * @When anonymous sees tag :tag with color :color for collective :collective with owner :owner
 	 * @When anonymous :fails to see tag :tag for collective :collective with owner :owner
 	 * @When anonymous :fails to see tag :tag with color :color for collective :collective with owner :owner
+	 * @When anonymous sees tag :tag with color :color in public page share :pageShare for collective :collective with owner :owner
+	 * @When anonymous :fails to see tag :tag with color :color in public page share :pageShare for collective :collective with owner :owner
 	 */
-	public function anonymousSeesTag(string $collective, string $tag, string $owner, ?string $color = null, ?string $fails = null): void {
+	public function anonymousSeesTag(string $collective, string $tag, string $owner, ?string $color = null, ?string $fails = null, ?string $pageShare = null): void {
 		$this->setCurrentUser($owner);
 		$collectiveId = $this->collectiveIdByName($collective);
-		$token = $this->getShareToken($collectiveId);
+		$token = $this->getPublicTagShareToken($collectiveId, $pageShare);
 		$id = $this->tagIdByName($collectiveId, $tag, $color, $token);
 		if ($fails !== 'fails') {
 			Assert::assertNotNull($id);
@@ -1910,6 +1918,14 @@ class FeatureContext implements Context {
 		} else {
 			$this->assertStatusCode(403);
 		}
+	}
+
+	private function getPublicTagShareToken(int $collectiveId, ?string $pageShare = null): ?string {
+		if ($pageShare === null) {
+			return $this->getShareToken($collectiveId);
+		}
+		$pageId = $this->pageIdByName($collectiveId, $pageShare);
+		return $this->getShareToken($collectiveId, $pageId);
 	}
 
 	private function getUserCollectivesPath(string $user): string {

--- a/tests/Integration/features/publicTags.feature
+++ b/tests/Integration/features/publicTags.feature
@@ -8,6 +8,8 @@ Feature: tags
     And user "jane" creates page "firstpage" with parentPath "Readme.md" in "BehatTagsPublicCollective"
     And user "jane" creates public share for "BehatTagsPublicCollective"
     And user "jane" sets editing permissions for collective share "BehatTagsPublicCollective"
+    And user "jane" creates public page share for page "firstpage" in "BehatTagsPublicCollective"
+    And user "jane" sets editing permissions for page share "firstpage" in collective "BehatTagsPublicCollective"
 
   Scenario: Create and update tag in public collective share
     When anonymous creates tag "test1" with color "FFFFFF" for collective "BehatTagsPublicCollective" with owner "jane"
@@ -21,6 +23,13 @@ Feature: tags
     Then anonymous adds tag "test2" to page "firstpage" in collective "BehatTagsPublicCollective" with owner "jane"
     And anonymous fails to add tagId "9999" to page "firstpage" in collective "BehatTagsPublicCollective" with owner "jane"
     And anonymous removes tag "test2" from page "firstpage" in collective "BehatTagsPublicCollective" with owner "jane"
+
+  Scenario: Fail to manage tags in public page share
+    Then anonymous sees tag "test1" with color "FF0000" in public page share "firstpage" for collective "BehatTagsPublicCollective" with owner "jane"
+    And anonymous fails to create tag "page-share-tag" with color "FFFFFF" in public page share "firstpage" for collective "BehatTagsPublicCollective" with owner "jane"
+    And anonymous fails to update tag "test1" with color "00FF00" in public page share "firstpage" for collective "BehatTagsPublicCollective" with owner "jane"
+    And anonymous fails to delete tag "test1" in public page share "firstpage" for collective "BehatTagsPublicCollective" with owner "jane"
+    And anonymous sees tag "test1" with color "FF0000" for collective "BehatTagsPublicCollective" with owner "jane"
 
   Scenario: Fail to create, update and delete tag in public read-only collective share
     When user "jane" unsets editing permissions for collective share "BehatTagsPublicCollective"


### PR DESCRIPTION
Editable page-level public shares must not manage the collective-wide tag palette. Keep tag reads available, but return 403 for tag create, update, and delete when the share token is scoped to a page.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
