### PR TITLE
feat: allow users to get notified about changes in a collective

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -148,6 +148,8 @@ return [
 			'requirements' => ['apiVersion' => '(1.0)', 'collectiveId' => '\d+']],
 		['name' => 'collectiveUserSettings#setFavoritePages', 'url' => '/api/v{apiVersion}/collectives/{collectiveId}/userSettings/favoritePages', 'verb' => 'PUT',
 			'requirements' => ['apiVersion' => '(1.0)', 'collectiveId' => '\d+']],
+		['name' => 'collectiveUserSettings#setNotify', 'url' => '/api/v{apiVersion}/collectives/{collectiveId}/userSettings/notify', 'verb' => 'PUT',
+			'requirements' => ['apiVersion' => '(1.0)', 'collectiveId' => '\d+']],
 
 		// Session API
 		['name' => 'session#create', 'url' => '/api/v{apiVersion}/collectives/{collectiveId}/sessions', 'verb' => 'POST',

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -30,6 +30,7 @@ use OCA\Collectives\Listeners\TextMentionListener;
 use OCA\Collectives\Middleware\PublicOCSMiddleware;
 use OCA\Collectives\Mount\CollectiveFolderManager;
 use OCA\Collectives\Mount\MountProvider;
+use OCA\Collectives\Notification\Notifier;
 use OCA\Collectives\Reference\SearchablePageReferenceProvider;
 use OCA\Collectives\Search\CollectiveProvider;
 use OCA\Collectives\Search\PageContentProvider;
@@ -81,6 +82,8 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(ShareDeletedEvent::class, ShareDeletedListener::class);
 		$context->registerEventListener(RenderReferenceEvent::class, CollectivesReferenceListener::class);
 		$context->registerEventListener(MentionEvent::class, TextMentionListener::class);
+
+		$context->registerNotifierService(Notifier::class);
 
 		$context->registerMiddleware(PublicOCSMiddleware::class);
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -29,6 +29,7 @@ use OCA\Collectives\Listeners\TextMentionListener;
 use OCA\Collectives\Middleware\PublicOCSMiddleware;
 use OCA\Collectives\Mount\CollectiveFolderManager;
 use OCA\Collectives\Mount\MountProvider;
+use OCA\Collectives\Notification\Notifier;
 use OCA\Collectives\Reference\SearchablePageReferenceProvider;
 use OCA\Collectives\Search\CollectiveProvider;
 use OCA\Collectives\Search\PageContentProvider;
@@ -80,6 +81,8 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(ShareDeletedEvent::class, ShareDeletedListener::class);
 		$context->registerEventListener(RenderReferenceEvent::class, CollectivesReferenceListener::class);
 		$context->registerEventListener(MentionEvent::class, TextMentionListener::class);
+
+		$context->registerNotifierService(Notifier::class);
 
 		$context->registerMiddleware(PublicOCSMiddleware::class);
 

--- a/lib/Controller/CollectiveController.php
+++ b/lib/Controller/CollectiveController.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace OCA\Collectives\Controller;
 
 use OCA\Collectives\Db\Collective;
-use OCA\Collectives\Fs\NodeHelper;
 use OCA\Collectives\ResponseDefinitions;
 use OCA\Collectives\Service\CircleExistsException;
 use OCA\Collectives\Service\CollectiveService;
@@ -44,7 +43,6 @@ class CollectiveController extends OCSController {
 		private IUserSession $userSession,
 		private IFactory $l10nFactory,
 		private LoggerInterface $logger,
-		private NodeHelper $nodeHelper,
 		private ?string $userId,
 	) {
 		parent::__construct($appName, $request);

--- a/lib/Controller/CollectiveUserSettingsController.php
+++ b/lib/Controller/CollectiveUserSettingsController.php
@@ -131,4 +131,28 @@ class CollectiveUserSettingsController extends OCSController {
 		}, $this->logger);
 		return new DataResponse([]);
 	}
+
+	/**
+	 * Set whether the user wants notifications about changes in this collective
+	 *
+	 * @param int $collectiveId ID of the collective
+	 * @param bool $subscribe Whether to receive notifications for changes
+	 *
+	 * @return DataResponse<Http::STATUS_OK, list<empty>, array{}>
+	 * @throws OCSNotFoundException Collective not found
+	 * @throws OCSForbiddenException Not permitted
+	 *
+	 * 200: notify setting was set
+	 */
+	#[NoAdminRequired]
+	public function setNotify(int $collectiveId, bool $notify): DataResponse {
+		$this->handleErrorResponse(function () use ($collectiveId, $notify): void {
+			$this->service->setNotify(
+				$collectiveId,
+				$this->getUid(),
+				$notify
+			);
+		}, $this->logger);
+		return new DataResponse([]);
+	}
 }

