### PR TITLE
fix(PagePicker): pass title from smart picker to text

### DIFF
--- a/playwright/e2e/page-picker.spec.ts
+++ b/playwright/e2e/page-picker.spec.ts
@@ -43,6 +43,17 @@ test.describe('Custom page picker - local search', () => {
 		await expect(pageWidget).toHaveAttribute('href', origin + targetPage.getPageUrl())
 	})
 
+	test('link to local page has page title as link text', async ({ page, editor }) => {
+		const targetPageItem = editor.pagePicker.locator('.page-preview-item').filter({ hasText: 'Target page' })
+		await targetPageItem.click()
+
+		const targetPagePreview = editor.getContent().locator('.preview').filter({ hasText: 'Target page' })
+		await targetPagePreview.getByLabel('Actions').click()
+		await page.getByRole('menuitemradio', { name: 'Text only' }).click()
+
+		await expect(editor.getContent().getByRole('link', { name: 'Target page', exact: true })).toBeVisible()
+	})
+
 	test('searching "landing page" lists landing pages', async ({ editor }) => {
 		await editor.pagePickerSearch.pressSequentially('landing page')
 

--- a/src/composables/useEditor.ts
+++ b/src/composables/useEditor.ts
@@ -9,7 +9,7 @@ import type { TextEditorInstance } from '../types.ts'
 import { t } from '@nextcloud/l10n'
 import debounce from 'debounce'
 import { computed, defineCustomElement, markRaw, nextTick, onBeforeUnmount, ref, watch } from 'vue'
-import { getLinkWithPicker } from '@nextcloud/vue/components/NcRichText'
+import { getReferenceWithPicker } from '@nextcloud/vue/components/NcRichText'
 import PageIcon from '../components/Icon/PageIcon.vue'
 import { useCirclesStore } from '../stores/circles.js'
 import { useCollectivesStore } from '../stores/collectives.js'
@@ -107,7 +107,7 @@ export function useEditor(davContent: Ref<string>) {
 				label: t('collectives', 'Link to page'),
 				icon: 'page-icon',
 				action: () => {
-					return getLinkWithPicker('collectives-ref-pages', false)
+					return getReferenceWithPicker('collectives-ref-pages', false)
 				},
 			},
 			openLinkHandler: window.OCA.Collectives.openLink,

--- a/src/views/PagePicker.vue
+++ b/src/views/PagePicker.vue
@@ -225,6 +225,14 @@ export default defineComponent({
 					+ generateUrl('/apps/collectives')
 					+ collectivePath
 					+ '/' + pagePath
+				const pickerReference = {
+					link: pageLink,
+					title: page.title,
+				}
+				this.$el.dispatchEvent(new CustomEvent('pick', {
+					bubbles: true,
+					detail: pickerReference,
+				}))
 				this.$el.dispatchEvent(new CustomEvent('submit', {
 					bubbles: true,
 					detail: pageLink,


### PR DESCRIPTION
Requires: nextcloud-libraries/nextcloud-vue#8532
Requires: nextcloud/text#8615

Fixes: #1583

We should only release this after nextcloud/text#8615 got released.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
