### PR TITLE
fix(links): register global collectives link handler and pass it to Text

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,6 +15,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
+        fail-fast: false
         matrix:
             server-branch: ['stable32', 'master']
             shardIndex: [1, 2, 3, 4]

--- a/playwright/e2e/page-links-handler.spec.ts
+++ b/playwright/e2e/page-links-handler.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {
+	GetCollectiveUrlParameters,
+	SameTabLinkTestCaseData,
+} from '../support/helpers/links.ts'
+
+import { mergeTests } from '@playwright/test'
+import { test as createCollectiveTest } from '../support/fixtures/create-collectives.ts'
+import { test as editorTest } from '../support/fixtures/editor.ts'
+import { testLinkOpensInSameTab } from '../support/helpers/links.ts'
+import { randomString } from '../support/helpers/randomString.ts'
+
+const triggers = ['preview', 'openLinkButton', 'ctrlClick'] as const
+
+const collectiveTest = createCollectiveTest.extend({
+	// eslint-disable-next-line no-empty-pattern
+	collectiveConfigs: async ({}, use) => use([
+		{
+			name: randomString(),
+			pages: [
+				{ title: 'Link Target', content: 'Some content' },
+				{ title: 'Link Source' },
+			],
+		},
+	]),
+})
+
+const test = mergeTests(collectiveTest, editorTest)
+
+test.describe('Link handler: authenticated → public share URL', () => {
+	for (const editMode of [false, true]) {
+		const modeLabel = editMode ? 'edit' : 'preview'
+		for (const trigger of triggers) {
+			test(`Opens public share URL link in same tab via ${trigger} (${modeLabel} mode)`, async ({ baseURL, collective, editor, page, user }) => {
+				test.skip(
+					trigger === 'ctrlClick' && process.env.PLAYWRIGHT_NC_SERVER_BRANCH === 'stable32',
+					'ctrlClick handler not implemented on stable32',
+				)
+
+				const sourcePage = collective.getPageByTitle('Link Source')
+				const targetPage = collective.getPageByTitle('Link Target')
+
+				if (!baseURL) {
+					throw new Error('baseURL is not defined')
+				}
+
+				const share = await collective.createShare({ page })
+
+				const linkData: SameTabLinkTestCaseData = {
+					description: 'public share URL',
+					getLinkUrl: ({ targetPage }: GetCollectiveUrlParameters) => targetPage.getPageUrl(share.data.token),
+					getExpectedUrl: ({ baseURL, targetPage }: GetCollectiveUrlParameters) => (new URL(targetPage.getPageUrl(), baseURL)).href,
+				}
+
+				await testLinkOpensInSameTab({
+					baseURL,
+					page,
+					user,
+					editor,
+					sourcePage,
+					targetPage,
+					targetCollective: collective,
+					linkData,
+					editMode,
+					trigger,
+				})
+
+				await share.delete()
+			})
+		}
+	}
+})
+
+test.describe('Link handler: public share → internal URL', () => {
+	for (const editMode of [false, true]) {
+		const modeLabel = editMode ? 'edit' : 'preview'
+		for (const trigger of triggers) {
+			test(`Opens internal URL link in same tab via ${trigger} in share context (${modeLabel} mode)`, async ({ baseURL, collective, editor, page, user }) => {
+				test.skip(
+					trigger === 'ctrlClick' && process.env.PLAYWRIGHT_NC_SERVER_BRANCH === 'stable32',
+					'ctrlClick handler not implemented on stable32',
+				)
+
+				const sourcePage = collective.getPageByTitle('Link Source')
+				const targetPage = collective.getPageByTitle('Link Target')
+
+				if (!baseURL) {
+					throw new Error('baseURL is not defined')
+				}
+
+				const share = await collective.createShare({ page })
+				if (editMode) {
+					await share.setEditable(true)
+				}
+
+				const linkData: SameTabLinkTestCaseData = {
+					description: 'internal URL without share token',
+					getLinkUrl: ({ targetPage }: GetCollectiveUrlParameters) => targetPage.getPageUrl(),
+					getExpectedUrl: ({ baseURL, targetPage, shareToken }: GetCollectiveUrlParameters) => (new URL(targetPage.getPageUrl(shareToken), baseURL)).href,
+				}
+
+				await testLinkOpensInSameTab({
+					baseURL,
+					page,
+					user,
+					editor,
+					sourcePage,
+					targetPage,
+					targetCollective: collective,
+					linkData,
+					editMode,
+					shareToken: share.data.token,
+					trigger,
+				})
+
+				await share.delete()
+			})
+		}
+	}
+})

