### PR TITLE
docs: remove superfluous build-time dependencies from DEVELOPING.md

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -123,12 +123,9 @@ supported the required Nextcloud server version.
 
 ## Build-time dependencies
 
-The following tools are required for app development. Some might already be installed on your system:
+The following tools are required for building the app. Some might already be installed on your system:
 
 * make: to run the Makefile targets
 * curl: to fetch some build tools from the web
 * npm: to install NodeJS dependencies and compile JS assets
 * g++: to compile some NodeJS dependencies
-* composer for installing php dependencies
-* Nextcloud server for running php tests
-* teams/circles app for passing some php tests that depend on it

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,6 +33,7 @@ to structure shared knowledge and cultivate trust.
 		<developer>https://github.com/nextcloud/collectives/blob/main/DEVELOPING.md</developer>
 	</documentation>
 
+	<category>office</category>
 	<category>organization</category>
 	<category>social</category>
 	<category>workflow</category>


### PR DESCRIPTION
Also add `office` app store category in `appinfo/info.xml`

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required
