### PR TITLE
fix(CollectiveActions): opening from start page with defined extra action

### DIFF
--- a/src/components/Collective/NcActionCollectiveActions.vue
+++ b/src/components/Collective/NcActionCollectiveActions.vue
@@ -140,7 +140,7 @@ export default {
 			'isCollectiveAdmin',
 		]),
 
-		...mapState(usePagesStore, ['pagesTreeWalk']),
+		...mapState(usePagesStore, ['pagesTreeWalkForCollective']),
 
 		circleLink() {
 			return generateUrl('/apps/contacts/direct/circle/' + this.collective.circleId)
@@ -160,7 +160,7 @@ export default {
 				return null
 			}
 
-			const pageIds = this.pagesTreeWalk().map((p) => p.id)
+			const pageIds = this.pagesTreeWalkForCollective(this.collective).map((p) => p.id)
 			return {
 				title: collectiveExtraAction.title ?? t('collectives', 'Extra action'),
 				click: () => collectiveExtraAction.click(pageIds) ?? function() {},

--- a/src/stores/pages.js
+++ b/src/stores/pages.js
@@ -305,8 +305,27 @@ export const usePagesStore = defineStore('pages', {
 			}
 		},
 
+		visibleSubpagesForCollective(state) {
+			return (collective, parentId) => {
+				return state.sortedSubpagesForCollective(collective, parentId)
+			}
+		},
+
 		visibleSubpages: (state) => (parentId) => {
 			return state.sortedSubpages(parentId)
+		},
+
+		pagesTreeWalkForCollective(state) {
+			return (collective, parentId = 0) => {
+				const pages = []
+				for (const page of state.visibleSubpagesForCollective(collective, parentId)) {
+					pages.push(page)
+					for (const subpage of state.pagesTreeWalkForCollective(collective, page.id)) {
+						pages.push(subpage)
+					}
+				}
+				return pages
+			}
 		},
 
 		pagesTreeWalk: (state) => (parentId = 0) => {
@@ -352,6 +371,9 @@ export const usePagesStore = defineStore('pages', {
 
 		sortByDefault() {
 			const collectivesStore = useCollectivesStore()
+			if (!collectivesStore.currentCollective) {
+				return 'byOrder'
+			}
 			return sortOrders.pageOrdersByNumber[collectivesStore.currentCollective.userPageOrder]
 		},
 


### PR DESCRIPTION
Opening the three-dot menu in the collectives list without a current collective (i.e. from the app start page) failed when having an extra action defined (e.g. when the pandoc app is installed). This was because getters used in `collectiveExtraAction` computed depended on currentCollective.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
