### PR TITLE
docs: fix URL to admin manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ to structure shared knowledge.
 ## 📚 Documentation
 
 * **[📙 Documentation for users and user groups](https://docs.nextcloud.com/server/latest/user_manual/en/collectives/index.html)**
-* **[📗 Documentation for administrators](https://docs.nextcloud.com/server/latest/admin_manual/en/collectives/index.html)**
+* **[📗 Documentation for administrators](https://docs.nextcloud.com/server/latest/admin_manual/collectives/index.html)**
 * **[📘 Documentation for developers](DEVELOPING.md)**
 * **[⚙️ OCS API](openapi.json).** - best viewed with the [OCS API Viewer app](https://apps.nextcloud.com/apps/ocs_api_viewer)
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ to structure shared knowledge.
 
 ## Why use Collectives?
 
-* **👥 Group-owned, non-hierarchical at its core**: Each collective is backed by a
+* **👥 Non-hierarchical at its core**: Each collective is backed by a
   [Nextcloud Team](https://docs.nextcloud.com/server/latest/user_manual/en/groupware/contacts.html#teams) - its
   content is owned by the group, not a single user.
 * **📝 Collaborative page editing** thanks to the [Text app](https://github.com/nextcloud/text).
 * **🔤 Well-known [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax** for page formatting.
-* **🔎 Full-text search** with automatic indexing to find content straight away.
+* **🔎 Full-text search** to find content straight away.
 
 ## 📚 Documentation
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ to structure shared knowledge.
 
 	<documentation>
 		<user>https://docs.nextcloud.com/server/latest/user_manual/en/collectives/index.html</user>
-		<admin>https://docs.nextcloud.com/server/latest/admin_manual/en/collectives/index.html</admin>
+		<admin>https://docs.nextcloud.com/server/latest/admin_manual/collectives/index.html</admin>
 		<developer>https://github.com/nextcloud/collectives/blob/main/DEVELOPING.md</developer>
 	</documentation>
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,12 +12,12 @@
 Your space to collaboratively write and organize. Collectives is designed for groups and communities
 to structure shared knowledge.
 
-* **👥 Group-owned, non-hierarchical at its core**: Each collective is backed by a
+* **👥 Non-hierarchical at its core**: Each collective is backed by a
   [Nextcloud Team](https://docs.nextcloud.com/server/latest/user_manual/en/groupware/contacts.html#teams) - its
   content is owned by the group, not a single user.
 * **📝 Collaborative page editing** thanks to the [Text app](https://github.com/nextcloud/text).
 * **🔤 Well-known [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax** for page formatting.
-* **🔎 Full-text search** with automatic indexing to find content straight away.
+* **🔎 Full-text search** to find content straight away.
 	]]></description>
 	<version>4.4.0</version>
 	<licence>agpl</licence>


### PR DESCRIPTION
### 📝 Summary

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
