### PR TITLE
[stable36] check share authentication in reference provider and validate emojis

### DIFF
--- a/.github/workflows/app-upgrade-mysql.yml
+++ b/.github/workflows/app-upgrade-mysql.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.3']
-        server-versions: ['master']
+        server-versions: ['stable33']
 
     services:
       mysql:

--- a/.github/workflows/app-upgrade-postgres.yml
+++ b/.github/workflows/app-upgrade-postgres.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.3']
-        server-versions: ['master']
+        server-versions: ['stable33']
 
     services:
       postgres:

--- a/.github/workflows/behat-sqlite-encryption.yml
+++ b/.github/workflows/behat-sqlite-encryption.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.3']
-        server-versions: ['stable31', 'master']
+        server-versions: ['stable31', 'stable33']
 
     steps:
       - name: Set app env

--- a/.github/workflows/behat-sqlite.yml
+++ b/.github/workflows/behat-sqlite.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.3']
-        server-versions: ['stable31', 'master']
+        server-versions: ['stable31', 'stable33']
 
     steps:
       - name: Set app env

--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -61,12 +61,12 @@ jobs:
 
     strategy:
       matrix:
-        server-versions: ['stable31', 'master']
+        server-versions: ['stable31', 'stable33']
         include:
           - server-versions: 'stable31'
             server-major: '31'
-          - server-versions: 'master'
-            server-major: ''
+          - server-versions: 'stable33'
+            server-major: '33'
 
     env:
       PUPPETEER_SKIP_DOWNLOAD: true
@@ -188,12 +188,12 @@ jobs:
         containers: [1, 2, 3, 4]
         php-versions: ['8.1', '8.4']
         databases: ['sqlite']
-        server-versions: ['stable31', 'master']
+        server-versions: ['stable31', 'stable33']
         exclude:
           - php-versions: '8.4'
             server-versions: 'stable31'
           - php-versions: '8.1'
-            server-versions: 'master'
+            server-versions: 'stable33'
 
     name: runner ${{ matrix.containers }} (${{ matrix.server-versions }})
 

--- a/.github/workflows/occ-cli-mysql.yml
+++ b/.github/workflows/occ-cli-mysql.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.3']
-        server-versions: ['master']
+        server-versions: ['stable33']
 
     services:
       mysql:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.6.2 - 2026.05.28
+
+### 🐛Fixes
+* 🐛 Check share authentication in reference provider.
+* 😀 Validate collective and page emojis.
+
+
 ## 3.6.1 - 2026.02.12
 
 ### 🐛Fixes

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ In your Nextcloud instance, simply navigate to **»Apps«**, find the
 **»Teams«** and **»Collectives«** apps and enable them.
 
 	]]></description>
-	<version>3.6.1</version>
+	<version>3.6.2</version>
 	<licence>agpl</licence>
 	<author>CollectiveCloud Team</author>
 	<namespace>Collectives</namespace>

--- a/lib/Reference/SearchablePageReferenceProvider.php
+++ b/lib/Reference/SearchablePageReferenceProvider.php
@@ -17,6 +17,7 @@ use OCA\Collectives\AppInfo\Application;
 use OCA\Collectives\Db\Collective;
 use OCA\Collectives\Model\PageInfo;
 use OCA\Collectives\Service\CollectiveService;
+use OCA\Collectives\Service\CollectiveShareService;
 use OCA\Collectives\Service\NotFoundException;
 use OCA\Collectives\Service\PageService;
 use OCA\Collectives\Service\SharePageService;
@@ -42,6 +43,7 @@ class SearchablePageReferenceProvider extends ADiscoverableReferenceProvider imp
 		private IDateTimeFormatter $dateTimeFormatter,
 		private ReferenceManager $referenceManager,
 		private LinkReferenceProvider $linkReferenceProvider,
+		private CollectiveShareService $collectiveShareService,
 		private ?string $userId,
 	) {
 	}