--- a/playwright/support/helpers/links.ts
+++ b/playwright/support/helpers/links.ts
@@ -146,6 +146,7 @@ export async function testLinkOpensInViewer({
  * @param options.linkData test case data
  * @param options.editMode whether to test in edit mode or preview mode
  * @param options.shareToken share token if the page is a share
+ * @param options.trigger trigger to open the link
  */
 export async function testLinkOpensInSameTab({
 	baseURL,

--- a/playwright/support/helpers/links.ts
+++ b/playwright/support/helpers/links.ts
@@ -42,6 +42,8 @@ export type NewTabLinkTestCaseData = {
 	getExpectedUrl: (params: GetUrlParameters) => string
 }
 
+type LinkTrigger = 'preview' | 'openLinkButton' | 'ctrlClick'
+
 export type ViewerLinkTestCase = {
 	page: Page
 	user: User
@@ -63,6 +65,7 @@ export type SameTabLinkTestCase = {
 	linkData: SameTabLinkTestCaseData
 	editMode: boolean
 	shareToken?: string
+	trigger?: LinkTrigger
 }
 
 export type NewTabLinkTestCase = {
@@ -111,7 +114,7 @@ export async function testLinkOpensInViewer({
 	await sourcePage.open(false)
 	await sourcePage.switchMode(editMode)
 	editor.setMode(editMode)
-	await editor.openLink({ linkText })
+	await editor.openLinkViaBubblePreview({ linkText })
 	await expect(sourcePage.getViewerContent()
 		.locator('.modal-header'))
 		.toContainText(linkData.fixtureName)
@@ -155,6 +158,7 @@ export async function testLinkOpensInSameTab({
 	linkData,
 	editMode,
 	shareToken,
+	trigger,
 }: SameTabLinkTestCase) {
 	const linkText = 'Link Text'
 	if (!targetPage || !targetCollective) {
@@ -171,10 +175,17 @@ export async function testLinkOpensInSameTab({
 	await sourcePage.open(false, shareToken)
 	await sourcePage.switchMode(editMode)
 	editor.setMode(editMode)
-	await editor.openCollectiveLink({
-		linkText,
-		pageTitle,
-	})
+
+	if (trigger === 'openLinkButton') {
+		await editor.openLinkViaOpenLinkButton({ linkText })
+	} else if (trigger === 'ctrlClick') {
+		await editor.ctrlClickLink({ linkText })
+	} else {
+		await editor.openCollectiveLinkViaBubblePreview({
+			linkText,
+			pageTitle,
+		})
+	}
 
 	await expect(page).toHaveURL(linkData.getExpectedUrl({ baseURL, collective: targetCollective, targetPage, shareToken }))
 }
@@ -215,7 +226,7 @@ export async function testLinkOpensInNewTab({
 	await sourcePage.switchMode(editMode)
 	editor.setMode(editMode)
 	const newTabPromise = page.waitForEvent('popup')
-	await editor.openLink({ linkText })
+	await editor.openLinkViaBubblePreview({ linkText })
 	const newTab = await newTabPromise
 	await newTab.waitForLoadState()
 

--- a/playwright/support/sections/EditorSection.ts
+++ b/playwright/support/sections/EditorSection.ts
@@ -75,34 +75,52 @@ export class EditorSection {
 		await this.getContent()
 			.getByRole('link', { name: linkText, exact: true })
 			.click()
-		await this.page.locator('.widgets--list')
+		await this.page.locator('.link-view-bubble')
 			.waitFor({ state: 'visible' })
-		return this.page.locator('.widgets--list')
+		return this.page.locator('.link-view-bubble')
 	}
 
 	public async hasCollectiveLink(linkText: string): Promise<void> {
 		await expect((await this.getLinkBubble(linkText))
-			.locator('.collective-page .title'))
+			.locator('.widgets--list .collective-page .title'))
 			.toHaveText(linkText)
 		// Click somewhere else to close the link bubble
 		await this.getContent()
 			.click()
 	}
 
-	public async openLink({ linkText }: {
+	public async openLinkViaBubblePreview({ linkText }: {
 		linkText: string
 	}): Promise<void> {
-		const link = await this.getLinkBubble(linkText)
-		await link
+		const linkBubble = await this.getLinkBubble(linkText)
+		await linkBubble
+			.locator('.widgets--list')
 			.getByRole('link')
 			.click()
+	}
+
+	public async openLinkViaOpenLinkButton({ linkText }: {
+		linkText: string
+	}): Promise<void> {
+		const linkBubble = await this.getLinkBubble(linkText)
+		await linkBubble
+			.getByRole('button', { name: 'Open link' })
+			.click()
+	}
+
+	public async ctrlClickLink({ linkText }: {
+		linkText: string
+	}): Promise<void> {
+		await this.getContent()
+			.getByRole('link', { name: linkText, exact: true })
+			.click({ modifiers: ['Control'] })
 	}
 
 	public async save(): Promise<void> {
 		await this.editor.getByRole('button', { name: 'Save document' }).click()
 	}
 
-	public async openCollectiveLink({ linkText, pageTitle }: {
+	public async openCollectiveLinkViaBubblePreview({ linkText, pageTitle }: {
 		linkText: string
 		pageTitle?: string
 	}): Promise<void> {

--- a/src/components/PagePreview.vue
+++ b/src/components/PagePreview.vue
@@ -53,7 +53,6 @@
 
 <script lang="ts">
 import { t } from '@nextcloud/l10n'
-import { generateUrl } from '@nextcloud/router'
 import { defineComponent } from 'vue'
 import NcUserBubble from '@nextcloud/vue/components/NcUserBubble'
 import PageIcon from './Icon/PageIcon.vue'
@@ -143,18 +142,13 @@ export default defineComponent({
 		t,
 
 		clickLink(event: Event) {
-			if (this.notFound || !this.link) {
+			if (!this.link) {
 				return false
 			}
 
-			const appUrl = '/apps/collectives'
-			const linkUrl = new URL(this.link, window.location)
-			// Only consider rerouting if we're inside the collectives app and for links to collectives app
-			if (window.OCA.Collectives?.vueRouter
-				&& linkUrl.pathname.toString().startsWith(generateUrl(appUrl))) {
+			if (window.OCA.Collectives?.openLink) {
 				event.preventDefault()
-				const collectivesUrl = linkUrl.href.substring(linkUrl.href.indexOf(appUrl) + appUrl.length)
-				window.OCA.Collectives.vueRouter.push(collectivesUrl)
+				window.OCA.Collectives.openLink(this.link)
 			}
 		},
 	},

--- a/src/composables/useCollectivesLinkHandler.ts
+++ b/src/composables/useCollectivesLinkHandler.ts
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Pinia } from 'pinia'
+import type { Router } from 'vue-router'
+import type { Collective } from '../types.ts'
+
+import { generateUrl } from '@nextcloud/router'
+import { useCollectivesStore } from '../stores/collectives.js'
+import { useRootStore } from '../stores/root.js'
+
+/**
+ * Check whether a URL collective segment (slug or name form) refers to
+ * the same collective as `currentCollective`.
+ *
+ * @param segment - URL-encoded collective segment
+ * @param currentCollective - store object with id, name, slug
+ */
+function isSegmentSameCollective(segment: string, currentCollective: Collective | null | undefined) {
+	if (!currentCollective) {
+		return false
+	}
+	const decoded = decodeURIComponent(segment)
+	// Try slug form: "CollectiveName-123"
+	const slugMatch = decoded.match(/^(.+)-(\d+)$/)
+	if (slugMatch) {
+		return Number(slugMatch[2]) === currentCollective.id
+	}
+	// Fall back to name form
+	return decoded === currentCollective.name
+}
+
+/**
+ * Create the smart Collectives link opener.
+ * Must be called after pinia and router are set up.
+ *
+ * @param router Vue Router instance
+ * @param pinia Pinia instance
+ */
+export function createOpenCollectivesLink(router: Router, pinia: Pinia) {
+	return function openCollectivesLink(href: string) {
+		const rootStore = useRootStore(pinia)
+		const collectivesStore = useCollectivesStore(pinia)
+
+		let linkUrl: URL
+		try {
+			linkUrl = new URL(href, window.location.href)
+		} catch {
+			window.open(href, '_blank')
+			return
+		}
+
+		const collectivesBase = generateUrl('/apps/collectives')
+		if (!linkUrl.pathname.startsWith(collectivesBase)) {
+			window.open(linkUrl.href, '_blank')
+			return
+		}
+
+		// The path inside the collectives router (everything after /apps/collectives)
+		const pathInRouter = linkUrl.pathname.slice(collectivesBase.length) || '/'
+		const searchAndHash = linkUrl.search + linkUrl.hash
+
+		// Is the target a public share URL? Matches /p/<token>[/...]
+		const publicShareMatch = pathInRouter.match(/^\/p\/([^/]+)(\/.*)?$/)
+
+		if (rootStore.isPublic) {
+			const currentToken = rootStore.shareTokenParam
+
+			if (publicShareMatch) {
+				// public → public: navigate directly (same or different token, router handles it)
+				router.push(pathInRouter + searchAndHash)
+			} else {
+				// public → internal: check if same collective
+				// pathInRouter looks like /<collectiveSegment>[/...]
+				const internalMatch = pathInRouter.match(/^\/([^/]+)(\/.*)?$/)
+				if (!internalMatch) {
+					window.open(linkUrl.href, '_blank')
+					return
+				}
+				const collectiveSegment = internalMatch[1]
+				const rest = internalMatch[2] || ''
+
+				if (isSegmentSameCollective(collectiveSegment, collectivesStore.currentCollective)) {
+					// Rewrite to /p/<token>/<segment><rest>
+					router.push(`/p/${currentToken}/${collectiveSegment}${rest}${searchAndHash}`)
+				} else {
+					// Different collective — open in new tab
+					window.open(linkUrl.href, '_blank')
+				}
+			}
+		} else {
+			if (publicShareMatch) {
+				// authenticated → public share link: strip /p/<token>
+				const rest = publicShareMatch[2] || '/'
+				router.push(rest + searchAndHash)
+			} else {
+				// authenticated → internal: navigate directly
+				router.push(pathInRouter + searchAndHash)
+			}
+		}
+	}
+}

--- a/src/composables/useEditor.ts
+++ b/src/composables/useEditor.ts
@@ -110,6 +110,7 @@ export function useEditor(davContent: Ref<string>) {
 					return getLinkWithPicker('collectives-ref-pages', false)
 				},
 			},
+			openLinkHandler: window.OCA.Collectives.openLink,
 			onCreate: ({ markdown }: { markdown: string }) => {
 				updateEditorContentDebounced(markdown)
 			},

--- a/src/composables/useReader.ts
+++ b/src/composables/useReader.ts
@@ -122,6 +122,7 @@ export function useReader(content: Ref<string>) {
 				component: 'page-info-bar',
 				props: {},
 			},
+			openLinkHandler: window.OCA.Collectives.openLink,
 			onOutlineToggle: pagesStore.setOutlineForCurrentPage,
 			onLoaded: () => {
 				nextTick(updateReadonlyBarProps)

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@
 import { createPinia } from 'pinia'
 import { createApp, watchEffect } from 'vue'
 import CollectivesApp from './CollectivesApp.vue'
+import { createOpenCollectivesLink } from './composables/useCollectivesLinkHandler.ts'
 import router from './router.js'
 import { useCollectivesStore } from './stores/collectives.js'
 import { usePagesStore } from './stores/pages.js'
@@ -15,12 +16,13 @@ if ('serviceWorker' in navigator) {
 	registerServiceWorker()
 }
 
+const pinia = createPinia()
+
 window.OCA.Collectives = {
 	...window.OCA.Collectives,
 	vueRouter: router,
+	openLink: createOpenCollectivesLink(router, pinia),
 }
-
-const pinia = createPinia()
 
 const app = createApp(CollectivesApp)
 app.use(pinia)

--- a/src/stores/pages.js
+++ b/src/stores/pages.js
@@ -45,7 +45,7 @@ export const usePagesStore = defineStore('pages', {
 	getters: {
 		collectiveId() {
 			const collectivesStore = useCollectivesStore()
-			return collectivesStore.currentCollective.id
+			return collectivesStore.currentCollective?.id
 		},
 
 		collectiveIndex(state) {


### PR DESCRIPTION
### 📝 Summary

Ensures that link navigation always uses the collectives link handler, regardless of whether clicking the preview, the "Open link" button in the link bubble, or Ctrl-clicking the link directly.

Requires https://github.com/nextcloud/text/pull/8571

* Fixes: #2378

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
