### PR TITLE
Fix: Correct pathing for Hugo build in Pages Action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -63,7 +63,8 @@ jobs:
           HUGO_ENV: production
         run: |
           hugo \
-            --config docs/hugo.toml \
+            --source docs \
+            --destination ../build/pages \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
           mv build/pages public


### PR DESCRIPTION
### 📝 Summary

Fixes faulty pathing for the Hugo build in the Pages Action, consequence of https://github.com/nextcloud/collectives/pull/2484. Whereas previously the config.toml would provide all the necessary paths to Hugo, now with more intricate Pathing and Assets overall, Hugo is being passed a source and output directory to not miss anything.