@@ -157,7 +159,9 @@ class SearchablePageReferenceProvider extends ADiscoverableReferenceProvider imp
 	 */
 	private function getCollective(?int $collectiveId, string $collectiveName, ?string $sharingToken): Collective {
 		if ($sharingToken) {
-			// TODO: Check if share is password protected; if yes, then check in session if authenticated
+			if (!$this->collectiveShareService->isShareAuthenticated($sharingToken)) {
+				throw new NotFoundException('Share is password protected and not authenticated');
+			}
 			return $this->collectiveService->findCollectiveByShare($sharingToken);
 		}
 

--- a/lib/Service/CollectiveService.php
+++ b/lib/Service/CollectiveService.php
@@ -215,6 +215,7 @@ class CollectiveService extends CollectiveServiceBase {
 		$collective->setCircleId($circle->getSingleId());
 		$collective->setPermissions(Collective::defaultPermissions);
 		if ($emoji) {
+			EmojiHelper::assertValid($emoji);
 			$collective->setEmoji($emoji);
 		}
 		$collective = $this->collectiveMapper->insert($collective);
@@ -270,6 +271,7 @@ class CollectiveService extends CollectiveServiceBase {
 		if ($emoji === '') {
 			$collective->setEmoji(null);
 		} elseif ($emoji) {
+			EmojiHelper::assertValid($emoji);
 			$collective->setEmoji($emoji);
 		}
 

--- a/lib/Service/CollectiveShareService.php
+++ b/lib/Service/CollectiveShareService.php
@@ -16,11 +16,13 @@ use OCA\Collectives\Fs\UserFolderHelper;
 use OCA\Collectives\Model\PageInfo;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\AppFramework\PublicShareController;
 use OCP\Constants;
 use OCP\DB\Exception;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException as FilesNotFoundException;
 use OCP\IL10N;
+use OCP\ISession;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Share\Exceptions\GenericShareException;
@@ -35,6 +37,7 @@ class CollectiveShareService {
 		private CollectiveShareMapper $collectiveShareMapper,
 		private PageService $pageService,
 		private IL10N $l10n,
+		private ISession $session,
 	) {
 	}
 
@@ -297,5 +300,33 @@ class CollectiveShareService {
 		} catch (Exception $e) {
 			throw new NotPermittedException('Failed to delete collective share for ' . $collectiveId, 0, $e);
 		}
+	}
+
+	public function isShareAuthenticated(string $token): bool {
+		try {
+			$share = $this->shareManager->getShareByToken($token);
+		} catch (ShareNotFound) {
+			return false;
+		}
+
+		if ($share->getPassword() === null) {
+			return true;
+		}
+
+		$passwordHash = $share->getPassword();
+
+		// Until Nextcloud 32 (TODO: remove once we support only NC33+)
+		if ($this->session->get('public_link_authenticated_token') === $token
+			&& $this->session->get('public_link_authenticated_password_hash') === $passwordHash) {
+			return true;
+		}
+
+		// Since Nextcloud 33
+		$allowedTokensJSON = $this->session->get(PublicShareController::DAV_AUTHENTICATED_FRONTEND) ?? '[]';
+		$allowedTokens = json_decode($allowedTokensJSON, true);
+		if (!is_array($allowedTokens)) {
+			$allowedTokens = [];
+		}
+		return ($allowedTokens[$token] ?? '') === $passwordHash;
 	}
 }

--- a/lib/Service/EmojiHelper.php
+++ b/lib/Service/EmojiHelper.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Service;
+
+/**
+ * validate emoji values before persisting them to the database (the 'emoji' columns use VARCHAR(8)) .
+ */
+class EmojiHelper {
+	public const MAX_LENGTH = 8;
+
+	/**
+	 * @throws UnprocessableEntityException
+	 */
+	public static function assertValid(?string $emoji): void {
+		if ($emoji === null || $emoji === '') {
+			return;
+		}
+
+		if (preg_match('/[\x00-\x1F\x7F]/u', $emoji) === 1) {
+			throw new UnprocessableEntityException('Emoji contains invalid characters');
+		}
+
+		if (!function_exists('grapheme_strlen')) {
+			throw new UnprocessableEntityException('Emoji validation is not available');
+		}
+
+		if (grapheme_strlen($emoji) !== 1) {
+			throw new UnprocessableEntityException('Emoji must be a single emoji character');
+		}
+
+		if (preg_match('/\p{Extended_Pictographic}/u', $emoji) !== 1) {
+			throw new UnprocessableEntityException('Emoji is not valid');
+		}
+
+		if (mb_strlen($emoji) > self::MAX_LENGTH) {
+			throw new UnprocessableEntityException(
+				'Emoji is too long (maximum ' . self::MAX_LENGTH . ' characters)',
+			);
+		}
+	}
+}

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -301,6 +301,7 @@ class PageService {
 		$page->setFileId($fileId);
 		$page->setLastUserId($userId);
 		if ($emoji !== null) {
+			EmojiHelper::assertValid($emoji);
 			$page->setEmoji($emoji);
 		}
 		if ($fullWidth !== null) {
@@ -938,6 +939,7 @@ class PageService {
 	 * @throws MissingDependencyException
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
+	 * @throws UnprocessableEntityException
 	 */
 	public function setEmoji(int $collectiveId, int $id, ?string $emoji, string $userId): PageInfo {
 		$this->verifyEditPermissions($collectiveId, $userId);

--- a/tests/Integration/features/bootstrap/FeatureContext.php
+++ b/tests/Integration/features/bootstrap/FeatureContext.php
@@ -625,17 +625,22 @@ class FeatureContext implements Context {
 	/**
 	 * @When user :user sets emoji for page :page to :emoji in :collective
 	 * @When user :user :fails to set emoji for page :page to :emoji in :collective
+	 * @When user :user :fails to set emoji for page :page to :invalid :emoji in :collective
 	 *
 	 * @throws GuzzleException
 	 */
-	public function userSetsPageEmoji(string $user, string $page, string $emoji, string $collective, ?string $fail = null): void {
+	public function userSetsPageEmoji(string $user, string $page, string $emoji, string $collective, ?string $fail = null, ?string $invalid = null): void {
 		$this->setCurrentUser($user);
 		$collectiveId = $this->collectiveIdByName($collective);
 		$pageId = $this->pageIdByName($collectiveId, $page);
 		$formData = new TableNode([['emoji', $emoji]]);
 		$this->sendOcsCollectivesRequest('PUT', 'collectives/' . $collectiveId . '/pages/' . $pageId . '/emoji', $formData);
 		if ($fail === 'fails') {
-			$this->assertStatusCode(403);
+			if ($invalid === 'invalid') {
+				$this->assertStatusCode(400);
+			} else {
+				$this->assertStatusCode(403);
+			}
 		} else {
 			$this->assertStatusCode(200);
 			$this->assertPageKeyValue($pageId, 'emoji', $emoji);

--- a/tests/Integration/features/pages.feature
+++ b/tests/Integration/features/pages.feature
@@ -48,6 +48,7 @@ Feature: pages
 
   Scenario: Change page emoji
     When user "jane" sets emoji for page "firstpage" to "🍏" in "BehatPagesCollective"
+    And user "jane" fails to set emoji for page "firstpage" to invalid "invalid" in "BehatPagesCollective"
     And user "jane" sets emoji for page "firstpage" to "" in "BehatPagesCollective"
 
   Scenario: Change page full width

--- a/tests/Unit/Search/SearchablePageReferenceProviderTest.php
+++ b/tests/Unit/Search/SearchablePageReferenceProviderTest.php
@@ -13,6 +13,7 @@ use OC\Collaboration\Reference\LinkReferenceProvider;
 use OC\Collaboration\Reference\ReferenceManager;
 use OCA\Collectives\Reference\SearchablePageReferenceProvider;
 use OCA\Collectives\Service\CollectiveService;
+use OCA\Collectives\Service\CollectiveShareService;
 use OCA\Collectives\Service\PageService;
 use OCA\Collectives\Service\SharePageService;
 use OCP\Collaboration\Reference\IPublicReferenceProvider;
@@ -23,10 +24,12 @@ use PHPUnit\Framework\TestCase;
 
 class SearchablePageReferenceProviderTest extends TestCase {
 	private SearchablePageReferenceProvider $provider;
+	private CollectiveService $collectiveService;
+	private CollectiveShareService $collectiveShareService;
 	protected function setUp(): void {
 		parent::setUp();
 		$this->needsIPublicReferenceProvider();
-		$collectiveService = $this->createMock(CollectiveService::class);
+		$this->collectiveService = $this->createMock(CollectiveService::class);
 		$pageService = $this->createMock(PageService::class);
 		$sharePageService = $this->createMock(SharePageService::class);
 		$l10n = $this->createMock(IL10N::class);
@@ -40,9 +43,10 @@ class SearchablePageReferenceProviderTest extends TestCase {
 		$dateTimeFormatter = $this->createMock(IDateTimeFormatter::class);
 		$referenceManager = $this->createMock(ReferenceManager::class);
 		$linkReferenceProvider = $this->createMock(LinkReferenceProvider::class);
+		$this->collectiveShareService = $this->createMock(CollectiveShareService::class);
 		$uid = 'jane';
 		$this->provider = new SearchablePageReferenceProvider(
-			$collectiveService,
+			$this->collectiveService,
 			$pageService,
 			$sharePageService,
 			$l10n,
@@ -50,6 +54,7 @@ class SearchablePageReferenceProviderTest extends TestCase {
 			$dateTimeFormatter,
 			$referenceManager,
 			$linkReferenceProvider,
+			$this->collectiveShareService,
 			$uid,
 		);
 	}
@@ -158,5 +163,21 @@ class SearchablePageReferenceProviderTest extends TestCase {
 	 */
 	public function testMatchUrlNonMatching(string $url): void {
 		self::assertEquals(null, $this->provider->matchUrl($url));
+	}
+
+	public function testResolveReferencePublicNotAuthenticated(): void {
+		$this->collectiveShareService
+			->method('isShareAuthenticated')
+			->with('sharetoken')
+			->willReturn(false);
+
+		$this->collectiveService
+			->expects(self::never())
+			->method('findCollectiveByShare');
+
+		$this->provider->resolveReferencePublic(
+			'https://nextcloud.local/apps/collectives/p/sharetoken/supacollective',
+			'sharetoken'
+		);
 	}
 }

--- a/tests/Unit/Service/CollectiveShareServiceTest.php
+++ b/tests/Unit/Service/CollectiveShareServiceTest.php
@@ -21,6 +21,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\Files\Folder;
 use OCP\IL10N;
+use OCP\ISession;
 use OCP\Lock\LockedException;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
@@ -59,13 +60,15 @@ class CollectiveShareServiceTest extends TestCase {
 		$l10n->method('t')->willReturnArgument(0);
 
 		$pageService = $this->createMock(PageService::class);
+		$session = $this->createMock(ISession::class);
 
 		$this->service = new CollectiveShareService(
 			$this->shareManager,
 			$this->userFolderHelper,
 			$this->collectiveShareMapper,
 			$pageService,
-			$l10n
+			$l10n,
+			$session
 		);
 
 		$this->collective = new Collective();
@@ -229,5 +232,15 @@ class CollectiveShareServiceTest extends TestCase {
 			->willReturn('passwordhash');
 		$collectiveShare = $this->service->updateShare($this->userId, $this->collective, null, 'token', false, 'password');
 		self::assertEquals('passwordhash', $collectiveShare->getPassword());
+	}
+
+	public function testIsShareNotAuthenticated(): void {
+		$share = $this->getMockBuilder(Share::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$share->method('getPassword')->willReturn('passwordhash');
+		$this->shareManager->method('getShareByToken')->willReturn($share);
+
+		self::assertFalse($this->service->isShareAuthenticated('token'));
 	}
 }

--- a/tests/Unit/Service/EmojiHelperTest.php
+++ b/tests/Unit/Service/EmojiHelperTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Unit\Service;
+
+use OCA\Collectives\Service\EmojiHelper;
+use OCA\Collectives\Service\UnprocessableEntityException;
+use PHPUnit\Framework\TestCase;
+
+class EmojiHelperTest extends TestCase {
+	public function testNullAndEmptyAreValid(): void {
+		EmojiHelper::assertValid(null);
+		EmojiHelper::assertValid('');
+		self::assertTrue(true);
+	}
+
+	public function testSingleEmojiIsValid(): void {
+		EmojiHelper::assertValid('👍');
+		EmojiHelper::assertValid('🃏');
+		self::assertTrue(true);
+	}
+
+	public function testEmojiWithSkinToneIsValid(): void {
+		EmojiHelper::assertValid('👍🏿');
+		self::assertTrue(true);
+	}
+
+	public function testRejectsMultipleEmojis(): void {
+		$this->expectException(UnprocessableEntityException::class);
+		$this->expectExceptionMessage('single emoji');
+		EmojiHelper::assertValid('😀😀😀');
+	}
+
+	public function testRejectsEmojiWithTrailingText(): void {
+		$this->expectException(UnprocessableEntityException::class);
+		$this->expectExceptionMessage('single emoji');
+		EmojiHelper::assertValid('👍5fg%');
+	}
+
+	public function testRejectsPlainText(): void {
+		$this->expectException(UnprocessableEntityException::class);
+		$this->expectExceptionMessage('single emoji');
+		EmojiHelper::assertValid('hello');
+	}
+
+	public function testRejectsSingleLetter(): void {
+		$this->expectException(UnprocessableEntityException::class);
+		$this->expectExceptionMessage('not valid');
+		EmojiHelper::assertValid('a');
+	}
+
+	public function testRejectsNewlines(): void {
+		$this->expectException(UnprocessableEntityException::class);
+		$this->expectExceptionMessage('invalid characters');
+		EmojiHelper::assertValid("👍\naaaaaaaa");
+	}
+
+	public function testRejectsControlCharacters(): void {
+		$this->expectException(UnprocessableEntityException::class);
+		$this->expectExceptionMessage('invalid characters');
+		EmojiHelper::assertValid("👍\x07");
+	}
+}


### PR DESCRIPTION
### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