--- a/lib/Controller/CollectiveUserSettingsController.php
+++ b/lib/Controller/CollectiveUserSettingsController.php
@@ -136,16 +136,16 @@ class CollectiveUserSettingsController extends OCSController {
 	 * Set whether the user wants notifications about changes in this collective
 	 *
 	 * @param int $collectiveId ID of the collective
-	 * @param bool $subscribe Whether to receive notifications for changes
+	 * @param int $notify Notification level (0=off, 1=mentions only, 2=all changes)
 	 *
 	 * @return DataResponse<Http::STATUS_OK, list<empty>, array{}>
 	 * @throws OCSNotFoundException Collective not found
 	 * @throws OCSForbiddenException Not permitted
 	 *
-	 * 200: notify setting was set
+	 * 200: notify level was set
 	 */
 	#[NoAdminRequired]
-	public function setNotify(int $collectiveId, bool $notify): DataResponse {
+	public function setNotify(int $collectiveId, int $notify): DataResponse {
 		$this->handleErrorResponse(function () use ($collectiveId, $notify): void {
 			$this->service->setNotify(
 				$collectiveId,

--- a/lib/Controller/OCSExceptionHelper.php
+++ b/lib/Controller/OCSExceptionHelper.php
@@ -29,13 +29,13 @@ trait OCSExceptionHelper {
 		try {
 			return $callback();
 		} catch (NotPermittedException $e) {
-			$logger?->debug('Collectives app NotPermitted Error: ' . $e->getMessage(), ['exception' => $e]);
+			$logger?->debug('Collectives NotPermitted error: ' . $e->getMessage(), ['exception' => $e]);
 			throw new OCSForbiddenException($e->getMessage());
 		} catch (NotFoundException $e) {
-			$logger?->debug('Collectives app NotFound Error: ' . $e->getMessage(), ['exception' => $e]);
+			$logger?->debug('Collectives NotFound error: ' . $e->getMessage(), ['exception' => $e]);
 			throw new OCSNotFoundException($e->getMessage());
 		} catch (UnprocessableEntityException $e) {
-			$logger?->debug('Collectives app Unprocessable Entity: ' . $e->getMessage(), ['exception' => $e]);
+			$logger?->debug('Collectives unprocessable entity: ' . $e->getMessage(), ['exception' => $e]);
 			throw new OCSBadRequestException($e->getMessage());
 		} catch (HintException $e) {
 			throw new OCSBadRequestException($e->getMessage());

--- a/lib/Controller/TemplateController.php
+++ b/lib/Controller/TemplateController.php
@@ -19,7 +19,6 @@ use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
 use OCP\IRequest;
-use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -34,7 +33,6 @@ class TemplateController extends OCSController {
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		private IUserSession $userSession,
 		private TemplateService $templateService,
 		private LoggerInterface $logger,
 		private ?string $userId,

--- a/lib/Db/Collective.php
+++ b/lib/Db/Collective.php
@@ -78,6 +78,7 @@ class Collective extends Entity implements JsonSerializable {
 	protected bool $userShowMembers = Collective::defaultShowMembers;
 	protected bool $userShowRecentPages = Collective::defaultShowRecentPages;
 	protected array $userFavoritePages = [];
+	protected bool $userNotify = false;
 	protected bool $canLeave = false;
 
 	public function getCircleId(): string {
@@ -233,6 +234,14 @@ class Collective extends Entity implements JsonSerializable {
 		$this->userFavoritePages = $userFavoritePages;
 	}
 
+	public function getUserNotify(): bool {
+		return $this->userNotify;
+	}
+
+	public function setUserNotify(bool $userNotify): void {
+		$this->userNotify = $userNotify;
+	}
+
 	public function getUserPermissions(bool $isShare = false): int {
 		// Public shares always get permissions of a simple member plus sharing permission of owner
 		if ($isShare) {
@@ -309,6 +318,7 @@ class Collective extends Entity implements JsonSerializable {
 			'userShowMembers' => $this->userShowMembers,
 			'userShowRecentPages' => $this->userShowRecentPages,
 			'userFavoritePages' => $this->userFavoritePages,
+			'userNotify' => $this->userNotify,
 			'canLeave' => $this->getCanLeave(),
 		];
 	}

--- a/lib/Db/Collective.php
+++ b/lib/Db/Collective.php
@@ -78,7 +78,7 @@ class Collective extends Entity implements JsonSerializable {
 	protected bool $userShowMembers = Collective::defaultShowMembers;
 	protected bool $userShowRecentPages = Collective::defaultShowRecentPages;
 	protected array $userFavoritePages = [];
-	protected bool $userNotify = false;
+	protected int $userNotify = CollectiveUserSettings::NOTIFY_MENTION;
 	protected bool $canLeave = false;
 
 	public function getCircleId(): string {
@@ -234,11 +234,11 @@ class Collective extends Entity implements JsonSerializable {
 		$this->userFavoritePages = $userFavoritePages;
 	}
 
-	public function getUserNotify(): bool {
+	public function getUserNotify(): int {
 		return $this->userNotify;
 	}
 
-	public function setUserNotify(bool $userNotify): void {
+	public function setUserNotify(int $userNotify): void {
 		$this->userNotify = $userNotify;
 	}
 

--- a/lib/Db/CollectiveUserSettings.php
+++ b/lib/Db/CollectiveUserSettings.php
@@ -30,6 +30,7 @@ class CollectiveUserSettings extends Entity implements JsonSerializable {
 		'show_members',
 		'show_recent_pages',
 		'favorite_pages',
+		'notify',
 	];
 
 	protected ?int $collectiveId = null;
@@ -104,6 +105,14 @@ class CollectiveUserSettings extends Entity implements JsonSerializable {
 			throw new NotPermittedException('Invalid favorite pages value.');
 		}
 		$this->setSetting('favorite_pages', $favoritePages);
+	}
+
+	/**
+	 * @throws NotPermittedException
+	 * @throws JsonException
+	 */
+	public function setNotify(bool $notify): void {
+		$this->setSetting('notify', $notify);
 	}
 
 	public function jsonSerialize(): array {

--- a/lib/Db/CollectiveUserSettings.php
+++ b/lib/Db/CollectiveUserSettings.php
@@ -33,6 +33,11 @@ class CollectiveUserSettings extends Entity implements JsonSerializable {
 		'notify',
 	];
 
+	public const NOTIFY_OFF = 0;
+	public const NOTIFY_MENTION = 1;
+	public const NOTIFY_ALL = 2;
+	private const NOTIFY_LEVELS = [self::NOTIFY_OFF, self::NOTIFY_MENTION, self::NOTIFY_ALL];
+
 	protected ?int $collectiveId = null;
 	protected ?string $userId = null;
 	protected int $pageOrder = Collective::defaultPageOrder;
@@ -111,7 +116,10 @@ class CollectiveUserSettings extends Entity implements JsonSerializable {
 	 * @throws NotPermittedException
 	 * @throws JsonException
 	 */
-	public function setNotify(bool $notify): void {
+	public function setNotify(int $notify): void {
+		if (!in_array($notify, self::NOTIFY_LEVELS, true)) {
+			throw new NotPermittedException('Invalid notify value: ' . $notify);
+		}
 		$this->setSetting('notify', $notify);
 	}
 

--- a/lib/Listeners/NodeWrittenListener.php
+++ b/lib/Listeners/NodeWrittenListener.php
@@ -13,18 +13,22 @@ use OCA\Collectives\Db\CollectiveMapper;
 use OCA\Collectives\Db\PageLinkMapper;
 use OCA\Collectives\Fs\MarkdownHelper;
 use OCA\Collectives\Mount\CollectiveStorage;
+use OCA\Collectives\Service\PageService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\Files\File;
 use OCP\IConfig;
+use OCP\IUserSession;
 
 /** @template-implements IEventListener<Event|NodeWrittenEvent> */
 class NodeWrittenListener implements IEventListener {
 	public function __construct(
-		private IConfig $config,
-		private PageLinkMapper $pageLinkMapper,
-		private CollectiveMapper $collectiveMapper,
+		private readonly IConfig $config,
+		private readonly PageLinkMapper $pageLinkMapper,
+		private readonly CollectiveMapper $collectiveMapper,
+		private readonly IUserSession $userSession,
+		private readonly PageService $pageService,
 	) {
 	}
 
@@ -46,5 +50,10 @@ class NodeWrittenListener implements IEventListener {
 
 		$linkedPageIds = MarkdownHelper::getLinkedPageIds($collective, $node->getContent(), $this->config->getSystemValue('trusted_domains', []));
 		$this->pageLinkMapper->updateByPageId($node->getId(), $linkedPageIds);
+
+		$userId = $this->userSession->getUser()?->getUID();
+		if ($userId) {
+			$this->pageService->notifyContentChange($node, $collective, $userId);
+		}
 	}
 }

--- a/lib/Listeners/NodeWrittenListener.php
+++ b/lib/Listeners/NodeWrittenListener.php
@@ -13,11 +13,13 @@ use OCA\Collectives\Db\CollectiveMapper;
 use OCA\Collectives\Db\PageLinkMapper;
 use OCA\Collectives\Fs\MarkdownHelper;
 use OCA\Collectives\Mount\CollectiveStorage;
+use OCA\Collectives\Service\PageService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\Files\File;
 use OCP\IConfig;
+use OCP\IUserSession;
 
 /** @template-implements IEventListener<Event|NodeWrittenEvent> */
 class NodeWrittenListener implements IEventListener {
@@ -25,6 +27,8 @@ class NodeWrittenListener implements IEventListener {
 		private readonly IConfig $config,
 		private readonly PageLinkMapper $pageLinkMapper,
 		private readonly CollectiveMapper $collectiveMapper,
+		private readonly IUserSession $userSession,
+		private readonly PageService $pageService,
 	) {
 	}
 
@@ -46,5 +50,10 @@ class NodeWrittenListener implements IEventListener {
 
 		$linkedPageIds = MarkdownHelper::getLinkedPageIds($collective, $node->getContent(), $this->config->getSystemValue('trusted_domains', []));
 		$this->pageLinkMapper->updateByPageId($node->getId(), $linkedPageIds);
+
+		$userId = $this->userSession->getUser()?->getUID();
+		if ($userId) {
+			$this->pageService->notifyContentChange($node, $collective, $userId);
+		}
 	}
 }

--- a/lib/Listeners/TextMentionListener.php
+++ b/lib/Listeners/TextMentionListener.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace OCA\Collectives\Listeners;
 
+use OCA\Collectives\Db\CollectiveUserSettings;
+use OCA\Collectives\Db\CollectiveUserSettingsMapper;
 use OCA\Collectives\Mount\CollectiveMountPoint;
 use OCA\Collectives\Service\CollectiveService;
 use OCA\Collectives\Service\PageService;
@@ -17,6 +19,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\Notification\AlreadyProcessedException;
 
 /** @template-implements IEventListener<Event|MentionEvent> */
 class TextMentionListener implements IEventListener {
@@ -25,6 +28,7 @@ class TextMentionListener implements IEventListener {
 		private IURLGenerator $urlGenerator,
 		private CollectiveService $collectiveService,
 		private PageService $pageService,
+		private CollectiveUserSettingsMapper $settingsMapper,
 		private ?string $userId,
 	) {
 	}
@@ -44,6 +48,15 @@ class TextMentionListener implements IEventListener {
 		}
 
 		$collective = $this->collectiveService->getCollective($mountPoint->getFolderId(), $this->userId);
+
+		// Skip notification if mentioned user has notifications turned off
+		$mentionedUserId = $event->getNotification()->getUser();
+		$settings = $this->settingsMapper->findByCollectiveAndUser($collective->getId(), $mentionedUserId);
+		$notifyLevel = ($settings?->getSetting('notify')) ?? CollectiveUserSettings::NOTIFY_MENTION;
+		if ($notifyLevel < CollectiveUserSettings::NOTIFY_MENTION) {
+			throw new AlreadyProcessedException();
+		}
+
 		$pageInfo = $this->pageService->findByFile($mountPoint->getFolderId(), $event->getFile(), $this->userId);
 
 		$collectiveLink = $this->urlGenerator->linkToRouteAbsolute('collectives.start.index') . rawurlencode($collective->getName());

--- a/lib/Listeners/TextMentionListener.php
+++ b/lib/Listeners/TextMentionListener.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace OCA\Collectives\Listeners;
 
+use OCA\Collectives\Db\CollectiveUserSettings;
+use OCA\Collectives\Db\CollectiveUserSettingsMapper;
 use OCA\Collectives\Mount\CollectiveMountPoint;
 use OCA\Collectives\Service\CollectiveService;
 use OCA\Collectives\Service\PageService;
@@ -17,6 +19,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\Notification\AlreadyProcessedException;
 
 /** @template-implements IEventListener<Event|MentionEvent> */
 class TextMentionListener implements IEventListener {
@@ -25,6 +28,7 @@ class TextMentionListener implements IEventListener {
 		private readonly IURLGenerator $urlGenerator,
 		private readonly CollectiveService $collectiveService,
 		private readonly PageService $pageService,
+		private readonly CollectiveUserSettingsMapper $settingsMapper,
 		private readonly ?string $userId,
 	) {
 	}
@@ -44,6 +48,15 @@ class TextMentionListener implements IEventListener {
 		}
 
 		$collective = $this->collectiveService->getCollective($mountPoint->getFolderId(), $this->userId);
+
+		// Skip notification if mentioned user has notifications turned off
+		$mentionedUserId = $event->getNotification()->getUser();
+		$settings = $this->settingsMapper->findByCollectiveAndUser($collective->getId(), $mentionedUserId);
+		$notifyLevel = ($settings?->getSetting('notify')) ?? CollectiveUserSettings::NOTIFY_MENTION;
+		if ($notifyLevel < CollectiveUserSettings::NOTIFY_MENTION) {
+			throw new AlreadyProcessedException();
+		}
+
 		$pageInfo = $this->pageService->findByFile($mountPoint->getFolderId(), $event->getFile(), $this->userId);
 
 		$collectiveLink = $this->urlGenerator->linkToRouteAbsolute('collectives.start.index') . rawurlencode($collective->getName());

--- a/lib/Migration/Version000900Date20210614000000.php
+++ b/lib/Migration/Version000900Date20210614000000.php
@@ -21,7 +21,7 @@ class Version000900Date20210614000000 extends SimpleMigrationStep {
 
 		$table = $schema->getTable('collectives');
 		if ($table->hasColumn('circle_unique_id')) {
-			$table->changeColumn('circle_unique_id', [
+			$table->modifyColumn('circle_unique_id', [
 				'length' => 31,
 			]);
 			return $schema;

--- a/lib/Migration/Version020802Date20231004000000.php
+++ b/lib/Migration/Version020802Date20231004000000.php
@@ -41,7 +41,7 @@ class Version020802Date20231004000000 extends SimpleMigrationStep {
 
 			// Required to allow setting other columns without providing a value for `page_order`
 			if ($table->hasColumn('page_order')) {
-				$table->changeColumn('page_order', [
+				$table->modifyColumn('page_order', [
 					'default' => 0,
 				]);
 			}
@@ -51,7 +51,7 @@ class Version020802Date20231004000000 extends SimpleMigrationStep {
 
 		if ($table->getColumn('settings')->getType() === Type::getType('json')) {
 			// `settings` column exists and is JSON, migrate to STRING
-			$table->changeColumn('settings', [
+			$table->modifyColumn('settings', [
 				'type' => Type::getType('string')
 			]);
 			return $schema;

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Notification;
+
+use OCA\Collectives\AppInfo\Application;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use OCP\Notification\INotification;
+use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
+
+class Notifier implements INotifier {
+	public const SUBJECT_PAGE_UPDATED = 'page_updated';
+	public const SUBJECT_PAGE_DELETED = 'page_deleted';
+
+	public function __construct(
+		private IFactory $factory,
+		private IURLGenerator $urlGenerator,
+		private IUserManager $userManager,
+	) {
+	}
+
+	public function getId(): string {
+		return Application::APP_NAME;
+	}
+
+	public function getName(): string {
+		return $this->factory->get(Application::APP_NAME)->t('Collectives');
+	}
+
+	public function prepare(INotification $notification, string $languageCode): INotification {
+		if ($notification->getApp() !== Application::APP_NAME) {
+			throw new UnknownNotificationException();
+		}
+
+		$l = $this->factory->get(Application::APP_NAME, $languageCode);
+		$params = $notification->getSubjectParameters();
+
+		$actingUser = $params['actingUser'];
+		$actingDisplayName = $this->userManager->getDisplayName($actingUser) ?? $actingUser;
+
+		$collectiveRichObject = [
+			'type' => 'highlight',
+			'id' => $params['collectiveId'],
+			'name' => $params['collectiveName'],
+			'link' => $params['collectiveLink'],
+		];
+
+		$pageRichObject = [
+			'type' => 'highlight',
+			'id' => $params['pageId'],
+			'name' => $params['pageTitle'],
+		];
+		if (!empty($params['pageLink'])) {
+			$pageRichObject['link'] = $params['pageLink'];
+		}
+
+		$userRichObject = [
+			'type' => 'user',
+			'id' => $actingUser,
+			'name' => $actingDisplayName,
+		];
+
+		$richParams = [
+			'user' => $userRichObject,
+			'collective' => $collectiveRichObject,
+			'page' => $pageRichObject,
+		];
+
+		$notification->setIcon(
+			$this->urlGenerator->getAbsoluteURL(
+				$this->urlGenerator->imagePath('collectives', 'collectives-dark.svg')
+			)
+		);
+
+		if (!empty($params['pageLink'])) {
+			$notification->setLink($params['pageLink']);
+		} else {
+			$notification->setLink($params['collectiveLink']);
+		}
+
+		switch ($notification->getSubject()) {
+			case self::SUBJECT_PAGE_UPDATED:
+				$notification->setRichSubject(
+					$l->t('{user} updated {page} in {collective}'),
+					$richParams,
+				);
+				break;
+			case self::SUBJECT_PAGE_DELETED:
+				$notification->setRichSubject(
+					$l->t('{user} deleted {page} from {collective}'),
+					$richParams,
+				);
+				break;
+			default:
+				throw new UnknownNotificationException();
+		}
+
+		return $notification;
+	}
+}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -36,6 +36,17 @@ class Notifier implements INotifier {
 		return $this->factory->get(Application::APP_NAME)->t('Collectives');
 	}
 
+	private function setParsedSubjectFromRichSubject(INotification $notification): void {
+		$placeholders = $replacements = [];
+		foreach ($notification->getRichSubjectParameters() as $key => $value) {
+			$placeholders[] = '{' . $key . '}';
+			$replacements[] = $value['name'] ?? '';
+		}
+		$notification->setParsedSubject(
+			str_replace($placeholders, $replacements, $notification->getParsedSubject())
+		);
+	}
+
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== Application::APP_NAME) {
 			throw new UnknownNotificationException();
@@ -104,6 +115,7 @@ class Notifier implements INotifier {
 				throw new UnknownNotificationException();
 		}
 
+		$this->setParsedSubjectFromRichSubject($notification);
 		return $notification;
 	}
 }

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -22,9 +22,9 @@ class Notifier implements INotifier {
 	public const SUBJECT_PAGE_DELETED = 'page_deleted';
 
 	public function __construct(
-		private IFactory $factory,
-		private IURLGenerator $urlGenerator,
-		private IUserManager $userManager,
+		private readonly IFactory $factory,
+		private readonly IURLGenerator $urlGenerator,
+		private readonly IUserManager $userManager,
 	) {
 	}
 
@@ -98,22 +98,17 @@ class Notifier implements INotifier {
 			$notification->setLink($params['collectiveLink']);
 		}
 
-		switch ($notification->getSubject()) {
-			case self::SUBJECT_PAGE_UPDATED:
-				$notification->setRichSubject(
-					$l->t('{user} updated {page} in {collective}'),
-					$richParams,
-				);
-				break;
-			case self::SUBJECT_PAGE_DELETED:
-				$notification->setRichSubject(
-					$l->t('{user} deleted {page} from {collective}'),
-					$richParams,
-				);
-				break;
-			default:
-				throw new UnknownNotificationException();
-		}
+		match ($notification->getSubject()) {
+			self::SUBJECT_PAGE_UPDATED => $notification->setRichSubject(
+				$l->t('{user} updated {page} in {collective}'),
+				$richParams,
+			),
+			self::SUBJECT_PAGE_DELETED => $notification->setRichSubject(
+				$l->t('{user} deleted {page} from {collective}'),
+				$richParams,
+			),
+			default => throw new UnknownNotificationException(),
+		};
 
 		$this->setParsedSubjectFromRichSubject($notification);
 		return $notification;

--- a/lib/Service/CollectiveHelper.php
+++ b/lib/Service/CollectiveHelper.php
@@ -49,6 +49,7 @@ class CollectiveHelper {
 				$c->setUserShowMembers(($settings ? $settings->getSetting('show_members') : null) ?? Collective::defaultShowMembers);
 				$c->setUserShowRecentPages(($settings ? $settings->getSetting('show_recent_pages') : null) ?? Collective::defaultShowRecentPages);
 				$c->setUserFavoritePages(($settings ? $settings->getSetting('favorite_pages') : null) ?? []);
+				$c->setUserNotify(($settings ? $settings->getSetting('notify') : null) ?? false);
 			}
 		}
 		return $collectives;

--- a/lib/Service/CollectiveHelper.php
+++ b/lib/Service/CollectiveHelper.php
@@ -11,6 +11,7 @@ namespace OCA\Collectives\Service;
 
 use OCA\Collectives\Db\Collective;
 use OCA\Collectives\Db\CollectiveMapper;
+use OCA\Collectives\Db\CollectiveUserSettings;
 use OCA\Collectives\Db\CollectiveUserSettingsMapper;
 
 class CollectiveHelper {
@@ -49,7 +50,7 @@ class CollectiveHelper {
 				$c->setUserShowMembers(($settings ? $settings->getSetting('show_members') : null) ?? Collective::defaultShowMembers);
 				$c->setUserShowRecentPages(($settings ? $settings->getSetting('show_recent_pages') : null) ?? Collective::defaultShowRecentPages);
 				$c->setUserFavoritePages(($settings ? $settings->getSetting('favorite_pages') : null) ?? []);
-				$c->setUserNotify(($settings ? $settings->getSetting('notify') : null) ?? false);
+				$c->setUserNotify(($settings ? $settings->getSetting('notify') : null) ?? CollectiveUserSettings::NOTIFY_MENTION);
 			}
 		}
 		return $collectives;

--- a/lib/Service/CollectiveHelper.php
+++ b/lib/Service/CollectiveHelper.php
@@ -50,6 +50,7 @@ class CollectiveHelper {
 				$c->setUserShowMembers(($settings ? $settings->getSetting('show_members') : null) ?? Collective::defaultShowMembers);
 				$c->setUserShowRecentPages(($settings ? $settings->getSetting('show_recent_pages') : null) ?? Collective::defaultShowRecentPages);
 				$c->setUserFavoritePages(($settings ? $settings->getSetting('favorite_pages') : null) ?? []);
+				$c->setUserNotify(($settings ? $settings->getSetting('notify') : null) ?? false);
 			}
 		}
 		return $collectives;

--- a/lib/Service/CollectiveHelper.php
+++ b/lib/Service/CollectiveHelper.php
@@ -12,6 +12,7 @@ namespace OCA\Collectives\Service;
 use Exception;
 use OCA\Collectives\Db\Collective;
 use OCA\Collectives\Db\CollectiveMapper;
+use OCA\Collectives\Db\CollectiveUserSettings;
 use OCA\Collectives\Db\CollectiveUserSettingsMapper;
 
 class CollectiveHelper {
@@ -50,7 +51,7 @@ class CollectiveHelper {
 				$c->setUserShowMembers(($settings ? $settings->getSetting('show_members') : null) ?? Collective::defaultShowMembers);
 				$c->setUserShowRecentPages(($settings ? $settings->getSetting('show_recent_pages') : null) ?? Collective::defaultShowRecentPages);
 				$c->setUserFavoritePages(($settings ? $settings->getSetting('favorite_pages') : null) ?? []);
-				$c->setUserNotify(($settings ? $settings->getSetting('notify') : null) ?? false);
+				$c->setUserNotify(($settings ? $settings->getSetting('notify') : null) ?? CollectiveUserSettings::NOTIFY_MENTION);
 			}
 		}
 		return $collectives;

--- a/lib/Service/CollectiveUserSettingsService.php
+++ b/lib/Service/CollectiveUserSettingsService.php
@@ -113,7 +113,7 @@ class CollectiveUserSettingsService {
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 */
-	public function setNotify(int $collectiveId, string $userId, bool $notify): void {
+	public function setNotify(int $collectiveId, string $userId, int $notify): void {
 		$settings = $this->initSettings($collectiveId, $userId);
 		$settings->setNotify($notify);
 

--- a/lib/Service/CollectiveUserSettingsService.php
+++ b/lib/Service/CollectiveUserSettingsService.php
@@ -108,4 +108,19 @@ class CollectiveUserSettingsService {
 			throw new NotPermittedException($e->getMessage(), 0, $e);
 		}
 	}
+
+	/**
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 */
+	public function setNotify(int $collectiveId, string $userId, bool $notify): void {
+		$settings = $this->initSettings($collectiveId, $userId);
+		$settings->setNotify($notify);
+
+		try {
+			$this->collectiveUserSettingsMapper->insertOrUpdate($settings);
+		} catch (Exception $e) {
+			throw new NotPermittedException($e->getMessage(), 0, $e);
+		}
+	}
 }

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Service;
+
+use OCA\Circles\Model\Member;
+use OCA\Collectives\AppInfo\Application;
+use OCA\Collectives\Db\Collective;
+use OCA\Collectives\Db\CollectiveUserSettingsMapper;
+use OCA\Collectives\Model\PageInfo;
+use OCA\Collectives\Notification\Notifier;
+use OCP\IURLGenerator;
+use OCP\Notification\IManager as INotificationManager;
+use Psr\Log\LoggerInterface;
+
+class NotificationService {
+	public function __construct(
+		private readonly INotificationManager $notificationManager,
+		private readonly CircleHelper $circleHelper,
+		private readonly CollectiveUserSettingsMapper $settingsMapper,
+		private readonly IURLGenerator $urlGenerator,
+		private readonly LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Notify all members of a collective if notifications are enabled.
+	 */
+	public function notifyMembers(
+		Collective $collective,
+		PageInfo $pageInfo,
+		string $subject,
+		string $actingUserId,
+		string $pageRelativePath,
+	): void {
+		try {
+			$circle = $this->circleHelper->getCircle($collective->getCircleUniqueId(), null, true);
+		} catch (MissingDependencyException|NotFoundException|NotPermittedException $e) {
+			$this->logger->warning('Could not fetch circle members for notification: ' . $e->getMessage(), ['exception' => $e]);
+			return;
+		}
+
+		// Collect direct user member IDs
+		$memberUserIds = [];
+		foreach ($circle->getMembers() as $member) {
+			// TODO: also notify indirect circle/team members
+			if ($member->getUserType() === Member::TYPE_USER) {
+				$memberUserIds[] = $member->getUserId();
+			}
+		}
+
+		if (empty($memberUserIds)) {
+			return;
+		}
+
+		// Fetch all user settings for this collective in one query
+		$allSettings = $this->settingsMapper->findByCollectiveId($collective->getId());
+		$notifyUserIds = [];
+		foreach ($allSettings as $setting) {
+			if ($setting->getSetting('notify') === true) {
+				$notifyUserIds[] = $setting->getUserId();
+			}
+		}
+
+		// Build URLs
+		$baseUrl = $this->urlGenerator->linkToRouteAbsolute('collectives.start.index');
+		$collectiveLink = $baseUrl . rawurlencode($collective->getUrlPath());
+		$pageLink = $subject !== Notifier::SUBJECT_PAGE_DELETED
+			? $baseUrl . $pageRelativePath
+			: '';
+
+		$collectiveNameWithEmoji = $collective->getEmoji()
+			? $collective->getEmoji() . ' ' . $collective->getName()
+			: $collective->getName();
+
+		$pageTitleWithEmoji = $pageInfo->getEmoji()
+			? $pageInfo->getEmoji() . ' ' . $pageInfo->getTitle()
+			: $pageInfo->getTitle();
+
+		$subjectParams = [
+			'actingUser' => $actingUserId,
+			'collectiveId' => (string)$collective->getId(),
+			'collectiveName' => $collectiveNameWithEmoji,
+			'collectiveLink' => $collectiveLink,
+			'pageId' => (string)$pageInfo->getId(),
+			'pageTitle' => $pageTitleWithEmoji,
+			'pageLink' => $pageLink,
+		];
+
+		foreach ($memberUserIds as $userId) {
+			// Skip acting and non-notify users
+			if ($userId === $actingUserId) {
+				continue;
+			}
+			if (!in_array($userId, $notifyUserIds, true)) {
+				continue;
+			}
+
+			// Replace existing notifications for this page
+			$filter = $this->notificationManager->createNotification();
+			$filter->setApp(Application::APP_NAME)
+				->setUser($userId)
+				->setObject('page', (string)$pageInfo->getId());
+			$this->notificationManager->markProcessed($filter);
+
+			$notification = $this->notificationManager->createNotification();
+			$notification->setApp(Application::APP_NAME)
+				->setUser($userId)
+				->setDateTime(new \DateTime())
+				->setObject('page', (string)$pageInfo->getId())
+				->setSubject($subject, $subjectParams);
+
+			$this->notificationManager->notify($notification);
+		}
+	}
+}

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -12,6 +12,7 @@ namespace OCA\Collectives\Service;
 use OCA\Circles\Model\Member;
 use OCA\Collectives\AppInfo\Application;
 use OCA\Collectives\Db\Collective;
+use OCA\Collectives\Db\CollectiveUserSettings;
 use OCA\Collectives\Db\CollectiveUserSettingsMapper;
 use OCA\Collectives\Model\PageInfo;
 use OCA\Collectives\Notification\Notifier;
@@ -63,7 +64,7 @@ class NotificationService {
 		$allSettings = $this->settingsMapper->findByCollectiveId($collective->getId());
 		$notifyUserIds = [];
 		foreach ($allSettings as $setting) {
-			if ($setting->getSetting('notify') === true) {
+			if ($setting->getSetting('notify') === CollectiveUserSettings::NOTIFY_ALL) {
 				$notifyUserIds[] = $setting->getUserId();
 			}
 		}

--- a/lib/Service/NotificationService.php
+++ b/lib/Service/NotificationService.php
@@ -50,7 +50,7 @@ class NotificationService {
 		// Collect direct user member IDs
 		$memberUserIds = [];
 		foreach ($circle->getMembers() as $member) {
-			// TODO: also notify indirect circle/team members
+			// Indirect members get detected below
 			if ($member->getUserType() === Member::TYPE_USER) {
 				$memberUserIds[] = $member->getUserId();
 			}
@@ -65,7 +65,24 @@ class NotificationService {
 		$notifyUserIds = [];
 		foreach ($allSettings as $setting) {
 			if ($setting->getSetting('notify') === CollectiveUserSettings::NOTIFY_ALL) {
-				$notifyUserIds[] = $setting->getUserId();
+				$userId = $setting->getUserId();
+
+				// Skip acting user
+				if ($userId === $actingUserId) {
+					continue;
+				}
+				if (in_array($userId, $memberUserIds, true)) {
+					$notifyUserIds[] = $setting->getUserId();
+					continue;
+				}
+
+				// Check for indirect membership
+				$circles = $this->circleHelper->getCircles($userId);
+				$circleIds = array_map(static fn ($circle) => $circle->getSingleId(), $circles);
+
+				if (in_array($collective->getCircleId(), $circleIds, true)) {
+					$notifyUserIds[] = $setting->getUserId();
+				}
 			}
 		}
 
@@ -94,15 +111,7 @@ class NotificationService {
 			'pageLink' => $pageLink,
 		];
 
-		foreach ($memberUserIds as $userId) {
-			// Skip acting and non-notify users
-			if ($userId === $actingUserId) {
-				continue;
-			}
-			if (!in_array($userId, $notifyUserIds, true)) {
-				continue;
-			}
-
+		foreach ($notifyUserIds as $userId) {
 			// Replace existing notifications for this page
 			$filter = $this->notificationManager->createNotification();
 			$filter->setApp(Application::APP_NAME)

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -18,6 +18,7 @@ use OCA\Collectives\Db\TagMapper;
 use OCA\Collectives\Fs\NodeHelper;
 use OCA\Collectives\Fs\UserFolderHelper;
 use OCA\Collectives\Model\PageInfo;
+use OCA\Collectives\Notification\Notifier;
 use OCA\Collectives\Trash\PageTrashBackend;
 use OCA\NotifyPush\Queue\IQueue;
 use OCP\App\IAppManager;
@@ -54,6 +55,7 @@ class PageService {
 		private readonly TagMapper $tagMapper,
 		private readonly PageLinkMapper $pageLinkMapper,
 		private readonly PageInfoTreeBuilderFactory $pageInfoTreeBuilderFactory,
+		private readonly NotificationService $notificationService,
 	) {
 		try {
 			$this->pushQueue = $container->get(IQueue::class);
@@ -727,6 +729,8 @@ class PageService {
 		$pageInfo->setLastUserDisplayName($this->userManager->getDisplayName($userId));
 		$this->updatePage($collectiveId, $pageInfo->getId(), $userId);
 		$this->notifyPush(['collectiveId' => $collectiveId, 'pages' => [$pageInfo]]);
+		$collective = $this->getCollective($collectiveId, $userId);
+		$this->notificationService->notifyMembers($collective, $pageInfo, Notifier::SUBJECT_PAGE_UPDATED, $userId, $this->getPageLink($collective->getUrlPath(), $pageInfo));
 		return $pageInfo;
 	}
 
@@ -945,6 +949,9 @@ class PageService {
 			$this->notifyPush(['collectiveId' => $collectiveId, 'pages' => [$newPageInfo]]);
 		}
 
+		$collective = $this->getCollective($collectiveId, $userId);
+		$this->notificationService->notifyMembers($collective, $newPageInfo, Notifier::SUBJECT_PAGE_UPDATED, $userId, $this->getPageLink($collective->getUrlPath(), $newPageInfo));
+
 		return $newPageInfo;
 	}
 
@@ -1039,6 +1046,8 @@ class PageService {
 		$pageInfo->setEmoji($emoji);
 		$this->updatePage($collectiveId, $pageInfo->getId(), $userId, $emoji);
 		$this->notifyPush(['collectiveId' => $collectiveId, 'pages' => [$pageInfo]]);
+		$collective = $this->getCollective($collectiveId, $userId);
+		$this->notificationService->notifyMembers($collective, $pageInfo, Notifier::SUBJECT_PAGE_UPDATED, $userId, $this->getPageLink($collective->getUrlPath(), $pageInfo));
 		return $pageInfo;
 	}
 
@@ -1188,6 +1197,7 @@ class PageService {
 			throw new NotPermittedException($e->getMessage(), 0, $e);
 		}
 
+		$collective = $this->getCollective($collectiveId, $userId);
 		$this->initTrashBackend();
 		if ($direct || !$this->trashBackend) {
 			// Delete directly if desired or trash is not available
@@ -1195,6 +1205,7 @@ class PageService {
 			$this->pageMapper->deleteByFileId($id);
 			$oldParentPageInfo = $this->removeFromSubpageOrder($collectiveId, $parentId, $id, $userId);
 			$this->notifyPush(['collectiveId' => $collectiveId, 'pages' => [$oldParentPageInfo], 'removed' => [$id]]);
+			$this->notificationService->notifyMembers($collective, $pageInfo, Notifier::SUBJECT_PAGE_DELETED, $userId, $this->getPageLink($collective->getUrlPath(), $pageInfo));
 			return $pageInfo;
 		}
 
@@ -1205,6 +1216,7 @@ class PageService {
 
 		$pageInfo->setTrashTimestamp($trashedPage->getTrashTimestamp());
 		$this->notifyPush(['collectiveId' => $collectiveId, 'pages' => [$pageInfo]]);
+		$this->notificationService->notifyMembers($collective, $pageInfo, Notifier::SUBJECT_PAGE_DELETED, $userId, $this->getPageLink($collective->getUrlPath(), $pageInfo));
 		return $pageInfo;
 	}
 
@@ -1281,5 +1293,17 @@ class PageService {
 			$pagePathRoute,
 			$pageTitleRoute
 		])) . $fileIdQuery;
+	}
+
+	public function notifyContentChange(File $file, Collective $collective, string $userId): void {
+		try {
+			$pageInfo = $this->getPageByFile($file);
+		} catch (\Throwable) {
+			return;
+		}
+		$this->notificationService->notifyMembers(
+			$collective, $pageInfo, Notifier::SUBJECT_PAGE_UPDATED,
+			$userId, $this->getPageLink($collective->getUrlPath(), $pageInfo)
+		);
 	}
 }

--- a/openapi.json
+++ b/openapi.json
@@ -10336,6 +10336,190 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/collectives/api/v{apiVersion}/collectives/{collectiveId}/userSettings/subscribe": {
+            "put": {
+                "operationId": "collective_user_settings-set-subscribe",
+                "summary": "Set whether the user wants notifications about changes in this collective",
+                "tags": [
+                    "collective_user_settings"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "subscribe"
+                                ],
+                                "properties": {
+                                    "subscribe": {
+                                        "type": "boolean",
+                                        "description": "Whether to receive notifications for changes"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "1.0"
+                            ],
+                            "default": "1.0"
+                        }
+                    },
+                    {
+                        "name": "collectiveId",
+                        "in": "path",
+                        "description": "ID of the collective",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "subscribe setting was set",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Collective not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Not permitted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/collectives/api/v{apiVersion}/collectives/{collectiveId}/sessions": {
             "post": {
                 "operationId": "session-create",

--- a/openapi.json
+++ b/openapi.json
@@ -10336,9 +10336,9 @@
                 }
             }
         },
-        "/ocs/v2.php/apps/collectives/api/v{apiVersion}/collectives/{collectiveId}/userSettings/subscribe": {
+        "/ocs/v2.php/apps/collectives/api/v{apiVersion}/collectives/{collectiveId}/userSettings/notify": {
             "put": {
-                "operationId": "collective_user_settings-set-subscribe",
+                "operationId": "collective_user_settings-set-notify",
                 "summary": "Set whether the user wants notifications about changes in this collective",
                 "tags": [
                     "collective_user_settings"
@@ -10358,12 +10358,13 @@
                             "schema": {
                                 "type": "object",
                                 "required": [
-                                    "subscribe"
+                                    "notify"
                                 ],
                                 "properties": {
-                                    "subscribe": {
-                                        "type": "boolean",
-                                        "description": "Whether to receive notifications for changes"
+                                    "notify": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Notification level (0=off, 1=mentions only, 2=all changes)"
                                     }
                                 }
                             }
@@ -10406,7 +10407,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "subscribe setting was set",
+                        "description": "notify level was set",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/playwright/e2e/notifications.spec.ts
+++ b/playwright/e2e/notifications.spec.ts
@@ -6,16 +6,21 @@
 import type { User as Account } from '@nextcloud/e2e-test-server'
 import type { Page } from '@playwright/test'
 
-import { expect } from '@playwright/test'
+import { expect, mergeTests } from '@playwright/test'
+import { notifyLevels } from '../../src/constants.js'
 import { test as createCollectiveTest } from '../support/fixtures/create-collectives.ts'
+import { test as navigationTest } from '../support/fixtures/navigation.ts'
 import { loginAsUser } from '../support/fixtures/random-user.ts'
 import { User } from '../support/fixtures/User.ts'
 import { randomString } from '../support/helpers/randomString.ts'
 import { apiUrl, ocsHeaders } from '../support/helpers/urls.ts'
+import { EditorSection } from '../support/sections/EditorSection.ts'
 
 type MemberFixture = { page: Page, user: User }
 
-const test = createCollectiveTest.extend<{ member: MemberFixture }>({
+const mergedTest = mergeTests(createCollectiveTest, navigationTest)
+
+const test = mergedTest.extend<{ member: MemberFixture }>({
 	// eslint-disable-next-line no-empty-pattern
 	collectiveConfigs: async ({}, use) => use([
 		{ name: randomString(), pages: [{ title: 'Notified Page' }] },
@@ -38,23 +43,50 @@ async function expectNotification(page: Page, collectiveName: string, pageTitle:
 	await expect(notification).toContainText(pageTitle)
 }
 
-test.describe('Notifications', () => {
-	test.beforeEach(async ({ collective }) => {
-		await collective.notify()
-	})
+async function expectNoNotification(page: Page): Promise<void> {
+	await page.locator('.notifications-button').click()
+	const notificationBox = page.locator('#header-menu-notifications')
+	await expect(notificationBox).toBeVisible()
+	const notification = notificationBox.locator('.notification')
+	await expect(notification).toHaveCount(0)
+}
 
-	test('User receives notification when member touches a page', async ({ collective, page, member }) => {
+test.describe('Notifications', () => {
+	test('User receives notification on being mentioned by default', async ({ collective, page, member, user }) => {
 		const testPage = collective.getPageByTitle('Notified Page')
-		await member.page.request.get(
-			apiUrl('v1.0', 'collectives', collective.data.id, 'pages', testPage.data.id, 'touch'),
-			{ headers: ocsHeaders, failOnStatusCode: true },
-		)
+
+		await member.page.goto(testPage.getPageUrl())
+		const memberEditor = new EditorSection(member.page)
+		await memberEditor.switchMode(true)
+		await memberEditor.getContent().pressSequentially(`Mentioning @${user.account.userId}`)
+		const suggestion = memberEditor.getMentionSuggestions().getByText(user.account.userId, { exact: true })
+		await suggestion.click()
+		await memberEditor.save()
 
 		await collective.openCollective()
 		await expectNotification(page, collective.data.name, testPage.data.title)
 	})
 
-	test('User receives notification when member updates page content', async ({ collective, page, member }) => {
+	test('User does not receive notification when notify level is off', async ({ collective, page, member, user }) => {
+		await collective.setNotify(notifyLevels.NOTIFY_OFF)
+
+		const testPage = collective.getPageByTitle('Notified Page')
+
+		await member.page.goto(testPage.getPageUrl())
+		const memberEditor = new EditorSection(member.page)
+		await memberEditor.switchMode(true)
+		await memberEditor.getContent().pressSequentially(`Mentioning @${user.account.userId}`)
+		const suggestion = memberEditor.getMentionSuggestions().getByText(user.account.userId, { exact: true })
+		await suggestion.click()
+		await memberEditor.save()
+
+		await collective.openCollective()
+		await expectNoNotification(page)
+	})
+
+	test('User receives notification when activated and member updates page content', async ({ collective, page, member }) => {
+		await collective.setNotify(notifyLevels.NOTIFY_ALL)
+
 		const testPage = collective.getPageByTitle('Notified Page')
 		await testPage.setContent({
 			content: '# Updated by member',
@@ -63,6 +95,21 @@ test.describe('Notifications', () => {
 		})
 
 		await collective.openCollective()
+		await expectNotification(page, collective.data.name, testPage.data.title)
+	})
+
+	test('User sets notify via UI and receives notification when member touches a page', async ({ collective, page, member, navigation }) => {
+		await collective.openCollective()
+		await navigation.open()
+		await navigation.clickCollectiveMenu(collective.data.name, 'Notifications')
+		await page.getByRole('button', { name: 'All changes', exact: true }).click()
+
+		const testPage = collective.getPageByTitle('Notified Page')
+		await member.page.request.get(
+			apiUrl('v1.0', 'collectives', collective.data.id, 'pages', testPage.data.id, 'touch'),
+			{ headers: ocsHeaders, failOnStatusCode: true },
+		)
+
 		await expectNotification(page, collective.data.name, testPage.data.title)
 	})
 })

--- a/playwright/e2e/notifications.spec.ts
+++ b/playwright/e2e/notifications.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { User as Account } from '@nextcloud/e2e-test-server'
+import type { Page } from '@playwright/test'
+
+import { expect } from '@playwright/test'
+import { test as createCollectiveTest } from '../support/fixtures/create-collectives.ts'
+import { loginAsUser } from '../support/fixtures/random-user.ts'
+import { User } from '../support/fixtures/User.ts'
+import { randomString } from '../support/helpers/randomString.ts'
+import { apiUrl, ocsHeaders } from '../support/helpers/urls.ts'
+
+type MemberFixture = { page: Page, user: User }
+
+const test = createCollectiveTest.extend<{ member: MemberFixture }>({
+	// eslint-disable-next-line no-empty-pattern
+	collectiveConfigs: async ({}, use) => use([
+		{ name: randomString(), pages: [{ title: 'Notified Page' }] },
+	]),
+	member: async ({ collective, browser, baseURL }, use) => {
+		const account: Account = await collective.addMember()
+		const memberPage = await loginAsUser(browser, baseURL, account)
+		await use({ page: memberPage, user: new User(account) })
+		await memberPage.close()
+	},
+})
+
+async function expectNotification(page: Page, collectiveName: string, pageTitle: string): Promise<void> {
+	await page.locator('.notifications-button').click()
+	const notificationBox = page.locator('#header-menu-notifications')
+	await expect(notificationBox).toBeVisible()
+	const notification = notificationBox.locator('.notification').first()
+	await expect(notification).toBeVisible()
+	await expect(notification).toContainText(collectiveName)
+	await expect(notification).toContainText(pageTitle)
+}
+
+test.describe('Notifications', () => {
+	test.beforeEach(async ({ collective }) => {
+		await collective.notify()
+	})
+
+	test('User receives notification when member touches a page', async ({ collective, page, member }) => {
+		const testPage = collective.getPageByTitle('Notified Page')
+		await member.page.request.get(
+			apiUrl('v1.0', 'collectives', collective.data.id, 'pages', testPage.data.id, 'touch'),
+			{ headers: ocsHeaders, failOnStatusCode: true },
+		)
+
+		await collective.openCollective()
+		await expectNotification(page, collective.data.name, testPage.data.title)
+	})
+
+	test('User receives notification when member updates page content', async ({ collective, page, member }) => {
+		const testPage = collective.getPageByTitle('Notified Page')
+		await testPage.setContent({
+			content: '# Updated by member',
+			user: member.user,
+			page: member.page,
+		})
+
+		await collective.openCollective()
+		await expectNotification(page, collective.data.name, testPage.data.title)
+	})
+})

--- a/playwright/start-nextcloud-server.js
+++ b/playwright/start-nextcloud-server.js
@@ -38,11 +38,25 @@ process.on('SIGINT', stop)
 // Start the Nextcloud docker container
 const ip = await start()
 await waitOnNextcloud(ip)
+
+// Install PHP composer
+await runExec(
+	['sh', '-c', 'curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer'],
+	{ user: 'root', verbose: true },
+)
+
+// Download required apps
 await runExec(['git', 'clone', '--depth=1', `--branch=${serverBranch}`, 'https://github.com/nextcloud/circles.git', 'apps/circles'], { verbose: true })
 await runExec(['git', 'clone', '--depth=1', `--branch=${serverBranch}`, 'https://github.com/nextcloud/files_pdfviewer.git', 'apps/files_pdfviewer'], { verbose: true })
+await runExec(['git', 'clone', '--depth=1', `--branch=${serverBranch}`, 'https://github.com/nextcloud/notifications.git', 'apps/notifications'], { verbose: true })
 await runExec(['git', 'clone', '--depth=1', `--branch=${serverBranch}`, 'https://github.com/nextcloud/password_policy.git', 'apps/password_policy'], { verbose: true })
 await runExec(['git', 'clone', '--depth=1', `--branch=${textBranch}`, 'https://github.com/nextcloud/text.git', 'apps/text'], { verbose: true })
-await configureNextcloud(['collectives', 'circles', 'files_pdfviewer', 'files_lock', 'text', 'viewer'])
+
+// Install PHP dependencies for apps where required
+await runExec(['sh', '-c', 'cd apps/notifications && composer install --no-dev --no-scripts --no-cache --no-interaction'], { verbose: true })
+
+// Configure Nextcloud
+await configureNextcloud(['collectives', 'circles', 'files_pdfviewer', 'files_lock', 'notifications', 'text', 'viewer'])
 
 // Idle to wait for shutdown
 while (true) {

--- a/playwright/start-nextcloud-server.js
+++ b/playwright/start-nextcloud-server.js
@@ -53,7 +53,7 @@ await runExec(['git', 'clone', '--depth=1', `--branch=${serverBranch}`, 'https:/
 await runExec(['git', 'clone', '--depth=1', `--branch=${textBranch}`, 'https://github.com/nextcloud/text.git', 'apps/text'], { verbose: true })
 
 // Install PHP dependencies for apps where required
-await runExec(['sh', '-c', 'cd apps/notifications && composer install --no-dev --no-scripts --no-cache --no-interaction'], { verbose: true })
+await runExec(['sh', '-c', 'cd apps/notifications && composer install --no-dev --no-cache --no-interaction'], { verbose: true })
 
 // Configure Nextcloud
 await configureNextcloud(['collectives', 'circles', 'files_pdfviewer', 'files_lock', 'notifications', 'text', 'viewer'])

--- a/playwright/start-nextcloud-server.js
+++ b/playwright/start-nextcloud-server.js
@@ -55,7 +55,7 @@ if (await isServerRunning()) {
 	await waitOnNextcloud(ip)
 	await runExec(['git', 'clone', '--depth=1', `--branch=${serverBranch}`, 'https://github.com/nextcloud/password_policy.git', 'apps/password_policy'], { verbose: true })
 	await runExec(['git', 'clone', '--depth=1', `--branch=${textBranch}`, 'https://github.com/nextcloud/text.git', 'apps/text'], { verbose: true })
-	await configureNextcloud(['collectives', 'circles', 'files_pdfviewer', 'files_lock', 'text', 'viewer'])
+	await configureNextcloud(['collectives', 'circles', 'files_pdfviewer', 'files_lock', 'notifications', 'text', 'viewer'])
 }
 
 // Idle to wait for shutdown

--- a/playwright/support/fixtures/Collective.ts
+++ b/playwright/support/fixtures/Collective.ts
@@ -226,6 +226,13 @@ export class Collective {
 		this.extraMembers.push(account)
 		return account
 	}
+
+	async notify(): Promise<void> {
+		await this.page.request.put(
+			apiUrl('v1.0', 'collectives', this.data.id, 'userSettings', 'notify'),
+			{ headers: ocsHeaders, data: { notify: true }, failOnStatusCode: true },
+		)
+	}
 }
 
 /**

--- a/playwright/support/fixtures/Collective.ts
+++ b/playwright/support/fixtures/Collective.ts
@@ -227,10 +227,10 @@ export class Collective {
 		return account
 	}
 
-	async notify(): Promise<void> {
+	async setNotify(level: number): Promise<void> {
 		await this.page.request.put(
 			apiUrl('v1.0', 'collectives', this.data.id, 'userSettings', 'notify'),
-			{ headers: ocsHeaders, data: { notify: true }, failOnStatusCode: true },
+			{ headers: ocsHeaders, data: { notify: level }, failOnStatusCode: true },
 		)
 	}
 }

--- a/playwright/support/fixtures/random-user.ts
+++ b/playwright/support/fixtures/random-user.ts
@@ -4,6 +4,7 @@
  */
 
 import type { User as Account } from '@nextcloud/e2e-test-server'
+import type { Browser, Page } from '@playwright/test'
 
 import { createRandomUser, login } from '@nextcloud/e2e-test-server/playwright'
 import { test as base } from '@playwright/test'
@@ -12,6 +13,23 @@ import { User } from './User.ts'
 export interface UserFixture {
 	account: Account
 	user: User
+}
+
+/**
+ * Log in as any account in a new browser page and return it.
+ *
+ * @param browser - the browser object
+ * @param baseURL - the base URL
+ * @param account - the user account
+ */
+export async function loginAsUser(browser: Browser, baseURL: string | undefined, account: Account): Promise<Page> {
+	// Important: make sure we authenticate in a clean environment by unsetting storage state.
+	const page = await browser.newPage({ storageState: undefined, baseURL })
+	await login(page.request, account)
+	const tokenResponse = await page.request.get('./csrftoken', { failOnStatusCode: true })
+	const { token } = (await tokenResponse.json()) as { token: string }
+	await page.context().setExtraHTTPHeaders({ requesttoken: token })
+	return page
 }
 
 /**
@@ -24,19 +42,7 @@ export const test = base.extend<object, UserFixture>({
 		await use(account)
 	}, { scope: 'worker' }],
 	page: async ({ account, browser, baseURL }, use) => {
-		// Important: make sure we authenticate in a clean environment by unsetting storage state.
-		const page = await browser.newPage({
-			storageState: undefined,
-			baseURL,
-		})
-
-		await login(page.request, account)
-		const tokenResponse = await page.request.get('./csrftoken', {
-			failOnStatusCode: true,
-		})
-		const { token } = (await tokenResponse.json()) as { token: string }
-		await page.context().setExtraHTTPHeaders({ requesttoken: token })
-
+		const page = await loginAsUser(browser, baseURL, account)
 		await use(page)
 		await page.close()
 	},

--- a/playwright/support/sections/NavigationSection.ts
+++ b/playwright/support/sections/NavigationSection.ts
@@ -45,7 +45,9 @@ export class NavigationSection {
 			.hover()
 		await collectiveItem.getByRole('button', { name: 'Actions' })
 			.click()
-		await this.page.getByRole('button', { name: action, exact: true })
+		// The extra `.action-item__popover` locator is needed to not conflict with other button with same name in DOM
+		await this.page.locator('.action-item__popper:visible')
+			.getByRole('button', { name: action, exact: true })
 			.click()
 	}
 

--- a/src/apis/collectives/collectives.js
+++ b/src/apis/collectives/collectives.js
@@ -9,7 +9,7 @@ import { apiUrl } from './urls.js'
 /**
  * URL for the collectives API
  *
- * @param {Array} parts - URL parts to append - will be joined with `/`
+ * @param {...string} parts - URL parts to append - will be joined with `/`
  */
 function collectivesApiUrl(...parts) {
 	return apiUrl('v1.0', 'collectives', ...parts)
@@ -18,7 +18,7 @@ function collectivesApiUrl(...parts) {
 /**
  * URL for the public collectives API
  *
- * @param {Array} parts - URL parts to append - will be joined with `/`
+ * @param {...string} parts - URL parts to append - will be joined with `/`
  */
 function publicCollectivesApiUrl(...parts) {
 	return apiUrl('v1.0', 'p', 'collectives', ...parts)
@@ -27,7 +27,7 @@ function publicCollectivesApiUrl(...parts) {
 /**
  * URL for the collectives trash API
  *
- * @param {Array} parts - URL parts to append - will be joined with `/`
+ * @param {...string} parts - URL parts to append - will be joined with `/`
  */
 function collectivesTrashApiUrl(...parts) {
 	return collectivesApiUrl('trash', ...parts)

--- a/src/apis/collectives/pages.js
+++ b/src/apis/collectives/pages.js
@@ -10,7 +10,7 @@ import { apiUrl } from './urls.js'
  * URL for the pages API inside the given context.
  *
  * @param {object} context - either the current collective or a share context
- * @param {Array} parts - URL parts to append - will be joined with `/`
+ * @param {...string} parts - URL parts to append - will be joined with `/`
  */
 function pagesApiUrl(context, ...parts) {
 	return context.isPublic
@@ -22,7 +22,7 @@ function pagesApiUrl(context, ...parts) {
  * URL for the page trash API
  *
  * @param {object} context - either the current collective or a share context
- * @param {Array} parts - URL parts to append - will be joined with `/`
+ * @param {...string} parts - URL parts to append - will be joined with `/`
  */
 function pagesTrashApiUrl(context, ...parts) {
 	return pagesApiUrl(context, 'trash', ...parts)
@@ -32,7 +32,7 @@ function pagesTrashApiUrl(context, ...parts) {
  * URL for the page search API
  *
  * @param {object} context - either the current collective or a share context
- * @param {Array} parts - URL parts to append - will be joined with `/`
+ * @param {...string} parts - URL parts to append - will be joined with `/`
  */
 function searchApiUrl(context, ...parts) {
 	return context.isPublic

--- a/src/apis/collectives/settings.js
+++ b/src/apis/collectives/settings.js
@@ -9,7 +9,7 @@ import { apiUrl } from './urls.js'
 /**
  * URL for the settings API
  *
- * @param {Array} parts - URL parts to append - will be joined with `/`
+ * @param {...string} parts - URL parts to append - will be joined with `/`
  */
 function settingsApiUrl(...parts) {
 	return apiUrl('v1.0', 'settings', parts)

--- a/src/apis/collectives/shares.js
+++ b/src/apis/collectives/shares.js
@@ -10,7 +10,7 @@ import { apiUrl } from './urls.js'
  * URL for the collective shares API
  *
  * @param {number} collectiveId - ID of the collective
- * @param {Array} parts - URL parts to append - will be joined with `/`
+ * @param {...string} parts - URL parts to append - will be joined with `/`
  */
 function collectiveSharesApiUrl(collectiveId, ...parts) {
 	return apiUrl('v1.0', 'collectives', collectiveId, 'shares', ...parts)
@@ -21,7 +21,7 @@ function collectiveSharesApiUrl(collectiveId, ...parts) {
  *
  * @param {number} collectiveId - ID of the collective
  * @param {number} pageId - ID of the page
- * @param {Array} parts - URL parts to append - will be joined with `/`
+ * @param {...string} parts - URL parts to append - will be joined with `/`
  */
 function pageSharesApiUrl(collectiveId, pageId, ...parts) {
 	return apiUrl('v1.0', 'collectives', collectiveId, 'pages', pageId, 'shares', ...parts)

--- a/src/apis/collectives/tags.js
+++ b/src/apis/collectives/tags.js
@@ -10,7 +10,7 @@ import { apiUrl } from './urls.js'
  * URL for the collective tags API
  *
  * @param {object} context - either the current collective or a share context
- * @param {Array} parts - URL parts to append - will be joined with `/`
+ * @param {...string} parts - URL parts to append - will be joined with `/`
  */
 function tagApiUrl(context, ...parts) {
 	return context.isPublic

--- a/src/apis/collectives/templates.js
+++ b/src/apis/collectives/templates.js
@@ -10,7 +10,7 @@ import { apiUrl } from './urls.js'
  * URL for templates API inside the given context.
  *
  * @param {object} context - either the current collective or a share context
- * @param {Array} parts - URL parts to append - will be joined with `/`
+ * @param {...string} parts - URL parts to append - will be joined with `/`
  */
 function templatesApiUrl(context, ...parts) {
 	return context.isPublic

--- a/src/apis/collectives/urls.js
+++ b/src/apis/collectives/urls.js
@@ -9,7 +9,7 @@ import { generateOcsUrl } from '@nextcloud/router'
  * URL for the versioned collectives API
  *
  * @param {string} version - Version of the API - currently `v1.0`
- * @param {Array} parts - URL parts to append - will be joined with `/`
+ * @param {...string} parts - URL parts to append - will be joined with `/`
  */
 export function apiUrl(version, ...parts) {
 	const path = ['apps/collectives/api', version, ...parts]

--- a/src/apis/collectives/userSettings.js
+++ b/src/apis/collectives/userSettings.js
@@ -37,7 +37,7 @@ export function setCollectiveUserSettingPageOrder(collectiveId, pageOrder) {
  */
 export function setCollectiveUserSettingShowMembers(collectiveId, showMembers) {
 	return axios.put(
-		collectiveUserSettingsApiUrl(collectiveId, 'showMembers'),
+		collectiveUserSettingsApiUrl(collectiveId, ['showMembers']),
 		{ showMembers },
 	)
 }
@@ -50,7 +50,7 @@ export function setCollectiveUserSettingShowMembers(collectiveId, showMembers) {
  */
 export function setCollectiveUserSettingShowRecentPages(collectiveId, showRecentPages) {
 	return axios.put(
-		collectiveUserSettingsApiUrl(collectiveId, 'showRecentPages'),
+		collectiveUserSettingsApiUrl(collectiveId, ['showRecentPages']),
 		{ showRecentPages },
 	)
 }
@@ -63,7 +63,20 @@ export function setCollectiveUserSettingShowRecentPages(collectiveId, showRecent
  */
 export function setCollectiveUserSettingFavoritePages(collectiveId, favoritePages) {
 	return axios.put(
-		collectiveUserSettingsApiUrl(collectiveId, 'favoritePages'),
+		collectiveUserSettingsApiUrl(collectiveId, ['favoritePages']),
 		{ favoritePages: JSON.stringify(favoritePages) },
+	)
+}
+
+/**
+ * Set whether user gets notified about changes in the collective
+ *
+ * @param {number} collectiveId ID of the collective to be updated
+ * @param {boolean} notify the desired value
+ */
+export function setCollectiveUserSettingNotify(collectiveId, notify) {
+	return axios.put(
+		collectiveUserSettingsApiUrl(collectiveId, ['notify']),
+		{ notify },
 	)
 }

--- a/src/apis/collectives/userSettings.js
+++ b/src/apis/collectives/userSettings.js
@@ -10,10 +10,10 @@ import { apiUrl } from './urls.js'
  * URL for the collective user settings API
  *
  * @param {number} collectiveId - ID of the collective
- * @param {Array} parts - URL parts to append - will be joined with `/`
+ * @param {...string} parts - URL parts to append - will be joined with `/`
  */
 function collectiveUserSettingsApiUrl(collectiveId, ...parts) {
-	return apiUrl('v1.0', 'collectives', collectiveId, 'userSettings', parts)
+	return apiUrl('v1.0', 'collectives', collectiveId, 'userSettings', ...parts)
 }
 
 /**
@@ -37,7 +37,7 @@ export function setCollectiveUserSettingPageOrder(collectiveId, pageOrder) {
  */
 export function setCollectiveUserSettingShowMembers(collectiveId, showMembers) {
 	return axios.put(
-		collectiveUserSettingsApiUrl(collectiveId, ['showMembers']),
+		collectiveUserSettingsApiUrl(collectiveId, 'showMembers'),
 		{ showMembers },
 	)
 }
@@ -50,7 +50,7 @@ export function setCollectiveUserSettingShowMembers(collectiveId, showMembers) {
  */
 export function setCollectiveUserSettingShowRecentPages(collectiveId, showRecentPages) {
 	return axios.put(
-		collectiveUserSettingsApiUrl(collectiveId, ['showRecentPages']),
+		collectiveUserSettingsApiUrl(collectiveId, 'showRecentPages'),
 		{ showRecentPages },
 	)
 }
@@ -63,7 +63,7 @@ export function setCollectiveUserSettingShowRecentPages(collectiveId, showRecent
  */
 export function setCollectiveUserSettingFavoritePages(collectiveId, favoritePages) {
 	return axios.put(
-		collectiveUserSettingsApiUrl(collectiveId, ['favoritePages']),
+		collectiveUserSettingsApiUrl(collectiveId, 'favoritePages'),
 		{ favoritePages: JSON.stringify(favoritePages) },
 	)
 }
@@ -76,7 +76,7 @@ export function setCollectiveUserSettingFavoritePages(collectiveId, favoritePage
  */
 export function setCollectiveUserSettingNotify(collectiveId, notify) {
 	return axios.put(
-		collectiveUserSettingsApiUrl(collectiveId, ['notify']),
+		collectiveUserSettingsApiUrl(collectiveId, 'notify'),
 		{ notify },
 	)
 }

--- a/src/components/Collective/NcActionCollectiveActions.vue
+++ b/src/components/Collective/NcActionCollectiveActions.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<div>
+	<div v-if="!submenu">
 		<NcActionButton
 			v-if="isCollectiveAdmin(collective)"
 			closeAfterClick
@@ -57,14 +57,13 @@
 		</NcActionButton>
 		<NcActionButton
 			v-if="!isPublic"
-			closeAfterClick
+			isMenu
 			:disabled="!networkOnline"
-			@click="toggleNotify()">
+			@click="$emit('update:submenu', 'notifications')">
 			<template #icon>
-				<BellOffOutlineIcon v-if="collective.userNotify" :size="20" />
-				<BellOutlineIcon v-else :size="20" />
+				<BellOutlineIcon :size="20" />
 			</template>
-			{{ notifyString }}
+			{{ t('collectives', 'Notifications') }}
 		</NcActionButton>
 		<NcActionButton
 			v-if="!isPublic && collective.canLeave !== false"
@@ -87,6 +86,28 @@
 			</template>
 		</NcActionButton>
 	</div>
+	<div v-else-if="submenu === 'notifications'">
+		<NcActionButton @click="$emit('update:submenu', null)">
+			<template #icon>
+				<ArrowLeftIcon :size="20" />
+			</template>
+			{{ t('collectives', 'Back') }}
+		</NcActionButton>
+		<NcActionSeparator />
+		<NcActionButton
+			v-for="option in notifyOptions"
+			:key="option.value"
+			closeAfterClick
+			type="radio"
+			:modelValue="String(collective.userNotify)"
+			:value="String(option.value)"
+			@click="setNotify(option.value)">
+			<template #icon>
+				<component :is="option.icon" :size="20" />
+			</template>
+			{{ option.label }}
+		</NcActionButton>
+	</div>
 </template>
 
 <script>
@@ -98,14 +119,17 @@ import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionLink from '@nextcloud/vue/components/NcActionLink'
 import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
 import AccountMultipleIcon from 'vue-material-design-icons/AccountMultipleOutline.vue'
+import ArrowLeftIcon from 'vue-material-design-icons/ArrowLeft.vue'
 import BellOffOutlineIcon from 'vue-material-design-icons/BellOffOutline.vue'
 import BellOutlineIcon from 'vue-material-design-icons/BellOutline.vue'
+import BellRingOutlineIcon from 'vue-material-design-icons/BellRingOutline.vue'
 import CogIcon from 'vue-material-design-icons/CogOutline.vue'
 import LogoutIcon from 'vue-material-design-icons/Logout.vue'
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import ShareVariantIcon from 'vue-material-design-icons/ShareVariantOutline.vue'
 import DownloadIcon from 'vue-material-design-icons/TrayArrowDown.vue'
 import PageTemplateIcon from '../Icon/PageTemplateIcon.vue'
+import { notifyLevels } from '../../constants.js'
 import { useCirclesStore } from '../../stores/circles.js'
 import { useCollectivesStore } from '../../stores/collectives.js'
 import { usePagesStore } from '../../stores/pages.js'
@@ -116,8 +140,10 @@ export default {
 
 	components: {
 		AccountMultipleIcon,
+		ArrowLeftIcon,
 		BellOffOutlineIcon,
 		BellOutlineIcon,
+		BellRingOutlineIcon,
 		CogIcon,
 		DownloadIcon,
 		LogoutIcon,
@@ -130,6 +156,11 @@ export default {
 	},
 
 	props: {
+		submenu: {
+			type: String,
+			default: null,
+		},
+
 		collective: {
 			type: Object,
 			required: true,
@@ -140,6 +171,8 @@ export default {
 			required: true,
 		},
 	},
+
+	emits: ['update:submenu'],
 
 	data() {
 		return {
@@ -165,10 +198,12 @@ export default {
 			return generateUrl(`/apps/collectives${this.collectivePrintPath(this.collective)}`)
 		},
 
-		notifyString() {
-			return this.collective.userNotify
-				? t('collectives', 'No notifications')
-				: t('collectives', 'Notifications')
+		notifyOptions() {
+			return [
+				{ value: notifyLevels.NOTIFY_ALL, icon: BellRingOutlineIcon, label: t('collectives', 'All changes') },
+				{ value: notifyLevels.NOTIFY_MENTION, icon: BellOutlineIcon, label: t('collectives', '@-mentions only') },
+				{ value: notifyLevels.NOTIFY_OFF, icon: BellOffOutlineIcon, label: t('collectives', 'Off') },
+			]
 		},
 
 		/**
@@ -221,11 +256,12 @@ export default {
 			this.setSettingsCollectiveId(this.collective.id)
 		},
 
-		toggleNotify() {
+		setNotify(level) {
 			this.setCollectiveUserSettingNotify({
 				id: this.collective.id,
-				notify: !this.collective.userNotify,
+				notify: level,
 			})
+			this.$emit('update:submenu', null)
 		},
 
 		leaveCollectiveWithUndo(collective) {

--- a/src/components/Collective/NcActionCollectiveActions.vue
+++ b/src/components/Collective/NcActionCollectiveActions.vue
@@ -56,6 +56,17 @@
 			{{ t('collectives', 'Settings') }}
 		</NcActionButton>
 		<NcActionButton
+			v-if="!isPublic"
+			closeAfterClick
+			:disabled="!networkOnline"
+			@click="toggleNotify()">
+			<template #icon>
+				<BellOffOutlineIcon v-if="collective.userNotify" :size="20" />
+				<BellOutlineIcon v-else :size="20" />
+			</template>
+			{{ notifyString }}
+		</NcActionButton>
+		<NcActionButton
 			v-if="!isPublic && collective.canLeave !== false"
 			closeAfterClick
 			:disabled="!networkOnline"
@@ -87,6 +98,8 @@ import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionLink from '@nextcloud/vue/components/NcActionLink'
 import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
 import AccountMultipleIcon from 'vue-material-design-icons/AccountMultipleOutline.vue'
+import BellOffOutlineIcon from 'vue-material-design-icons/BellOffOutline.vue'
+import BellOutlineIcon from 'vue-material-design-icons/BellOutline.vue'
 import CogIcon from 'vue-material-design-icons/CogOutline.vue'
 import LogoutIcon from 'vue-material-design-icons/Logout.vue'
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
@@ -103,6 +116,8 @@ export default {
 
 	components: {
 		AccountMultipleIcon,
+		BellOffOutlineIcon,
+		BellOutlineIcon,
 		CogIcon,
 		DownloadIcon,
 		LogoutIcon,
@@ -150,6 +165,12 @@ export default {
 			return generateUrl(`/apps/collectives${this.collectivePrintPath(this.collective)}`)
 		},
 
+		notifyString() {
+			return this.collective.userNotify
+				? t('collectives', 'No notifications')
+				: t('collectives', 'Notifications')
+		},
+
 		/**
 		 * Other apps can register an extra collective action via
 		 * window.OCA.Collectives.CollectiveExtraAction
@@ -177,6 +198,7 @@ export default {
 			'markCollectiveDeleted',
 			'setMembersCollectiveId',
 			'setSettingsCollectiveId',
+			'setCollectiveUserSettingNotify',
 			'setTemplatesCollectiveId',
 			'unmarkCollectiveDeleted',
 		]),
@@ -197,6 +219,13 @@ export default {
 
 		openCollectiveSettings() {
 			this.setSettingsCollectiveId(this.collective.id)
+		},
+
+		toggleNotify() {
+			this.setCollectiveUserSettingNotify({
+				id: this.collective.id,
+				notify: !this.collective.userNotify,
+			})
 		},
 
 		leaveCollectiveWithUndo(collective) {

--- a/src/components/Nav/CollectiveListItem.vue
+++ b/src/components/Nav/CollectiveListItem.vue
@@ -22,6 +22,7 @@
 		</template>
 		<template #actions>
 			<NcActionCollectiveActions
+				v-model:submenu="collectiveSubmenu"
 				:collective
 				:networkOnline />
 		</template>
@@ -61,6 +62,12 @@ export default {
 	setup() {
 		const isMobile = useIsMobile()
 		return { isMobile }
+	},
+
+	data() {
+		return {
+			collectiveSubmenu: null,
+		}
 	},
 
 	computed: {

--- a/src/components/Page/PageActionMenu.vue
+++ b/src/components/Page/PageActionMenu.vue
@@ -8,137 +8,142 @@
 		<NcActions forceMenu @click.stop>
 			<!-- Collective actions: only displayed for landing page -->
 			<template v-if="isLandingPage">
-				<NcActionCollectiveActions :collective="currentCollective" :networkOnline />
-				<NcActionSeparator />
+				<NcActionCollectiveActions
+					v-model:submenu="collectiveSubmenu"
+					:collective="currentCollective"
+					:networkOnline />
+				<NcActionSeparator v-if="!collectiveSubmenu" />
 			</template>
 
-			<!-- Last edited info -->
-			<NcActionLastUser
-				v-if="displayLastEditedInfo"
-				:lastUserId
-				:lastUserDisplayName
-				:timestamp />
-			<NcActionSeparator v-if="displayLastEditedInfo" />
+			<template v-if="!collectiveSubmenu">
+				<!-- Last edited info -->
+				<NcActionLastUser
+					v-if="displayLastEditedInfo"
+					:lastUserId
+					:lastUserDisplayName
+					:timestamp />
+				<NcActionSeparator v-if="displayLastEditedInfo" />
 
-			<!-- Sidebar toggle: only displayed on mobile and in page title menu -->
-			<template v-if="displaySidebarAction">
+				<!-- Sidebar toggle: only displayed on mobile and in page title menu -->
+				<template v-if="displaySidebarAction">
+					<NcActionButton
+						:aria-label="t('collectives', 'Open page sidebar')"
+						aria-controls="app-sidebar-vue"
+						closeAfterClick
+						@click="toggleSidebar()">
+						<template #icon>
+							<DockRightIcon :size="20" />
+						</template>
+						{{ t('collectives', 'Open page sidebar') }}
+					</NcActionButton>
+					<NcActionSeparator />
+				</template>
+
+				<!-- Page view options: only displayed in page title menu -->
+				<template v-if="!inPageList">
+					<NcActionCheckbox
+						v-if="!isMobile"
+						v-model="currentPage.isFullWidth"
+						:disabled="!networkOnline || !currentCollectiveCanEdit"
+						@check="onCheckFullWidthView"
+						@uncheck="onUncheckFullWidthView">
+						{{ t('collectives', 'Full width') }}
+					</NcActionCheckbox>
+					<NcActionButton
+						closeAfterClick
+						@click="toggleOutline(currentPageId)">
+						<template #icon>
+							<FormatListBulletedIcon :size="20" />
+						</template>
+						{{ toggleOutlineString }}
+					</NcActionButton>
+					<NcActionSeparator v-if="!inPageList" />
+				</template>
+
+				<!-- Favor page action: not displayed for landing page -->
 				<NcActionButton
-					:aria-label="t('collectives', 'Open page sidebar')"
-					aria-controls="app-sidebar-vue"
+					v-if="!isLandingPage"
 					closeAfterClick
-					@click="toggleSidebar()">
+					:disabled="!networkOnline"
+					@click="toggleFavoritePage({ id: currentCollective.id, pageId })">
 					<template #icon>
-						<DockRightIcon :size="20" />
+						<StarOffIcon v-if="isFavoritePage(currentCollective.id, pageId)" :size="20" />
+						<StarIcon v-else :size="20" />
 					</template>
-					{{ t('collectives', 'Open page sidebar') }}
+					{{ toggleFavoriteString }}
 				</NcActionButton>
-				<NcActionSeparator />
-			</template>
 
-			<!-- Page view options: only displayed in page title menu -->
-			<template v-if="!inPageList">
-				<NcActionCheckbox
-					v-if="!isMobile"
-					v-model="currentPage.isFullWidth"
-					:disabled="!networkOnline || !currentCollectiveCanEdit"
-					@check="onCheckFullWidthView"
-					@uncheck="onUncheckFullWidthView">
-					{{ t('collectives', 'Full width') }}
-				</NcActionCheckbox>
+				<!-- Share page action: not displayed for landing page (already in collectives actions there) -->
 				<NcActionButton
+					v-if="currentCollectiveCanShare && !isLandingPage"
 					closeAfterClick
-					@click="toggleOutline(currentPageId)">
+					@click="openShareTab">
 					<template #icon>
-						<FormatListBulletedIcon :size="20" />
+						<ShareVariantIcon :size="20" />
 					</template>
-					{{ toggleOutlineString }}
+					{{ t('collectives', 'Share link') }}
 				</NcActionButton>
-				<NcActionSeparator v-if="!inPageList" />
+
+				<!-- Edit page emoji: not displayed for landing page -->
+				<NcActionButton
+					v-if="currentCollectiveCanEdit && !isLandingPage"
+					closeAfterClick
+					:disabled="!networkOnline"
+					@click="gotoPageEmojiPicker">
+					<template #icon>
+						<EmoticonIcon :size="20" />
+					</template>
+					{{ setEmojiString }}
+				</NcActionButton>
+
+				<!-- Open tags modal: always displayed if has edit permissions -->
+				<NcActionButton
+					v-if="currentCollectiveCanEdit"
+					closeAfterClick
+					:disabled="!networkOnline"
+					@click="onOpenTagsModal">
+					<template #icon>
+						<TagMultipleIcon :size="20" />
+					</template>
+					{{ t('collectives', 'Manage tags') }}
+				</NcActionButton>
+
+				<!-- Move/copy page via modal: always displayed if has edit permissions -->
+				<NcActionButton
+					v-if="currentCollectiveCanEdit && !isLandingPage"
+					closeAfterClick
+					:disabled="!networkOnline"
+					@click="onOpenMoveOrCopyModal">
+					<template #icon>
+						<OpenInNewIcon :size="20" />
+					</template>
+					{{ t('collectives', 'Move or copy') }}
+				</NcActionButton>
+
+				<!-- Download action: always displayed -->
+				<NcActionLink
+					:href="pageDavUrl(pageById(pageId))"
+					:class="{ 'action-link--disabled': !networkOnline }"
+					:download="pageById(pageId).fileName"
+					closeAfterClick>
+					<template #icon>
+						<DownloadIcon :size="20" />
+					</template>
+					{{ t('collectives', 'Download') }}
+				</NcActionLink>
+
+				<!-- Delete page -->
+				<NcActionButton
+					v-if="displayDeleteAction"
+					closeAfterClick
+					:disabled="!networkOnline"
+					@click="deletePage(pageId)">
+					<template #icon>
+						<DeleteIcon :size="20" />
+					</template>
+					{{ deletePageString }}
+				</NcActionButton>
 			</template>
-
-			<!-- Favor page action: not displayed for landing page -->
-			<NcActionButton
-				v-if="!isLandingPage"
-				closeAfterClick
-				:disabled="!networkOnline"
-				@click="toggleFavoritePage({ id: currentCollective.id, pageId })">
-				<template #icon>
-					<StarOffIcon v-if="isFavoritePage(currentCollective.id, pageId)" :size="20" />
-					<StarIcon v-else :size="20" />
-				</template>
-				{{ toggleFavoriteString }}
-			</NcActionButton>
-
-			<!-- Share page action: not displayed for landing page (already in collectives actions there) -->
-			<NcActionButton
-				v-if="currentCollectiveCanShare && !isLandingPage"
-				closeAfterClick
-				@click="openShareTab">
-				<template #icon>
-					<ShareVariantIcon :size="20" />
-				</template>
-				{{ t('collectives', 'Share link') }}
-			</NcActionButton>
-
-			<!-- Edit page emoji: not displayed for landing page -->
-			<NcActionButton
-				v-if="currentCollectiveCanEdit && !isLandingPage"
-				closeAfterClick
-				:disabled="!networkOnline"
-				@click="gotoPageEmojiPicker">
-				<template #icon>
-					<EmoticonIcon :size="20" />
-				</template>
-				{{ setEmojiString }}
-			</NcActionButton>
-
-			<!-- Open tags modal: always displayed if has edit permissions -->
-			<NcActionButton
-				v-if="currentCollectiveCanEdit"
-				closeAfterClick
-				:disabled="!networkOnline"
-				@click="onOpenTagsModal">
-				<template #icon>
-					<TagMultipleIcon :size="20" />
-				</template>
-				{{ t('collectives', 'Manage tags') }}
-			</NcActionButton>
-
-			<!-- Move/copy page via modal: always displayed if has edit permissions -->
-			<NcActionButton
-				v-if="currentCollectiveCanEdit && !isLandingPage"
-				closeAfterClick
-				:disabled="!networkOnline"
-				@click="onOpenMoveOrCopyModal">
-				<template #icon>
-					<OpenInNewIcon :size="20" />
-				</template>
-				{{ t('collectives', 'Move or copy') }}
-			</NcActionButton>
-
-			<!-- Download action: always displayed -->
-			<NcActionLink
-				:href="pageDavUrl(pageById(pageId))"
-				:class="{ 'action-link--disabled': !networkOnline }"
-				:download="pageById(pageId).fileName"
-				closeAfterClick>
-				<template #icon>
-					<DownloadIcon :size="20" />
-				</template>
-				{{ t('collectives', 'Download') }}
-			</NcActionLink>
-
-			<!-- Delete page -->
-			<NcActionButton
-				v-if="displayDeleteAction"
-				closeAfterClick
-				:disabled="!networkOnline"
-				@click="deletePage(pageId)">
-				<template #icon>
-					<DeleteIcon :size="20" />
-				</template>
-				{{ deletePageString }}
-			</NcActionButton>
 		</NcActions>
 		<MoveOrCopyModal
 			v-if="showMoveOrCopyModal"
@@ -266,6 +271,7 @@ export default {
 		return {
 			showMoveOrCopyModal: false,
 			showTagsModal: false,
+			collectiveSubmenu: null,
 		}
 	},
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -45,6 +45,12 @@ export const pageModes = {
 	MODE_EDIT: 1,
 }
 
+export const notifyLevels = {
+	NOTIFY_OFF: 0,
+	NOTIFY_MENTION: 1,
+	NOTIFY_ALL: 2,
+}
+
 export const editorApiReaderFileId = 'READER_FILE_ID'
 export const editorApiUpdateReadonlyBarProps = 'UPDATE_READONLY_BAR_PROPS'
 export const editorApiAttachments = 'ATTACHMENTS'

--- a/src/constants.js
+++ b/src/constants.js
@@ -48,6 +48,13 @@ export const pageModes = {
 // Circle members
 export const CIRCLE_MEMBERS_PARTIAL_LIMIT = 15
 
+// Notification levels
+export const notifyLevels = {
+	NOTIFY_OFF: 0,
+	NOTIFY_MENTION: 1,
+	NOTIFY_ALL: 2,
+}
+
 export const editorApiReaderFileId = 'READER_FILE_ID'
 export const editorApiUpdateReadonlyBarProps = 'UPDATE_READONLY_BAR_PROPS'
 export const editorApiAttachments = 'ATTACHMENTS'

--- a/src/stores/collectives.js
+++ b/src/stores/collectives.js
@@ -397,5 +397,10 @@ export const useCollectivesStore = defineStore('collectives', {
 			this.patchCollectiveWithProperty({ id, property: 'userFavoritePages', value: favoritePages })
 			await api.setCollectiveUserSettingFavoritePages(id, favoritePages)
 		},
+
+		async setCollectiveUserSettingNotify({ id, notify }) {
+			this.patchCollectiveWithProperty({ id, property: 'userNotify', value: notify })
+			await api.setCollectiveUserSettingNotify(id, notify)
+		},
 	},
 })

--- a/tests/Integration/config/behat.yml
+++ b/tests/Integration/config/behat.yml
@@ -14,7 +14,7 @@ default:
                     ocsUrl: 'https://nextcloud.local/ocs/v2.php'
                     publicUrl: 'https://nextcloud.local/public.php'
                     remoteUrl: 'https://nextcloud.local/remote.php'
-                    occPath: 'nc-shell.sh master_enc php occ'
+                    occPath: 'nc-shell.sh master php occ'
 ci:
     suites:
         default:

--- a/tests/Integration/features/bootstrap/FeatureContext.php
+++ b/tests/Integration/features/bootstrap/FeatureContext.php
@@ -1963,7 +1963,7 @@ class FeatureContext implements Context {
 	 */
 	public function webdavNodeExists(string $user, string $path, ?string $fail = null): void {
 		$this->setCurrentUser($user);
-		$this->sendRemoteRequest('PROPFIND', '/dav/files/' . $user . '/' . trim($path, '/'), null, null, ['Depth' => 0]);
+		$this->sendRemoteRequest('PROPFIND', '/dav/files/' . $user . '/' . trim($path, '/'), null, null, ['Depth' => '0']);
 		if ($fail === 'fails') {
 			$this->assertStatusCode(404);
 		} else {
@@ -1980,7 +1980,7 @@ class FeatureContext implements Context {
 		$this->setCurrentUser($user);
 		$headers = [
 			'Content-Type' => 'Content-Type: text/xml; charset="utf-8"',
-			'Depth' => 0,
+			'Depth' => '0',
 		];
 		$dom = new DOMDocument('1.0', 'UTF-8');
 		$xPropfind = $dom->createElementNS('DAV:', 'D:propfind');
@@ -2011,7 +2011,7 @@ class FeatureContext implements Context {
 		$token = $this->getShareToken($collectiveId);
 		$headers = [
 			'Content-Type' => 'Content-Type: text/xml; charset="utf-8"',
-			'Depth' => 0,
+			'Depth' => '0',
 		];
 		$dom = new DOMDocument('1.0', 'UTF-8');
 		$xPropfind = $dom->createElementNS('DAV:', 'D:propfind');
@@ -2037,7 +2037,7 @@ class FeatureContext implements Context {
 		$this->setCurrentUser($user);
 		$headers = [
 			'Content-Type' => 'Content-Type: text/xml; charset="utf-8"',
-			'Depth' => 1,
+			'Depth' => '1',
 		];
 		$dom = new DOMDocument('1.0', 'UTF-8');
 		$xPropfind = $dom->createElementNS('DAV:', 'D:propfind');
@@ -2517,7 +2517,7 @@ class FeatureContext implements Context {
 		if ($this->nextcloudVersion === null) {
 			$headers = [
 				'Content-Type' => 'Content-Type: text/xml; charset="utf-8"',
-				'Depth' => 0,
+				'Depth' => '0',
 			];
 
 			$statusUrl = str_replace('index.php', 'status.php', $this->baseUrl);

--- a/tests/Integration/features/bootstrap/FeatureContext.php
+++ b/tests/Integration/features/bootstrap/FeatureContext.php
@@ -2503,11 +2503,7 @@ class FeatureContext implements Context {
 		// clear the cached JSON response
 		$this->json = null;
 		try {
-			if ($verb === 'PROPFIND' || $verb === 'MOVE') {
-				$this->response = $client->request($verb, $url, $options);
-			} else {
-				$this->response = $client->{$verb}($url, $options);
-			}
+			$this->response = $client->request($verb, $url, $options);
 		} catch (ClientException $e) {
 			$this->response = $e->getResponse();
 		}

--- a/tests/Integration/features/bootstrap/FeatureContext.php
+++ b/tests/Integration/features/bootstrap/FeatureContext.php
@@ -2096,15 +2096,18 @@ class FeatureContext implements Context {
 
 	/**
 	 * @When user :user deletes folder :folder
+	 * @When user :user deletes folder :folder if it :exists
 	 *
 	 * @throws GuzzleException
 	 */
-	public function deletesFolder(string $user, string $folderName): void {
+	public function deletesFolder(string $user, string $folderName, ?string $noFail = null): void {
 		$this->setCurrentUser($user);
 		$folderPath = '/dav/files/' . $user . '/' . $folderName;
 
 		$this->sendRemoteRequest('DELETE', $folderPath);
-		$this->assertStatusCode(204);
+		if ($noFail === null) {
+			$this->assertStatusCode(204);
+		}
 	}
 
 	/**

--- a/tests/Integration/features/mountpoint.feature
+++ b/tests/Integration/features/mountpoint.feature
@@ -18,7 +18,8 @@ Feature: mountpoint
     And user "bob" has webdav access to "BehatMountPoint" with permissions "MG"
 
   Scenario: Delete empty folder when in conflict with mountpoint
-    When user "jane" creates folder "MyCollectives"
+    When user "jane" deletes folder "MyCollectives" if it exists
+    And user "jane" creates folder "MyCollectives"
     And user "jane" sees webdav node "MyCollectives"
     And user "jane" creates collective "BehatMountPoint2"
     And user "jane" sees webdav node ".Collectives/BehatMountPoint2"
@@ -34,7 +35,8 @@ Feature: mountpoint
     Then user "jane" trashes and deletes collective "BehatMountPoint2"
 
   Scenario: Rename non-empty node when in conflict with mountpoint
-    When user "jane" creates folder "MyCollectives"
+    When user "jane" deletes folder "MyCollectives (1)" if it exists
+    And user "jane" creates folder "MyCollectives"
     And user "jane" creates folder "MyCollectives/subfolder"
     And user "jane" sees webdav node "MyCollectives/subfolder"
     And user "jane" creates collective "BehatMountPoint3"
@@ -53,7 +55,8 @@ Feature: mountpoint
     Then user "jane" trashes and deletes collective "BehatMountPoint3"
 
   Scenario: Change collectives user folder for user
-    When user "bob" creates folder "some"
+    When user "bob" deletes folder "some" if it exists
+    And user "bob" creates folder "some"
     And user "bob" sets setting "user_folder" to value "/some/folder"
     And user "bob" fails to see webdav node ".Collectives"
     And user "bob" sees webdav node "some/folder"

--- a/tests/Unit/Service/CollectiveServiceTest.php
+++ b/tests/Unit/Service/CollectiveServiceTest.php
@@ -207,7 +207,7 @@ class CollectiveServiceTest extends TestCase {
 			'userShowMembers' => true,
 			'userShowRecentPages' => true,
 			'userFavoritePages' => [],
-			'userNotify' => false,
+			'userNotify' => 1,
 			'canLeave' => true,
 		], $collective->jsonSerialize());
 	}

--- a/tests/Unit/Service/CollectiveServiceTest.php
+++ b/tests/Unit/Service/CollectiveServiceTest.php
@@ -207,6 +207,7 @@ class CollectiveServiceTest extends TestCase {
 			'userShowMembers' => true,
 			'userShowRecentPages' => true,
 			'userFavoritePages' => [],
+			'userNotify' => false,
 			'canLeave' => true,
 		], $collective->jsonSerialize());
 	}

--- a/tests/Unit/Service/CollectiveServiceTest.php
+++ b/tests/Unit/Service/CollectiveServiceTest.php
@@ -205,6 +205,7 @@ class CollectiveServiceTest extends TestCase {
 			'userShowMembers' => true,
 			'userShowRecentPages' => true,
 			'userFavoritePages' => [],
+			'userNotify' => false,
 			'canLeave' => true,
 		], $collective->jsonSerialize());
 	}

--- a/tests/Unit/Service/CollectiveServiceTest.php
+++ b/tests/Unit/Service/CollectiveServiceTest.php
@@ -205,7 +205,7 @@ class CollectiveServiceTest extends TestCase {
 			'userShowMembers' => true,
 			'userShowRecentPages' => true,
 			'userFavoritePages' => [],
-			'userNotify' => false,
+			'userNotify' => 1,
 			'canLeave' => true,
 		], $collective->jsonSerialize());
 	}

--- a/tests/Unit/Service/PageServiceTest.php
+++ b/tests/Unit/Service/PageServiceTest.php
@@ -22,6 +22,7 @@ use OCA\Collectives\Model\PageInfo;
 use OCA\Collectives\Mount\CollectiveFolderManager;
 use OCA\Collectives\Service\CollectiveServiceBase;
 use OCA\Collectives\Service\NotFoundException;
+use OCA\Collectives\Service\NotificationService;
 use OCA\Collectives\Service\NotPermittedException;
 use OCA\Collectives\Service\PageInfoTreeBuilderFactory;
 use OCA\Collectives\Service\PageService;
@@ -113,6 +114,8 @@ class PageServiceTest extends TestCase {
 			$this->collectiveService,
 		);
 
+		$notificationService = $this->createMock(NotificationService::class);
+
 		$this->service = new PageService(
 			$appManager,
 			$this->pageMapper,
@@ -126,6 +129,7 @@ class PageServiceTest extends TestCase {
 			$tagMapper,
 			$pageLinkMapper,
 			$pageInfoTreeBuilderFactory,
+			$notificationService,
 		);
 	}
 


### PR DESCRIPTION
Sends notifications if pages got updated or deleted. Doesn't send notifications when a page got created on purpose as usually pages get renamed straight after they got created.

Also allows to turn notifications off completely for a collective, which also silences notifications on being mentioned in a page.

Fixes: #317

#### 🖼️ Screenshots

Collectives Action Menu 1 | Collectives Action Menu 2
---|---
<img width="300" height="573" alt="image" src="https://github.com/user-attachments/assets/f02280b4-3da8-42d1-a523-f8237fa92f2a" /> | <img width="292" height="232" alt="image" src="https://github.com/user-attachments/assets/bc03e895-7496-4166-81e6-f8c96d9d7691" />

| Notification |
| --- |
| <img width="525" height="192" alt="image" src="https://github.com/user-attachments/assets/f4bf505d-3ef1-4d45-ad9b-d7853b9e7b38" /> |

### 🚧 TODO

So far it only sends notifications on page updates (content updated, page renamed/moved/deleted, emoji changed). I wonder whether adding/removing members shall trigger a notification as well. And how about tagging/untagging pages etc.?

Also, so far there's only three states: "all changes", "@-mention only" (the default) and "off" (no notifications at all). I wonder whether we want to make this more fine-grained, but maybe that's something for a follow-up later on.

- [x] Decide if collective actions is the right place for the subscribe toggle in UI
- [x] Playwright tests
- [ ] Consider activity app integration

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by my
