### PR TITLE
docs: fix URL to user documentation in website

### DIFF
--- a/docs/content/links/Docs/index.md
+++ b/docs/content/links/Docs/index.md
@@ -1,5 +1,5 @@
 +++
 title = 'Docs'
 tags = ["links"]
-link = "https://docs.nextcloud.com/server/latest/user_manual/zh_HK/collectives/index.html"
+link = "https://docs.nextcloud.com/server/latest/user_manual/en/collectives/index.html"
 +++

--- a/docs/content/links/github/index.md
+++ b/docs/content/links/github/index.md
@@ -1,5 +1,5 @@
 +++
-title = 'Github'
+title = 'GitHub'
 tags = ["links"]
 link = "https://github.com/nextcloud/collectives"
 +++


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
