### PR TITLE
fix: enforce collective editLevel in public share editable flag

### DIFF
--- a/lib/Db/Collective.php
+++ b/lib/Db/Collective.php
@@ -276,6 +276,10 @@ class Collective extends Entity implements JsonSerializable {
 		return $this->level >= $this->getEditPermissionLevel();
 	}
 
+	public function memberCanEdit(): bool {
+		return $this->getEditPermissionLevel() <= Member::LEVEL_MEMBER;
+	}
+
 	public function canShare(): bool {
 		return $this->level >= $this->getSharePermissionLevel();
 	}

--- a/lib/Service/CollectiveShareService.php
+++ b/lib/Service/CollectiveShareService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Collectives\Service;
 
 use OCA\Collectives\Db\Collective;
+use OCA\Collectives\Db\CollectiveMapper;
 use OCA\Collectives\Db\CollectiveShare;
 use OCA\Collectives\Db\CollectiveShareMapper;
 use OCA\Collectives\Fs\UserFolderHelper;
@@ -33,6 +34,7 @@ class CollectiveShareService {
 		private IShareManager $shareManager,
 		private UserFolderHelper $userFolderHelper,
 		private CollectiveShareMapper $collectiveShareMapper,
+		private CollectiveMapper $collectiveMapper,
 		private PageService $pageService,
 		private IL10N $l10n,
 	) {
@@ -119,7 +121,7 @@ class CollectiveShareService {
 			return null;
 		}
 
-		$collectiveShare->setEditable($this->isShareEditable($folderShare));
+		$collectiveShare->setEditable($this->isShareEditable($folderShare, $collectiveShare));
 		if ($folderShare->getPassword()) {
 			$collectiveShare->setPassword($folderShare->getPassword());
 		}
@@ -145,7 +147,7 @@ class CollectiveShareService {
 			return null;
 		}
 
-		$collectiveShare->setEditable($this->isShareEditable($folderShare));
+		$collectiveShare->setEditable($this->isShareEditable($folderShare, $collectiveShare));
 		if ($folderShare->getPassword()) {
 			$collectiveShare->setPassword($folderShare->getPassword());
 		}
@@ -163,7 +165,7 @@ class CollectiveShareService {
 				// Corresponding folder share not found, delete the collective share as well.
 				$this->collectiveShareMapper->delete($share);
 			}
-			$share->setEditable($this->isShareEditable($folderShare));
+			$share->setEditable($this->isShareEditable($folderShare, $share));
 			if ($folderShare->getPassword()) {
 				$share->setPassword($folderShare->getPassword());
 			}
@@ -173,9 +175,12 @@ class CollectiveShareService {
 		return $shares;
 	}
 
-	private function isShareEditable(IShare $folderShare): bool {
-		$folderShare->getPermissions();
-		return ($folderShare->getPermissions() & Collective::editPermissions) === Collective::editPermissions;
+	private function isShareEditable(IShare $folderShare, CollectiveShare $collectiveShare): bool {
+		if (($folderShare->getPermissions() & Collective::editPermissions) !== Collective::editPermissions) {
+			return false;
+		}
+		$collective = $this->collectiveMapper->findByIdAndUser($collectiveShare->getCollectiveId(), null);
+		return $collective !== null && $collective->canEdit();
 	}
 
 	/**
@@ -255,7 +260,7 @@ class CollectiveShareService {
 
 		$this->shareManager->updateShare($folderShare);
 
-		$share->setEditable($this->isShareEditable($folderShare));
+		$share->setEditable($this->isShareEditable($folderShare, $share));
 		if ($folderShare->getPassword()) {
 			$share->setPassword($folderShare->getPassword());
 		}

--- a/lib/Service/CollectiveShareService.php
+++ b/lib/Service/CollectiveShareService.php
@@ -179,8 +179,8 @@ class CollectiveShareService {
 		if (($folderShare->getPermissions() & Collective::editPermissions) !== Collective::editPermissions) {
 			return false;
 		}
-		$collective = $this->collectiveMapper->findByIdAndUser($collectiveShare->getCollectiveId(), null);
-		return $collective !== null && $collective->canEdit();
+		$collective = $this->collectiveMapper->findByIdAndUser($collectiveShare->getCollectiveId(), $collectiveShare->getOwner());
+		return $collective !== null && $collective->memberCanEdit();
 	}
 
 	/**

--- a/tests/Integration/features/publicTags.feature
+++ b/tests/Integration/features/publicTags.feature
@@ -41,6 +41,20 @@ Feature: tags
     Then anonymous fails to add tag "test2" to page "firstpage" in collective "BehatTagsPublicCollective" with owner "jane"
     And anonymous fails to remove tag "test2" from page "firstpage" in collective "BehatTagsPublicCollective" with owner "jane"
 
+  Scenario: Fail to create, update and delete tag when collective restricts editing to admins
+    When user "jane" sets editing permissions for collective share "BehatTagsPublicCollective"
+    And user "jane" sets "edit" level in collective "BehatTagsPublicCollective" to "Admin"
+    Then anonymous fails to create tag "test3" with color "00FF00" for collective "BehatTagsPublicCollective" with owner "jane"
+    Then anonymous fails to update tag "test2" with color "0000FF" for collective "BehatTagsPublicCollective" with owner "jane"
+    Then anonymous fails to delete tag "test2" for collective "BehatTagsPublicCollective" with owner "jane"
+    And user "jane" sets "edit" level in collective "BehatTagsPublicCollective" to "Member"
+
+  Scenario: Fail to tag and untag a page when collective restricts editing to admins
+    When user "jane" sets "edit" level in collective "BehatTagsPublicCollective" to "Admin"
+    Then anonymous fails to add tag "test2" to page "firstpage" in collective "BehatTagsPublicCollective" with owner "jane"
+    And anonymous fails to remove tag "test1" from page "firstpage" in collective "BehatTagsPublicCollective" with owner "jane"
+    And user "jane" sets "edit" level in collective "BehatTagsPublicCollective" to "Member"
+
   Scenario: Delete tag
     When user "jane" sets editing permissions for collective share "BehatTagsPublicCollective"
     And anonymous deletes tag "test1" for collective "BehatTagsPublicCollective" with owner "jane"

--- a/tests/Unit/Service/CollectiveShareServiceTest.php
+++ b/tests/Unit/Service/CollectiveShareServiceTest.php
@@ -11,6 +11,7 @@ namespace Unit\Service;
 
 use OC\Share20\Share;
 use OCA\Collectives\Db\Collective;
+use OCA\Collectives\Db\CollectiveMapper;
 use OCA\Collectives\Db\CollectiveShare;
 use OCA\Collectives\Db\CollectiveShareMapper;
 use OCA\Collectives\Fs\UserFolderHelper;
@@ -58,12 +59,14 @@ class CollectiveShareServiceTest extends TestCase {
 			->getMock();
 		$l10n->method('t')->willReturnArgument(0);
 
+		$collectiveMapper = $this->createMock(CollectiveMapper::class);
 		$pageService = $this->createMock(PageService::class);
 
 		$this->service = new CollectiveShareService(
 			$this->shareManager,
 			$this->userFolderHelper,
 			$this->collectiveShareMapper,
+			$collectiveMapper,
 			$pageService,
 			$l10n
 		);

--- a/tests/Unit/Service/CollectiveShareServiceTest.php
+++ b/tests/Unit/Service/CollectiveShareServiceTest.php
@@ -163,6 +163,8 @@ class CollectiveShareServiceTest extends TestCase {
 
 	public function testFindShareShareNotFoundException(): void {
 		$collectiveShare = new CollectiveShare();
+		$collectiveShare->setCollectiveId($this->collectiveId);
+		$collectiveShare->setOwner($this->userId);
 		$collectiveShare->setToken('token');
 		$this->collectiveShareMapper->method('findOneByCollectiveIdAndUser')
 			->willReturn($collectiveShare);
@@ -176,6 +178,8 @@ class CollectiveShareServiceTest extends TestCase {
 
 	public function testFindShare(): void {
 		$collectiveShare = new CollectiveShare();
+		$collectiveShare->setCollectiveId($this->collectiveId);
+		$collectiveShare->setOwner($this->userId);
 		$collectiveShare->setToken('token');
 		$this->collectiveShareMapper->method('findOneByCollectiveIdAndUser')
 			->willReturn($collectiveShare);
@@ -197,6 +201,8 @@ class CollectiveShareServiceTest extends TestCase {
 
 	public function testUpdateShare(): void {
 		$collectiveShare = new CollectiveShare();
+		$collectiveShare->setCollectiveId($this->collectiveId);
+		$collectiveShare->setOwner($this->userId);
 		$this->collectiveShareMapper->method('findOneByCollectiveIdAndTokenAndUser')
 			->willReturn($collectiveShare);
 


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
