### PR TITLE
Docs: Add Community Talk Button to Frontpage

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -53,7 +53,7 @@ section {
 	#feature-media-desktop {
 		display: flex;
 		justify-content: center;
-		margin-bottom: 3em;
+		margin-bottom: 4em;
 	}
 
 	#feature-media-desktop img {
@@ -106,7 +106,7 @@ section {
 	justify-content: center;
 	gap: 3em;
     color: var(--collectives-brown);
-	margin-bottom: 3em;
+	margin-bottom: 4em;
 }
 
 #features div {
@@ -187,7 +187,7 @@ button, button:hover, button:active {
 	flex-wrap: wrap;
 	justify-content: center;
 	gap: 2em;
-	margin-bottom: 3em;
+	margin-bottom: 4em;
 }
 
 .btn-wrap {
@@ -202,7 +202,7 @@ button, button:hover, button:active {
 	margin-left: 10px;
 	margin-top: 0px;
 	margin-bottom: 0px;
-	text-shadow: 1px 0 15px var(--nextcloud-blue-darker); 
+	text-shadow: 1px 0 15px var(--nextcloud-blue-darker);
 }
 
 .btn-wrap img {

--- a/docs/content/links/Community/icon.svg
+++ b/docs/content/links/Community/icon.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xml:space="preserve"
+   viewBox="0 0 512 512"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="icon.svg"
+   inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs2" /><sodipodi:namedview
+     id="namedview2"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.60766989"
+     inkscape:cx="437.73767"
+     inkscape:cy="155.51207"
+     inkscape:window-width="1004"
+     inkscape:window-height="1368"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" /><path
+     d="m 256.01099,53.259995 c -109.27953,0 -197.913929,90.786005 -197.913929,202.718315 0,111.9323 88.634399,202.71831 197.913929,202.71831 36.1678,0 71.7147,-10.33466 102.60479,-29.57303 24.37058,9.85768 78.85512,39.2717 91.73893,26.55212 13.50472,-13.19656 -15.83311,-75.6815 -22.97354,-98.73574 C 444.61133,326.25399 453.7697,291.59313 453.7697,256.1373 453.92492,144.046 365.29053,53.259995 256.01099,53.259995 m 0,77.112455 c 67.83403,0 122.62903,56.28414 122.62903,125.60586 0,69.48071 -54.95022,125.60585 -122.62903,125.60585 -67.6788,0 -122.62902,-56.28414 -122.62902,-125.60585 0,-69.32172 54.79499,-125.60586 122.62902,-125.60586"
+     style="fill:#ffffff;stroke-width:1.57099"
+     id="path2" /></svg>

--- a/docs/content/links/Community/index.md
+++ b/docs/content/links/Community/index.md
@@ -1,0 +1,5 @@
++++
+title = 'Community'
+tags = ["links"]
+link = "https://cloud.nextcloud.com/call/2618694936"
++++


### PR DESCRIPTION
### 📝 Summary

* Resolves: # <!-- related GitHub issue -->

Add a button for Community Talk. Adjusted spacing to give a bit more breathing room with growing content.
Opted for the Talk Icon and Label "Community" instead of "Community Talk" to keep cohesive with other label length and felt it's still understandable and accessible enough. See Screenshots for comparison.

#### 🖼️ Screenshots

<img width="1280" height="800" alt="Screen Shot 2026-05-13 at 11 29 28" src="https://github.com/user-attachments/assets/aa060b36-82d6-4597-bed9-77f20908168b" />

<img width="1280" height="800" alt="Screen Shot 2026-05-13 at 11 30 14" src="https://github.com/user-attachments/assets/50bc172f-a4f5-4f9f-8e3d-33faff2903b1" />


