### PR TITLE
Perf: Optimize pages loading (Filecache path like approach)

### DIFF
--- a/lib/Db/PageLinkMapper.php
+++ b/lib/Db/PageLinkMapper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Collectives\Db;
 
 use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 class PageLinkMapper {
@@ -29,6 +30,33 @@ class PageLinkMapper {
 			->from(self::TABLE_NAME)
 			->where($qb->expr()->eq('page_id', $qb->createNamedParameter($pageId)));
 		return $qb->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+	}
+
+	/**
+	 * @param int[] $pageIds
+	 * @return array<int, int[]> Linked page ids indexed by page id
+	 * @throws Exception
+	 */
+	public function findByPageIds(array $pageIds): array {
+		if (empty($pageIds)) {
+			return [];
+		}
+
+		$linkedPageIds = [];
+		foreach (array_chunk($pageIds, 1000) as $chunk) {
+			$qb = $this->db->getQueryBuilder();
+			$qb->select('page_id', 'linked_page_id')
+				->from(self::TABLE_NAME)
+				->where($qb->expr()->in('page_id', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)));
+
+			$result = $qb->executeQuery();
+			while ($row = $result->fetch()) {
+				$linkedPageIds[(int)$row['page_id']][] = (int)$row['linked_page_id'];
+			}
+			$result->closeCursor();
+		}
+
+		return $linkedPageIds;
 	}
 
 	/**

--- a/lib/Db/PageMapper.php
+++ b/lib/Db/PageMapper.php
@@ -89,22 +89,24 @@ class PageMapper extends QBMapper {
 			return [];
 		}
 
-		$qb = $this->db->getQueryBuilder();
-		$qb->select('*')
-			->from($this->tableName)
-			->where($qb->expr()->in('file_id',
-				$qb->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)));
-
-		if ($trashed) {
-			$qb->andWhere($qb->expr()->isNotNull('trash_timestamp'));
-		} else {
-			$qb->andWhere($qb->expr()->isNull('trash_timestamp'));
-		}
-
-		$pages = $this->findEntities($qb);
 		$pagesByFileId = [];
-		foreach ($pages as $page) {
-			$pagesByFileId[$page->getFileId()] = $page;
+		foreach (array_chunk($fileIds, 1000) as $chunk) {
+			$qb = $this->db->getQueryBuilder();
+			$qb->select('*')
+				->from($this->tableName)
+				->where($qb->expr()->in('file_id',
+					$qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)));
+
+			if ($trashed) {
+				$qb->andWhere($qb->expr()->isNotNull('trash_timestamp'));
+			} else {
+				$qb->andWhere($qb->expr()->isNull('trash_timestamp'));
+			}
+
+			$pages = $this->findEntities($qb);
+			foreach ($pages as $page) {
+				$pagesByFileId[$page->getFileId()] = $page;
+			}
 		}
 
 		return $pagesByFileId;

--- a/lib/Model/CollectiveFileInfo.php
+++ b/lib/Model/CollectiveFileInfo.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Model;
+
+/**
+ * Lightweight representation of a file entry from the `filecache` table.
+ *
+ * `path` is relative to the collective root folder (e.g. `Readme.md` or
+ * `subfolder/page.md`), so it matches the semantics of `File::getInternalPath()`
+ * within the jailed collective storage.
+ */
+class CollectiveFileInfo {
+	public function __construct(
+		public readonly int $fileId,
+		public readonly int $storage,
+		public readonly string $path,
+		public readonly int $parent,
+		public readonly string $name,
+		public readonly int $mimetype,
+		public readonly int $mimepart,
+		public readonly int $size,
+		public readonly int $mtime,
+		public readonly int $storageMtime,
+		public readonly int $encrypted,
+		public readonly string $etag,
+		public readonly int $permissions,
+	) {
+	}
+
+	public function isPage(): bool {
+		return str_ends_with($this->name, PageInfo::SUFFIX);
+	}
+
+	public function isIndexPage(): bool {
+		return $this->name === PageInfo::INDEX_PAGE_TITLE . PageInfo::SUFFIX;
+	}
+}

--- a/lib/Model/PageInfo.php
+++ b/lib/Model/PageInfo.php
@@ -230,6 +230,70 @@ class PageInfo implements JsonSerializable {
 	}
 
 	/**
+	 * Build the page info from a lightweight filecache entry (see PageService::getPagesFromFolder).
+	 */
+	public function fromFileInfo(
+		CollectiveFileInfo $fileInfo,
+		int $parentId,
+		?string $collectivePath = null,
+		?string $lastUserId = null,
+		?string $lastUserDisplayName = null,
+		?string $emoji = null,
+		?string $subpageOrder = null,
+		?bool $fullWidth = false,
+		?string $slug = null,
+		?string $tags = null,
+		?array $linkedPageIds = null,
+	): void {
+		$this->setId($fileInfo->fileId);
+		$dirName = dirname($fileInfo->path);
+		$dirName = $dirName === '.' ? '' : $dirName;
+		if ($fileInfo->isIndexPage()) {
+			if ($parentId === 0) {
+				// Landing page
+				$this->setTitle(Server::get(IFactory::class)->get('collectives')->t('Landing page'));
+			} else {
+				// Index page
+				$this->setTitle(basename($dirName));
+			}
+		} else {
+			$this->setTitle(basename($fileInfo->name, self::SUFFIX));
+		}
+		$this->setFilePath($dirName);
+		$this->setTimestamp($fileInfo->mtime);
+		$this->setSize($fileInfo->size);
+		$this->setFileName($fileInfo->name);
+		if ($collectivePath !== null) {
+			$this->setCollectivePath($collectivePath);
+		}
+		if ($lastUserId !== null) {
+			$this->setLastUserId($lastUserId);
+		}
+		if ($lastUserDisplayName !== null) {
+			$this->setLastUserDisplayName($lastUserDisplayName);
+		}
+		if ($emoji !== null) {
+			$this->setEmoji($emoji);
+		}
+		if ($fullWidth !== null) {
+			$this->setFullWidth($fullWidth);
+		}
+		if ($subpageOrder !== null) {
+			$this->setSubpageOrder($subpageOrder);
+		}
+		if ($slug !== null) {
+			$this->setSlug($slug);
+		}
+		if ($tags !== null) {
+			$this->setTags($tags);
+		}
+		if ($linkedPageIds !== null) {
+			$this->setLinkedPageIds($linkedPageIds);
+		}
+		$this->setParentId($parentId);
+	}
+
+	/**
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */

--- a/lib/Model/PageInfo.php
+++ b/lib/Model/PageInfo.php
@@ -245,52 +245,26 @@ class PageInfo implements JsonSerializable {
 		?string $tags = null,
 		?array $linkedPageIds = null,
 	): void {
-		$this->setId($fileInfo->fileId);
 		$dirName = dirname($fileInfo->path);
 		$dirName = $dirName === '.' ? '' : $dirName;
-		if ($fileInfo->isIndexPage()) {
-			if ($parentId === 0) {
-				// Landing page
-				$this->setTitle(Server::get(IFactory::class)->get('collectives')->t('Landing page'));
-			} else {
-				// Index page
-				$this->setTitle(basename($dirName));
-			}
-		} else {
-			$this->setTitle(basename($fileInfo->name, self::SUFFIX));
-		}
-		$this->setFilePath($dirName);
-		$this->setTimestamp($fileInfo->mtime);
-		$this->setSize($fileInfo->size);
-		$this->setFileName($fileInfo->name);
-		if ($collectivePath !== null) {
-			$this->setCollectivePath($collectivePath);
-		}
-		if ($lastUserId !== null) {
-			$this->setLastUserId($lastUserId);
-		}
-		if ($lastUserDisplayName !== null) {
-			$this->setLastUserDisplayName($lastUserDisplayName);
-		}
-		if ($emoji !== null) {
-			$this->setEmoji($emoji);
-		}
-		if ($fullWidth !== null) {
-			$this->setFullWidth($fullWidth);
-		}
-		if ($subpageOrder !== null) {
-			$this->setSubpageOrder($subpageOrder);
-		}
-		if ($slug !== null) {
-			$this->setSlug($slug);
-		}
-		if ($tags !== null) {
-			$this->setTags($tags);
-		}
-		if ($linkedPageIds !== null) {
-			$this->setLinkedPageIds($linkedPageIds);
-		}
-		$this->setParentId($parentId);
+		$this->fromData(
+			$fileInfo->fileId,
+			$dirName,
+			$fileInfo->isIndexPage(),
+			$parentId,
+			$fileInfo->name,
+			$fileInfo->mtime,
+			$fileInfo->size,
+			$collectivePath,
+			$lastUserId,
+			$lastUserDisplayName,
+			$emoji,
+			$subpageOrder,
+			$fullWidth,
+			$slug,
+			$tags,
+			$linkedPageIds,
+		);
 	}
 
 	/**
@@ -309,11 +283,51 @@ class PageInfo implements JsonSerializable {
 		?string $tags = null,
 		?array $linkedPageIds = null,
 	): void {
-		$this->setId($file->getId());
-		// Set folder name as title for all index pages except the collective landing page
 		$dirName = dirname($file->getInternalPath());
 		$dirName = $dirName === '.' ? '' : $dirName;
-		if (strcmp($file->getName(), self::INDEX_PAGE_TITLE . self::SUFFIX) === 0) {
+		$isIndexPage = strcmp($file->getName(), self::INDEX_PAGE_TITLE . self::SUFFIX) === 0;
+		$mountPoint = explode('/', $file->getMountPoint()->getMountPoint(), 4);
+		$collectivePath = count($mountPoint) >= 4 ? rtrim($mountPoint[3], '/') : null;
+		$this->fromData(
+			$file->getId(),
+			$dirName,
+			$isIndexPage,
+			$parentId,
+			$file->getName(),
+			$file->getMTime(),
+			(int)$file->getSize(),
+			$collectivePath,
+			$lastUserId,
+			$lastUserDisplayName,
+			$emoji,
+			$subpageOrder,
+			$fullWidth,
+			$slug,
+			$tags,
+			$linkedPageIds,
+		);
+	}
+
+	private function fromData(
+		int $id,
+		string $dirName,
+		bool $isIndexPage,
+		int $parentId,
+		string $fileName,
+		int $timestamp,
+		int $size,
+		?string $collectivePath = null,
+		?string $lastUserId = null,
+		?string $lastUserDisplayName = null,
+		?string $emoji = null,
+		?string $subpageOrder = null,
+		?bool $fullWidth = false,
+		?string $slug = null,
+		?string $tags = null,
+		?array $linkedPageIds = null,
+	): void {
+		$this->setId($id);
+		if ($isIndexPage) {
 			if ($parentId === 0) {
 				// Landing page
 				$this->setTitle(Server::get(IFactory::class)->get('collectives')->t('Landing page'));
@@ -322,15 +336,14 @@ class PageInfo implements JsonSerializable {
 				$this->setTitle(basename($dirName));
 			}
 		} else {
-			$this->setTitle(basename($file->getName(), self::SUFFIX));
+			$this->setTitle(basename($fileName, self::SUFFIX));
 		}
 		$this->setFilePath($dirName);
-		$this->setTimestamp($file->getMTime());
-		$this->setSize((int)$file->getSize());
-		$this->setFileName($file->getName());
-		$mountPoint = explode('/', $file->getMountPoint()->getMountPoint(), 4);
-		if (count($mountPoint) >= 4) {
-			$this->setCollectivePath(rtrim($mountPoint[3], '/'));
+		$this->setTimestamp($timestamp);
+		$this->setSize($size);
+		$this->setFileName($fileName);
+		if ($collectivePath !== null) {
+			$this->setCollectivePath($collectivePath);
 		}
 		if ($lastUserId !== null) {
 			$this->setLastUserId($lastUserId);

--- a/lib/Mount/CollectiveFolderManager.php
+++ b/lib/Mount/CollectiveFolderManager.php
@@ -15,6 +15,7 @@ use OC\Files\Node\LazyFolder;
 use OC\Files\Storage\Wrapper\Jail;
 use OC\Files\Storage\Wrapper\PermissionsMask;
 use OCA\Collectives\ACL\ACLStorageWrapper;
+use OCA\Collectives\Model\CollectiveFileInfo;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Folder;
@@ -247,6 +248,57 @@ class CollectiveFolderManager {
 			$result[$row['folder_id']] = $row;
 		}
 		/** @psalm-suppress LessSpecificReturnStatement */
+		return $result;
+	}
+
+	/**
+	 * Load all filecache entries (files and folders) of a collective folder in a single query.
+	 *
+	 * @return CollectiveFileInfo[] Indexed by file id, with paths relative to the collective root folder
+	 *
+	 * @throws NotFoundException
+	 * @throws \OCP\DB\Exception
+	 */
+	public function getFileCacheForCollective(int $collectiveId, ?string $subdirectory = null): array {
+		$jailPath = $this->getJailPath($collectiveId);
+		$storageId = $this->getRootFolderStorageId();
+
+		$qb = $this->connection->getQueryBuilder();
+
+		// Trailing slash matters: it restricts to descendants and
+		// avoids matching siblings (e.g. `16` must not match `160`).
+		$likePath = $jailPath . '/' . ($subdirectory ? $subdirectory . '/' : '');
+		$likePath = $this->connection->escapeLikeParameter($likePath) . '%';
+
+		$qb->select('fileid', 'storage', 'path', 'parent', 'name', 'mimetype', 'mimepart',
+			'size', 'mtime', 'storage_mtime', 'encrypted', 'etag', 'permissions')
+			->from('filecache')
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->like('path', $qb->createNamedParameter($likePath)));
+
+		$prefixLength = strlen($jailPath . '/');
+		$result = [];
+		$cursor = $qb->executeQuery();
+		while ($row = $cursor->fetch()) {
+			$relativePath = substr($row['path'], $prefixLength);
+			$result[(int)$row['fileid']] = new CollectiveFileInfo(
+				fileId: (int)$row['fileid'],
+				storage: (int)$row['storage'],
+				path: $relativePath,
+				parent: (int)$row['parent'],
+				name: (string)$row['name'],
+				mimetype: (int)$row['mimetype'],
+				mimepart: (int)$row['mimepart'],
+				size: (int)$row['size'],
+				mtime: (int)$row['mtime'],
+				storageMtime: (int)$row['storage_mtime'],
+				encrypted: (int)$row['encrypted'],
+				etag: (string)$row['etag'],
+				permissions: (int)$row['permissions'],
+			);
+		}
+		$cursor->closeCursor();
+
 		return $result;
 	}
 

--- a/lib/Service/PageInfoTreeBuilder.php
+++ b/lib/Service/PageInfoTreeBuilder.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Service;
+
+use OCA\Collectives\Db\Page;
+use OCA\Collectives\Db\PageLinkMapper;
+use OCA\Collectives\Db\PageMapper;
+use OCA\Collectives\Model\CollectiveFileInfo;
+use OCA\Collectives\Model\PageInfo;
+use OCA\Collectives\Mount\CollectiveFolderManager;
+use OCP\DB\Exception as DBException;
+use OCP\Files\Folder;
+use OCP\Files\InvalidPathException;
+use OCP\Files\NotFoundException as FilesNotFoundException;
+use OCP\Files\NotPermittedException as FilesNotPermittedException;
+use OCP\IUserManager;
+use Symfony\Component\String\Slugger\SluggerInterface;
+
+/**
+ * Builds the PageInfo tree for a single folder of a collective.
+ *
+ * One instance is created per call (see PageInfoTreeBuilderFactory). The filecache
+ * lookup, batched metadata queries and other values that only depend on the
+ * constructor arguments are computed lazily and cached for the lifetime of the
+ * instance.
+ */
+class PageInfoTreeBuilder {
+	/** @var CollectiveFileInfo[]|null */
+	private ?array $fileInfos = null;
+	/** @var array<int, CollectiveFileInfo[]>|null */
+	private ?array $childrenByParent = null;
+	/** @var int[]|null */
+	private ?array $pageFileIds = null;
+	/** @var array<int, Page>|null */
+	private ?array $pagesByFileId = null;
+	/** @var array<int, int[]>|null */
+	private ?array $linkedPageIdsByFileId = null;
+	/** @var array<string, null|string>|null */
+	private ?array $displayNames = null;
+	private ?string $collectivePath = null;
+
+	public function __construct(
+		private readonly PageMapper $pageMapper,
+		private readonly PageLinkMapper $pageLinkMapper,
+		private readonly IUserManager $userManager,
+		private readonly SluggerInterface $slugger,
+		private readonly CollectiveFolderManager $collectiveFolderManager,
+		private readonly CollectiveServiceBase $collectiveService,
+		private readonly int $collectiveId,
+		private readonly Folder $folder,
+		private readonly string $userId,
+		private readonly bool $recurse,
+		private readonly bool $forceIndex,
+	) {
+	}
+
+	/**
+	 * Recursively build PageInfo objects from the in-memory filecache tree.
+	 *
+	 * @param PageInfo[] $pageInfos
+	 *
+	 * @throws MissingDependencyException
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 */
+	public function build(int $folderId, int $parentPageId, array &$pageInfos): void {
+		$indexFileInfo = null;
+		$pageFileInfos = [];
+		$subFolderIds = [];
+		foreach ($this->childrenByParent()[$folderId] ?? [] as $child) {
+			if (str_starts_with($child->name, '.')) {
+				// Ignore hidden folders and files
+				continue;
+			}
+
+			if (isset($this->childrenByParent()[$child->fileId])) {
+				// Has children, so it's a (non-empty) folder
+				$subFolderIds[] = $child->fileId;
+			} elseif ($child->isIndexPage()) {
+				$indexFileInfo = $child;
+			} elseif ($child->isPage()) {
+				$pageFileInfos[] = $child;
+			}
+		}
+
+		// forceIndex only applies to the entry folder, not to subfolders
+		$forceIndex = $this->forceIndex && $folderId === $this->folder->getId();
+
+		if ($indexFileInfo === null) {
+			if (!$forceIndex && !$this->folderHasPages($folderId)) {
+				// Ignore folders without an index page and without any (sub)pages
+				return;
+			}
+
+			// Create missing index page if folder or subfolders have page files (or forceIndex)
+			$folder = $this->folder->getFirstNodeById($folderId);
+			if (!($folder instanceof Folder)) {
+				return;
+			}
+			$indexPageInfo = $this->createIndexPage($folder, $parentPageId);
+			$indexPageId = $indexPageInfo->getId();
+		} else {
+			$indexPageInfo = $this->buildPageInfo($indexFileInfo, $parentPageId);
+			$indexPageId = $indexFileInfo->fileId;
+		}
+		$pageInfos[] = $indexPageInfo;
+
+		foreach ($pageFileInfos as $pageFileInfo) {
+			$pageInfos[] = $this->buildPageInfo($pageFileInfo, $indexPageId);
+		}
+
+		foreach ($subFolderIds as $subFolderId) {
+			if ($this->recurse) {
+				$this->build($subFolderId, $indexPageId, $pageInfos);
+				continue;
+			}
+
+			// Not recursive: only add the subfolder's index page (ignore subfolders without one)
+			$subIndexFileInfo = $this->findIndexPageInfo($subFolderId);
+			if ($subIndexFileInfo !== null) {
+				$pageInfos[] = $this->buildPageInfo($subIndexFileInfo, $indexPageId);
+			}
+		}
+	}
+
+	/**
+	 * @return CollectiveFileInfo[]
+	 *
+	 * @throws NotFoundException
+	 */
+	private function fileInfos(): array {
+		if ($this->fileInfos === null) {
+			try {
+				$this->fileInfos = $this->collectiveFolderManager->getFileCacheForCollective($this->collectiveId, $this->folder->getInternalPath());
+			} catch (DBException $e) {
+				throw new NotFoundException($e->getMessage(), 0, $e);
+			}
+		}
+
+		return $this->fileInfos;
+	}
+
+	/**
+	 * Group child entries by their parent folder file id.
+	 *
+	 * @return array<int, CollectiveFileInfo[]>
+	 *
+	 * @throws NotFoundException
+	 */
+	private function childrenByParent(): array {
+		if ($this->childrenByParent === null) {
+			$this->childrenByParent = [];
+			foreach ($this->fileInfos() as $fileInfo) {
+				$this->childrenByParent[$fileInfo->parent][] = $fileInfo;
+			}
+		}
+
+		return $this->childrenByParent;
+	}
+
+	/**
+	 * File ids of all page files in the tree.
+	 *
+	 * @return int[]
+	 *
+	 * @throws NotFoundException
+	 */
+	private function pageFileIds(): array {
+		if ($this->pageFileIds === null) {
+			$this->pageFileIds = [];
+			foreach ($this->fileInfos() as $fileInfo) {
+				if ($fileInfo->isPage()) {
+					$this->pageFileIds[] = $fileInfo->fileId;
+				}
+			}
+		}
+
+		return $this->pageFileIds;
+	}
+
+	/**
+	 * Batch load page metadata for all page files.
+	 *
+	 * @return array<int, Page>
+	 *
+	 * @throws NotFoundException
+	 */
+	private function pagesByFileId(): array {
+		if ($this->pagesByFileId === null) {
+			$this->pagesByFileId = $this->pageMapper->findByFileIds($this->pageFileIds());
+		}
+
+		return $this->pagesByFileId;
+	}
+
+	/**
+	 * @return array<int, int[]>
+	 *
+	 * @throws NotFoundException
+	 */
+	private function linkedPageIdsByFileId(): array {
+		if ($this->linkedPageIdsByFileId === null) {
+			$this->linkedPageIdsByFileId = $this->pageLinkMapper->findByPageIds($this->pageFileIds());
+		}
+
+		return $this->linkedPageIdsByFileId;
+	}
+
+	/**
+	 * @return array<string, null|string>
+	 *
+	 * @throws NotFoundException
+	 */
+	private function displayNames(): array {
+		if ($this->displayNames === null) {
+			$this->displayNames = [];
+			foreach ($this->pagesByFileId() as $page) {
+				$lastUserId = $page->getLastUserId();
+				if ($lastUserId !== null && !isset($this->displayNames[$lastUserId])) {
+					$this->displayNames[$lastUserId] = $this->userManager->getDisplayName($lastUserId);
+				}
+			}
+		}
+
+		return $this->displayNames;
+	}
+
+	/**
+	 * Derive collectivePath from the mount point (incl. user folder prefix),
+	 * matching PageInfo::fromFile().
+	 *
+	 * @throws MissingDependencyException
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 */
+	private function collectivePath(): string {
+		if ($this->collectivePath === null) {
+			$mountPoint = explode('/', $this->folder->getMountPoint()->getMountPoint(), 4);
+			$this->collectivePath = (count($mountPoint) >= 4)
+				? rtrim($mountPoint[3], '/')
+				: $this->collectiveService->getCollective($this->collectiveId, $this->userId)->getName();
+		}
+
+		return $this->collectivePath;
+	}
+
+	/**
+	 * @throws NotFoundException
+	 */
+	private function findIndexPageInfo(int $folderId): ?CollectiveFileInfo {
+		foreach ($this->childrenByParent()[$folderId] ?? [] as $child) {
+			if ($child->isIndexPage()) {
+				return $child;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @throws NotFoundException
+	 */
+	private function folderHasPages(int $folderId): bool {
+		foreach ($this->childrenByParent()[$folderId] ?? [] as $child) {
+			if (str_starts_with($child->name, '.')) {
+				continue;
+			}
+
+			if (isset($this->childrenByParent()[$child->fileId])) {
+				if ($this->folderHasPages($child->fileId)) {
+					return true;
+				}
+			} elseif ($child->isPage()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @throws MissingDependencyException
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 */
+	private function buildPageInfo(CollectiveFileInfo $fileInfo, int $parentId): PageInfo {
+		$page = $this->pagesByFileId()[$fileInfo->fileId] ?? null;
+		$lastUserId = $page?->getLastUserId();
+		$pageInfo = new PageInfo();
+		$pageInfo->fromFileInfo(
+			$fileInfo,
+			$parentId,
+			$this->collectivePath(),
+			$lastUserId,
+			$lastUserId !== null ? ($this->displayNames()[$lastUserId] ?? null) : null,
+			$page?->getEmoji(),
+			$page?->getSubpageOrder(),
+			$page !== null && $page->getFullWidth(),
+			$page?->getSlug(),
+			$page?->getTags(),
+			$this->linkedPageIdsByFileId()[$fileInfo->fileId] ?? null,
+		);
+
+		return $pageInfo;
+	}
+
+	/**
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 */
+	private function createIndexPage(Folder $folder, int $parentPageId): PageInfo {
+		try {
+			$newFile = $folder->newFile(PageInfo::INDEX_PAGE_TITLE . PageInfo::SUFFIX);
+		} catch (FilesNotPermittedException $e) {
+			throw new NotPermittedException($e->getMessage(), 0, $e);
+		}
+
+		$pageInfo = new PageInfo();
+		try {
+			$pageInfo->fromFile(
+				$newFile,
+				$parentPageId,
+				$this->userId,
+				$this->userManager->getDisplayName($this->userId),
+			);
+			$slug = $this->slugger->slug(PageInfo::INDEX_PAGE_TITLE)->toString();
+			$page = new Page();
+			$page->setFileId($newFile->getId());
+			$page->setLastUserId($this->userId);
+			$page->setSlug($slug);
+			$this->pageMapper->updateOrInsert($page);
+			$pageInfo->setSlug($slug);
+		} catch (FilesNotFoundException|InvalidPathException $e) {
+			throw new NotFoundException($e->getMessage(), 0, $e);
+		}
+
+		return $pageInfo;
+	}
+}

--- a/lib/Service/PageInfoTreeBuilderFactory.php
+++ b/lib/Service/PageInfoTreeBuilderFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Service;
+
+use OCA\Collectives\Db\PageLinkMapper;
+use OCA\Collectives\Db\PageMapper;
+use OCA\Collectives\Mount\CollectiveFolderManager;
+use OCP\Files\Folder;
+use OCP\IUserManager;
+use Symfony\Component\String\Slugger\SluggerInterface;
+
+/**
+ * Combines the dependency-injected collaborators with the per-call arguments
+ * required to build a PageInfoTreeBuilder.
+ */
+class PageInfoTreeBuilderFactory {
+	public function __construct(
+		private readonly PageMapper $pageMapper,
+		private readonly PageLinkMapper $pageLinkMapper,
+		private readonly IUserManager $userManager,
+		private readonly SluggerInterface $slugger,
+		private readonly CollectiveFolderManager $collectiveFolderManager,
+		private readonly CollectiveServiceBase $collectiveService,
+	) {
+	}
+
+	public function create(int $collectiveId, Folder $folder, string $userId, bool $recurse, bool $forceIndex): PageInfoTreeBuilder {
+		return new PageInfoTreeBuilder(
+			$this->pageMapper,
+			$this->pageLinkMapper,
+			$this->userManager,
+			$this->slugger,
+			$this->collectiveFolderManager,
+			$this->collectiveService,
+			$collectiveId,
+			$folder,
+			$userId,
+			$recurse,
+			$forceIndex,
+		);
+	}
+}

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -17,10 +17,13 @@ use OCA\Collectives\Db\PageMapper;
 use OCA\Collectives\Db\TagMapper;
 use OCA\Collectives\Fs\NodeHelper;
 use OCA\Collectives\Fs\UserFolderHelper;
+use OCA\Collectives\Model\CollectiveFileInfo;
 use OCA\Collectives\Model\PageInfo;
+use OCA\Collectives\Mount\CollectiveFolderManager;
 use OCA\Collectives\Trash\PageTrashBackend;
 use OCA\NotifyPush\Queue\IQueue;
 use OCP\App\IAppManager;
+use OCP\DB\Exception as DBException;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\InvalidPathException;
@@ -53,6 +56,7 @@ class PageService {
 		private readonly SluggerInterface $slugger,
 		private readonly TagMapper $tagMapper,
 		private readonly PageLinkMapper $pageLinkMapper,
+		private readonly CollectiveFolderManager $collectiveFolderManager,
 	) {
 		try {
 			$this->pushQueue = $container->get(IQueue::class);
@@ -434,81 +438,225 @@ class PageService {
 	}
 
 	/**
-	 * @throws FilesNotFoundException
+	 * Loads the whole collective page tree with a single filecache query
+	 * and batched metadata queries (no N+1 queries).
+	 *
+	 * @param bool $recurse Descend into subfolders; if false, only their index page is added
+	 * @param bool $forceIndex Create the entry folder's index page even if it has no pages
+	 *
+	 * @return PageInfo[]
+	 *
+	 * @throws MissingDependencyException
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 */
 	public function getPagesFromFolder(int $collectiveId, Folder $folder, string $userId, bool $recurse = false, bool $forceIndex = false): array {
-		$subPageInfos = [];
-		$folderNodes = $folder->getDirectoryListing();
+		try {
+			$fileInfos = $this->collectiveFolderManager->getFileCacheForCollective($collectiveId, $folder->getInternalPath());
+		} catch (DBException $e) {
+			throw new NotFoundException($e->getMessage(), 0, $e);
+		}
 
-		$hasPages = false;
-		$pageFiles = [];
-		foreach ($folderNodes as $node) {
-			if (str_starts_with($node->getName(), '.')) {
-				// Ignore hidden folders
+		// Group child entries by their parent folder file id
+		$childrenByParent = [];
+		foreach ($fileInfos as $fileInfo) {
+			$childrenByParent[$fileInfo->parent][] = $fileInfo;
+		}
+
+		// Batch load page metadata, links and display names
+		$pageFileIds = [];
+		foreach ($fileInfos as $fileInfo) {
+			if ($fileInfo->isPage()) {
+				$pageFileIds[] = $fileInfo->fileId;
+			}
+		}
+		$pagesByFileId = $this->pageMapper->findByFileIds($pageFileIds);
+		$linkedPageIdsByFileId = $this->pageLinkMapper->findByPageIds($pageFileIds);
+		$displayNames = [];
+		foreach ($pagesByFileId as $page) {
+			$lastUserId = $page->getLastUserId();
+			if ($lastUserId !== null && !isset($displayNames[$lastUserId])) {
+				$displayNames[$lastUserId] = $this->userManager->getDisplayName($lastUserId);
+			}
+		}
+
+		// Derive collectivePath from the mount point (incl. user folder prefix),
+		// matching PageInfo::fromFile().
+		$mountPoint = explode('/', $folder->getMountPoint()->getMountPoint(), 4);
+		$collectivePath = (count($mountPoint) >= 4)
+			? rtrim($mountPoint[3], '/')
+			: $this->getCollective($collectiveId, $userId)->getName();
+
+		$pageInfos = [];
+		$this->buildPageInfoTree(
+			$collectiveId,
+			$folder,
+			$folder->getId(),
+			0,
+			$forceIndex,
+			$recurse,
+			$childrenByParent,
+			$pagesByFileId,
+			$linkedPageIdsByFileId,
+			$displayNames,
+			$collectivePath,
+			$userId,
+			$pageInfos,
+		);
+
+		return $pageInfos;
+	}
+
+	/**
+	 * Recursively build PageInfo objects from the in-memory filecache tree.
+	 *
+	 * @param array<int, CollectiveFileInfo[]> $childrenByParent
+	 * @param array<int, Page> $pagesByFileId
+	 * @param array<int, int[]> $linkedPageIdsByFileId
+	 * @param array<string, null|string> $displayNames
+	 * @param PageInfo[] $pageInfos
+	 *
+	 * @throws MissingDependencyException
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 */
+	private function buildPageInfoTree(
+		int $collectiveId,
+		Folder $collectiveFolder,
+		int $folderId,
+		int $parentPageId,
+		bool $forceIndex,
+		bool $recurse,
+		array $childrenByParent,
+		array $pagesByFileId,
+		array $linkedPageIdsByFileId,
+		array $displayNames,
+		string $collectivePath,
+		string $userId,
+		array &$pageInfos,
+	): void {
+		$indexFileInfo = null;
+		$pageFileInfos = [];
+		$subFolderIds = [];
+		foreach ($childrenByParent[$folderId] ?? [] as $child) {
+			if (str_starts_with($child->name, '.')) {
+				// Ignore hidden folders and files
 				continue;
 			}
 
-			if ($node instanceof Folder) {
-				if ($recurse) {
-					// Recursive: get subpage infos from folder
-					try {
-						array_push($subPageInfos, ...$this->getPagesFromFolder($collectiveId, $node, $userId, true));
-					} catch (NotFoundException) {
-						// If parent folder doesn't have an index page, `getPagesFromFolder()` throws NotFoundException even though having subpages.
-						$hasPages = true;
-					}
-				} else {
-					// Not recursive: get index page of folder, as the folder is not to be processed
-					try {
-						$subPageInfos[] = $this->getPageByFile(self::getIndexPageFile($node), $node);
-					} catch (NotFoundException) {
-						// Ignore subfolders without index page
-					}
+			if (isset($childrenByParent[$child->fileId])) {
+				// Has children, so it's a (non-empty) folder
+				$subFolderIds[] = $child->fileId;
+			} elseif ($child->isIndexPage()) {
+				$indexFileInfo = $child;
+			} elseif ($child->isPage()) {
+				$pageFileInfos[] = $child;
+			}
+		}
+
+		if ($indexFileInfo === null) {
+			if (!$forceIndex && !$this->folderHasPages($folderId, $childrenByParent)) {
+				// Ignore folders without an index page and without any (sub)pages
+				return;
+			}
+
+			// Create missing index page if folder or subfolders have page files (or forceIndex)
+			$folder = $collectiveFolder->getFirstNodeById($folderId);
+			if (!($folder instanceof Folder)) {
+				return;
+			}
+			$indexPageInfo = $this->newPage($collectiveId, $folder, PageInfo::INDEX_PAGE_TITLE, $userId, PageInfo::INDEX_PAGE_TITLE);
+			$indexPageInfo->setParentId($parentPageId);
+			$indexPageId = $indexPageInfo->getId();
+		} else {
+			$indexPageInfo = $this->buildPageInfo($indexFileInfo, $parentPageId, $pagesByFileId, $linkedPageIdsByFileId, $displayNames, $collectivePath);
+			$indexPageId = $indexFileInfo->fileId;
+		}
+		$pageInfos[] = $indexPageInfo;
+
+		foreach ($pageFileInfos as $pageFileInfo) {
+			$pageInfos[] = $this->buildPageInfo($pageFileInfo, $indexPageId, $pagesByFileId, $linkedPageIdsByFileId, $displayNames, $collectivePath);
+		}
+
+		foreach ($subFolderIds as $subFolderId) {
+			if ($recurse) {
+				$this->buildPageInfoTree($collectiveId, $collectiveFolder, $subFolderId, $indexPageId, false, true, $childrenByParent, $pagesByFileId, $linkedPageIdsByFileId, $displayNames, $collectivePath, $userId, $pageInfos);
+				continue;
+			}
+
+			// Not recursive: only add the subfolder's index page (ignore subfolders without one)
+			$subIndexFileInfo = $this->findIndexPageInfo($subFolderId, $childrenByParent);
+			if ($subIndexFileInfo !== null) {
+				$pageInfos[] = $this->buildPageInfo($subIndexFileInfo, $indexPageId, $pagesByFileId, $linkedPageIdsByFileId, $displayNames, $collectivePath);
+			}
+		}
+	}
+
+	/**
+	 * @param array<int, CollectiveFileInfo[]> $childrenByParent
+	 */
+	private function findIndexPageInfo(int $folderId, array $childrenByParent): ?CollectiveFileInfo {
+		foreach ($childrenByParent[$folderId] ?? [] as $child) {
+			if ($child->isIndexPage()) {
+				return $child;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param array<int, CollectiveFileInfo[]> $childrenByParent
+	 */
+	private function folderHasPages(int $folderId, array $childrenByParent): bool {
+		foreach ($childrenByParent[$folderId] ?? [] as $child) {
+			if (str_starts_with($child->name, '.')) {
+				continue;
+			}
+
+			if (isset($childrenByParent[$child->fileId])) {
+				if ($this->folderHasPages($child->fileId, $childrenByParent)) {
+					return true;
 				}
-			} elseif ($node instanceof File && NodeHelper::isPage($node)) {
-				$hasPages = true;
-				$pageFiles[] = $node;
-				if (!isset($indexPage) && NodeHelper::isIndexPage($node)) {
-					$indexPage = $this->getPageByFile($node, $folder);
-				}
+			} elseif ($child->isPage()) {
+				return true;
 			}
 		}
 
-		// One of the subfolders had a page
-		if (isset($subPageInfos[0])) {
-			$hasPages = true;
-		}
+		return false;
+	}
 
-		if (!isset($indexPage)) {
-			if ($hasPages || $forceIndex) {
-				// Create missing index page if folder or subfolders have page files (or forceIndex)
-				$indexPage = $this->newPage($collectiveId, $folder, PageInfo::INDEX_PAGE_TITLE, $userId, PageInfo::INDEX_PAGE_TITLE);
-			} else {
-				// Ignore folders without an index page
-				return [];
-			}
-		}
+	/**
+	 * @param array<int, Page> $pagesByFileId
+	 * @param array<int, int[]> $linkedPageIdsByFileId
+	 * @param array<string, null|string> $displayNames
+	 */
+	private function buildPageInfo(
+		CollectiveFileInfo $fileInfo,
+		int $parentId,
+		array $pagesByFileId,
+		array $linkedPageIdsByFileId,
+		array $displayNames,
+		string $collectivePath,
+	): PageInfo {
+		$page = $pagesByFileId[$fileInfo->fileId] ?? null;
+		$lastUserId = $page?->getLastUserId();
+		$pageInfo = new PageInfo();
+		$pageInfo->fromFileInfo(
+			$fileInfo,
+			$parentId,
+			$collectivePath,
+			$lastUserId,
+			$lastUserId !== null ? ($displayNames[$lastUserId] ?? null) : null,
+			$page?->getEmoji(),
+			$page?->getSubpageOrder(),
+			$page !== null && $page->getFullWidth(),
+			$page?->getSlug(),
+			$page?->getTags(),
+			$linkedPageIdsByFileId[$fileInfo->fileId] ?? null,
+		);
 
-		// Add markdown files from this folder
-		$folderPageInfos = [];
-		foreach ($pageFiles as $pageFile) {
-			if (NodeHelper::isIndexPage($pageFile)) {
-				continue;
-			}
-
-			try {
-				$pageInfo = $this->getPageByFile($pageFile, $folder);
-			} catch (NotFoundException) {
-				// If parent folder doesn't have an index page, it throws NotFoundException.
-				continue;
-			}
-
-			$folderPageInfos[] = $pageInfo;
-		}
-
-		return array_merge([$indexPage], $folderPageInfos, $subPageInfos);
+		return $pageInfo;
 	}
 
 	/**

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -17,13 +17,10 @@ use OCA\Collectives\Db\PageMapper;
 use OCA\Collectives\Db\TagMapper;
 use OCA\Collectives\Fs\NodeHelper;
 use OCA\Collectives\Fs\UserFolderHelper;
-use OCA\Collectives\Model\CollectiveFileInfo;
 use OCA\Collectives\Model\PageInfo;
-use OCA\Collectives\Mount\CollectiveFolderManager;
 use OCA\Collectives\Trash\PageTrashBackend;
 use OCA\NotifyPush\Queue\IQueue;
 use OCP\App\IAppManager;
-use OCP\DB\Exception as DBException;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\InvalidPathException;
@@ -56,7 +53,7 @@ class PageService {
 		private readonly SluggerInterface $slugger,
 		private readonly TagMapper $tagMapper,
 		private readonly PageLinkMapper $pageLinkMapper,
-		private readonly CollectiveFolderManager $collectiveFolderManager,
+		private readonly PageInfoTreeBuilderFactory $pageInfoTreeBuilderFactory,
 	) {
 		try {
 			$this->pushQueue = $container->get(IQueue::class);
@@ -451,212 +448,11 @@ class PageService {
 	 * @throws NotPermittedException
 	 */
 	public function getPagesFromFolder(int $collectiveId, Folder $folder, string $userId, bool $recurse = false, bool $forceIndex = false): array {
-		try {
-			$fileInfos = $this->collectiveFolderManager->getFileCacheForCollective($collectiveId, $folder->getInternalPath());
-		} catch (DBException $e) {
-			throw new NotFoundException($e->getMessage(), 0, $e);
-		}
-
-		// Group child entries by their parent folder file id
-		$childrenByParent = [];
-		foreach ($fileInfos as $fileInfo) {
-			$childrenByParent[$fileInfo->parent][] = $fileInfo;
-		}
-
-		// Batch load page metadata, links and display names
-		$pageFileIds = [];
-		foreach ($fileInfos as $fileInfo) {
-			if ($fileInfo->isPage()) {
-				$pageFileIds[] = $fileInfo->fileId;
-			}
-		}
-		$pagesByFileId = $this->pageMapper->findByFileIds($pageFileIds);
-		$linkedPageIdsByFileId = $this->pageLinkMapper->findByPageIds($pageFileIds);
-		$displayNames = [];
-		foreach ($pagesByFileId as $page) {
-			$lastUserId = $page->getLastUserId();
-			if ($lastUserId !== null && !isset($displayNames[$lastUserId])) {
-				$displayNames[$lastUserId] = $this->userManager->getDisplayName($lastUserId);
-			}
-		}
-
-		// Derive collectivePath from the mount point (incl. user folder prefix),
-		// matching PageInfo::fromFile().
-		$mountPoint = explode('/', $folder->getMountPoint()->getMountPoint(), 4);
-		$collectivePath = (count($mountPoint) >= 4)
-			? rtrim($mountPoint[3], '/')
-			: $this->getCollective($collectiveId, $userId)->getName();
-
+		$builder = $this->pageInfoTreeBuilderFactory->create($collectiveId, $folder, $userId, $recurse, $forceIndex);
 		$pageInfos = [];
-		$this->buildPageInfoTree(
-			$collectiveId,
-			$folder,
-			$folder->getId(),
-			0,
-			$forceIndex,
-			$recurse,
-			$childrenByParent,
-			$pagesByFileId,
-			$linkedPageIdsByFileId,
-			$displayNames,
-			$collectivePath,
-			$userId,
-			$pageInfos,
-		);
+		$builder->build($folder->getId(), 0, $pageInfos);
 
 		return $pageInfos;
-	}
-
-	/**
-	 * Recursively build PageInfo objects from the in-memory filecache tree.
-	 *
-	 * @param array<int, CollectiveFileInfo[]> $childrenByParent
-	 * @param array<int, Page> $pagesByFileId
-	 * @param array<int, int[]> $linkedPageIdsByFileId
-	 * @param array<string, null|string> $displayNames
-	 * @param PageInfo[] $pageInfos
-	 *
-	 * @throws MissingDependencyException
-	 * @throws NotFoundException
-	 * @throws NotPermittedException
-	 */
-	private function buildPageInfoTree(
-		int $collectiveId,
-		Folder $collectiveFolder,
-		int $folderId,
-		int $parentPageId,
-		bool $forceIndex,
-		bool $recurse,
-		array $childrenByParent,
-		array $pagesByFileId,
-		array $linkedPageIdsByFileId,
-		array $displayNames,
-		string $collectivePath,
-		string $userId,
-		array &$pageInfos,
-	): void {
-		$indexFileInfo = null;
-		$pageFileInfos = [];
-		$subFolderIds = [];
-		foreach ($childrenByParent[$folderId] ?? [] as $child) {
-			if (str_starts_with($child->name, '.')) {
-				// Ignore hidden folders and files
-				continue;
-			}
-
-			if (isset($childrenByParent[$child->fileId])) {
-				// Has children, so it's a (non-empty) folder
-				$subFolderIds[] = $child->fileId;
-			} elseif ($child->isIndexPage()) {
-				$indexFileInfo = $child;
-			} elseif ($child->isPage()) {
-				$pageFileInfos[] = $child;
-			}
-		}
-
-		if ($indexFileInfo === null) {
-			if (!$forceIndex && !$this->folderHasPages($folderId, $childrenByParent)) {
-				// Ignore folders without an index page and without any (sub)pages
-				return;
-			}
-
-			// Create missing index page if folder or subfolders have page files (or forceIndex)
-			$folder = $collectiveFolder->getFirstNodeById($folderId);
-			if (!($folder instanceof Folder)) {
-				return;
-			}
-			$indexPageInfo = $this->newPage($collectiveId, $folder, PageInfo::INDEX_PAGE_TITLE, $userId, PageInfo::INDEX_PAGE_TITLE);
-			$indexPageInfo->setParentId($parentPageId);
-			$indexPageId = $indexPageInfo->getId();
-		} else {
-			$indexPageInfo = $this->buildPageInfo($indexFileInfo, $parentPageId, $pagesByFileId, $linkedPageIdsByFileId, $displayNames, $collectivePath);
-			$indexPageId = $indexFileInfo->fileId;
-		}
-		$pageInfos[] = $indexPageInfo;
-
-		foreach ($pageFileInfos as $pageFileInfo) {
-			$pageInfos[] = $this->buildPageInfo($pageFileInfo, $indexPageId, $pagesByFileId, $linkedPageIdsByFileId, $displayNames, $collectivePath);
-		}
-
-		foreach ($subFolderIds as $subFolderId) {
-			if ($recurse) {
-				$this->buildPageInfoTree($collectiveId, $collectiveFolder, $subFolderId, $indexPageId, false, true, $childrenByParent, $pagesByFileId, $linkedPageIdsByFileId, $displayNames, $collectivePath, $userId, $pageInfos);
-				continue;
-			}
-
-			// Not recursive: only add the subfolder's index page (ignore subfolders without one)
-			$subIndexFileInfo = $this->findIndexPageInfo($subFolderId, $childrenByParent);
-			if ($subIndexFileInfo !== null) {
-				$pageInfos[] = $this->buildPageInfo($subIndexFileInfo, $indexPageId, $pagesByFileId, $linkedPageIdsByFileId, $displayNames, $collectivePath);
-			}
-		}
-	}
-
-	/**
-	 * @param array<int, CollectiveFileInfo[]> $childrenByParent
-	 */
-	private function findIndexPageInfo(int $folderId, array $childrenByParent): ?CollectiveFileInfo {
-		foreach ($childrenByParent[$folderId] ?? [] as $child) {
-			if ($child->isIndexPage()) {
-				return $child;
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * @param array<int, CollectiveFileInfo[]> $childrenByParent
-	 */
-	private function folderHasPages(int $folderId, array $childrenByParent): bool {
-		foreach ($childrenByParent[$folderId] ?? [] as $child) {
-			if (str_starts_with($child->name, '.')) {
-				continue;
-			}
-
-			if (isset($childrenByParent[$child->fileId])) {
-				if ($this->folderHasPages($child->fileId, $childrenByParent)) {
-					return true;
-				}
-			} elseif ($child->isPage()) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * @param array<int, Page> $pagesByFileId
-	 * @param array<int, int[]> $linkedPageIdsByFileId
-	 * @param array<string, null|string> $displayNames
-	 */
-	private function buildPageInfo(
-		CollectiveFileInfo $fileInfo,
-		int $parentId,
-		array $pagesByFileId,
-		array $linkedPageIdsByFileId,
-		array $displayNames,
-		string $collectivePath,
-	): PageInfo {
-		$page = $pagesByFileId[$fileInfo->fileId] ?? null;
-		$lastUserId = $page?->getLastUserId();
-		$pageInfo = new PageInfo();
-		$pageInfo->fromFileInfo(
-			$fileInfo,
-			$parentId,
-			$collectivePath,
-			$lastUserId,
-			$lastUserId !== null ? ($displayNames[$lastUserId] ?? null) : null,
-			$page?->getEmoji(),
-			$page?->getSubpageOrder(),
-			$page !== null && $page->getFullWidth(),
-			$page?->getSlug(),
-			$page?->getTags(),
-			$linkedPageIdsByFileId[$fileInfo->fileId] ?? null,
-		);
-
-		return $pageInfo;
 	}
 
 	/**

--- a/tests/Unit/Service/PageServiceTest.php
+++ b/tests/Unit/Service/PageServiceTest.php
@@ -23,6 +23,7 @@ use OCA\Collectives\Mount\CollectiveFolderManager;
 use OCA\Collectives\Service\CollectiveServiceBase;
 use OCA\Collectives\Service\NotFoundException;
 use OCA\Collectives\Service\NotPermittedException;
+use OCA\Collectives\Service\PageInfoTreeBuilderFactory;
 use OCA\Collectives\Service\PageService;
 use OCA\Collectives\Service\SessionService;
 use OCP\Files\File;
@@ -103,6 +104,15 @@ class PageServiceTest extends TestCase {
 
 		$this->collectiveFolderManager = $this->createMock(CollectiveFolderManager::class);
 
+		$pageInfoTreeBuilderFactory = new PageInfoTreeBuilderFactory(
+			$this->pageMapper,
+			$pageLinkMapper,
+			$userManager,
+			$slugger,
+			$this->collectiveFolderManager,
+			$this->collectiveService,
+		);
+
 		$this->service = new PageService(
 			$appManager,
 			$this->pageMapper,
@@ -115,7 +125,7 @@ class PageServiceTest extends TestCase {
 			$slugger,
 			$tagMapper,
 			$pageLinkMapper,
-			$this->collectiveFolderManager,
+			$pageInfoTreeBuilderFactory,
 		);
 	}
 

--- a/tests/Unit/Service/PageServiceTest.php
+++ b/tests/Unit/Service/PageServiceTest.php
@@ -10,16 +10,16 @@ declare(strict_types=1);
 namespace Unit\Service;
 
 use OC\App\AppManager;
-use OC\Files\Mount\MountPoint;
 use OCA\Circles\Model\Member;
 use OCA\Collectives\Db\Collective;
-use OCA\Collectives\Db\Page;
 use OCA\Collectives\Db\PageLinkMapper;
 use OCA\Collectives\Db\PageMapper;
 use OCA\Collectives\Db\TagMapper;
 use OCA\Collectives\Fs\NodeHelper;
 use OCA\Collectives\Fs\UserFolderHelper;
+use OCA\Collectives\Model\CollectiveFileInfo;
 use OCA\Collectives\Model\PageInfo;
+use OCA\Collectives\Mount\CollectiveFolderManager;
 use OCA\Collectives\Service\CollectiveServiceBase;
 use OCA\Collectives\Service\NotFoundException;
 use OCA\Collectives\Service\NotPermittedException;
@@ -41,6 +41,7 @@ class PageServiceTest extends TestCase {
 	private NodeHelper $nodeHelper;
 	private CollectiveServiceBase $collectiveService;
 	private Folder $collectiveFolder;
+	private CollectiveFolderManager $collectiveFolderManager;
 	private PageService $service;
 	private string $userId = 'jane';
 	private int $collectiveId = 1;
@@ -100,6 +101,8 @@ class PageServiceTest extends TestCase {
 
 		$pageLinkMapper = $this->createMock(PageLinkMapper::class);
 
+		$this->collectiveFolderManager = $this->createMock(CollectiveFolderManager::class);
+
 		$this->service = new PageService(
 			$appManager,
 			$this->pageMapper,
@@ -112,6 +115,7 @@ class PageServiceTest extends TestCase {
 			$slugger,
 			$tagMapper,
 			$pageLinkMapper,
+			$this->collectiveFolderManager,
 		);
 	}
 
@@ -193,237 +197,130 @@ class PageServiceTest extends TestCase {
 		PageService::getIndexPageFile($folder);
 	}
 
-	private function prepareFile(string $fileName, Folder $parent, IMountPoint $mountPoint, int $id = 1): File {
-		$file = $this->createMock(File::class);
-		$file->method('getId')
-			->willReturn($id);
-		$file->method('getName')
-			->willReturn($fileName);
-		$file->method('getParent')
-			->willReturn($parent);
-		$file->method('getMountPoint')
-			->willReturn($mountPoint);
-		$file->method('getInternalPath')
-			->willReturn('.Collectives/testfolder/' . $fileName);
-		$file->method('getMTime')
-			->willReturn(0);
-		$file->method('getSize')
-			->willReturn(0);
+	private function fileInfo(int $fileId, int $parent, string $name, string $path): CollectiveFileInfo {
+		return new CollectiveFileInfo(
+			$fileId,
+			1,
+			$path,
+			$parent,
+			$name,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			'',
+			31,
+		);
+	}
 
-		return $file;
+	private function buildExpectedPageInfo(CollectiveFileInfo $fileInfo, int $parentId, string $collectivePath): PageInfo {
+		$pageInfo = new PageInfo();
+		$pageInfo->fromFileInfo($fileInfo, $parentId, $collectivePath);
+		return $pageInfo;
 	}
 
 	public function testGetPagesFromFolderWithSubfolderWithoutRecurse(): void {
-		$files = [];
-		$pageInfos = [];
-
-		$folder = $this->getMockBuilder(Folder::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$folder->method('getParent')
-			->willReturn($folder);
-		$folder->method('getName')
-			->willReturn('testfolder');
-
-		$mountPoint = $this->getMockBuilder(MountPoint::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$mountPoint->method('getMountPoint')->willReturn('/files/user/.Collectives/collective/');
-
-		$indexFile = $this->prepareFile('Readme.md', $folder, $mountPoint, 101);
-		$folder->method('get')
-			->willReturn($indexFile);
-		$indexPage = new Page();
-		$this->pageMapper->method('findByFileId')
-			->willReturn($indexPage);
-		$indexPageInfo = new PageInfo();
-		$indexPageInfo->fromFile($indexFile, 1);
-		$indexPageInfo->setParentId(101);
-		$indexPageInfo->setTitle('testfolder');
-
-		$files[] = $indexFile;
-		$pageInfos[] = $indexPageInfo;
-
-		// Add markdown files
-		$fileNameList = ['page1.md', 'page2.md'];
-		foreach ($fileNameList as $fileName) {
-			$file = $this->prepareFile($fileName, $folder, $mountPoint);
-			$files[] = $file;
-
-			$pageInfo = new PageInfo();
-			$pageInfo->fromFile($file, 1);
-			$pageInfo->setParentId(101);
-			$pageInfos[] = $pageInfo;
-		}
-
-		// Add subfolder
-		$subfolder = $this->createMock(Folder::class);
-		$subfolder->method('getId')
-			->willReturn(102);
-		$subfolder->method('getName')
-			->willReturn($fileName);
-		$subfolder->method('getParent')
-			->willReturn($folder);
-		$subfolder->method('getMountPoint')
-			->willReturn($mountPoint);
-		$subfolder->method('getInternalPath')
-			->willReturn('.Collectives/testfolder/' . $fileName);
-		$subfolder->method('getMTime')
-			->willReturn(0);
-		$subfolder->method('getSize')
-			->willReturn(0);
-
-		$subfolderIndexFile = $this->prepareFile('Readme.md', $subfolder, $mountPoint, 103);
-		$subfolderIndexPageInfo = new PageInfo();
-		$subfolderIndexPageInfo->fromFile($subfolderIndexFile, 1);
-		$subfolderIndexPageInfo->setParentId(101);
-
-		$subfolder->method('get')
-			->with(PageInfo::INDEX_PAGE_TITLE . PageInfo::SUFFIX)
-			->willReturn($subfolderIndexFile);
-
-		$files[] = $subfolder;
-		$pageInfos[] = $subfolderIndexPageInfo;
-
-		$folder->method('getDirectoryListing')
-			->willReturn($files);
-
-		self::assertEquals($pageInfos, $this->service->getPagesFromFolder($this->collectiveId, $folder, $this->userId));
-	}
-
-	public function testGetPagesFromFolderRecursive(): void {
-		$filesNotJustMd = [];
-		$filesJustMd = [];
-		$pageInfos = [];
-
-		$folder = $this->getMockBuilder(Folder::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$folder->method('getParent')
-			->willReturn($folder);
-		$folder->method('getName')
-			->willReturn('testfolder');
+		$collectivePath = '.Collectives/collective';
 
 		$mountPoint = $this->createMock(IMountPoint::class);
 		$mountPoint->method('getMountPoint')->willReturn('/files/user/.Collectives/collective/');
 
-		$indexFile = $this->prepareFile('Readme.md', $folder, $mountPoint, 101);
-		$folder->method('get')
-			->willReturn($indexFile);
-		$indexPage = new Page();
-		$this->pageMapper->method('findByFileId')
-			->willReturn($indexPage);
-		$indexPageInfo = new PageInfo();
-		$indexPageInfo->fromFile($indexFile, 1);
-		$indexPageInfo->setParentId(101);
-		$indexPageInfo->setTitle('testfolder');
+		$folder = $this->createMock(Folder::class);
+		$folder->method('getId')->willReturn(100);
+		$folder->method('getInternalPath')->willReturn('');
+		$folder->method('getMountPoint')->willReturn($mountPoint);
 
-		$filesJustMd[] = $indexFile;
-		$filesNotJustMd[] = $indexFile;
-		$pageInfos[] = $indexPageInfo;
+		$index = $this->fileInfo(101, 100, 'Readme.md', 'Readme.md');
+		$page1 = $this->fileInfo(1, 100, 'page1.md', 'page1.md');
+		$page2 = $this->fileInfo(2, 100, 'page2.md', 'page2.md');
+		$subfolder = $this->fileInfo(102, 100, 'subfolder', 'subfolder');
+		$subfolderIndex = $this->fileInfo(103, 102, 'Readme.md', 'subfolder/Readme.md');
 
-		$fileNameList = [ 'page1.md', 'page2.md', 'page3.md', 'another.jpg', 'whatever.txt' ];
-		foreach ($fileNameList as $fileName) {
-			// Add all files to $filesNotJustMd
-			$file = $this->prepareFile($fileName, $folder, $mountPoint);
+		$this->collectiveFolderManager->method('getFileCacheForCollective')
+			->willReturn([$index, $page1, $page2, $subfolder, $subfolderIndex]);
 
-			$filesNotJustMd[] = $file;
+		// Without recursion only the subfolder's index page is added
+		$expected = [
+			$this->buildExpectedPageInfo($index, 0, $collectivePath),
+			$this->buildExpectedPageInfo($page1, 101, $collectivePath),
+			$this->buildExpectedPageInfo($page2, 101, $collectivePath),
+			$this->buildExpectedPageInfo($subfolderIndex, 101, $collectivePath),
+		];
 
-			// Only add markdown files to $filesJustMd
-			if (!NodeHelper::isPage($file)) {
-				continue;
-			}
-
-			$filesJustMd[] = $file;
-
-			$pageInfo = new PageInfo();
-			$pageInfo->fromFile($file, 1);
-			$pageInfo->setParentId(101);
-			$pageInfos[] = $pageInfo;
-		}
-
-		$folder->method('getDirectoryListing')
-			->willReturnOnConsecutiveCalls(
-				$filesJustMd,
-				$filesNotJustMd,
-			);
-
-		self::assertEquals($pageInfos, $this->service->getPagesFromFolder($this->collectiveId, $folder, $this->userId, true));
-		self::assertEquals($pageInfos, $this->service->getPagesFromFolder($this->collectiveId, $folder, $this->userId, true));
+		self::assertEquals($expected, $this->service->getPagesFromFolder($this->collectiveId, $folder, $this->userId));
 	}
 
-	public function testGetPagesFromFolderWithMissingIndex(): void {
-		$files = [];
-		$pageInfos = [];
+	public function testGetPagesFromFolderRecursive(): void {
+		$collectivePath = '.Collectives/collective';
 
-		$mountPoint = $this->getMockBuilder(MountPoint::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$mountPoint = $this->createMock(IMountPoint::class);
 		$mountPoint->method('getMountPoint')->willReturn('/files/user/.Collectives/collective/');
 
 		$folder = $this->createMock(Folder::class);
-		$folder->method('getParent')
-			->willReturn($folder);
-		$folder->method('getName')
-			->willReturn('testfolder');
+		$folder->method('getId')->willReturn(100);
+		$folder->method('getInternalPath')->willReturn('');
+		$folder->method('getMountPoint')->willReturn($mountPoint);
 
-		$file1Name = 'page1.md';
-		$file1 = $this->getMockBuilder(File::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$file1->method('getId')
-			->willReturn(1);
-		$file1->method('getName')
-			->willReturn($file1Name);
-		$file1->method('getParent')
-			->willReturn($folder);
-		$file1->method('getMountPoint')
-			->willReturn($mountPoint);
-		$file1->method('getInternalPath')
-			->willReturn('.Collectives/testfolder/' . $file1Name);
-		$file1->method('getMTime')
-			->willReturn(0);
-		$file1->method('getSize')
-			->willReturn(0);
-		$files[] = $file1;
+		$index = $this->fileInfo(101, 100, 'Readme.md', 'Readme.md');
+		$page1 = $this->fileInfo(1, 100, 'page1.md', 'page1.md');
+		$subfolder = $this->fileInfo(102, 100, 'subfolder', 'subfolder');
+		$subfolderIndex = $this->fileInfo(103, 102, 'Readme.md', 'subfolder/Readme.md');
+		$subPage = $this->fileInfo(3, 102, 'page3.md', 'subfolder/page3.md');
 
-		$folder->method('getDirectoryListing')
-			->willReturn($files);
+		$this->collectiveFolderManager->method('getFileCacheForCollective')
+			->willReturn([$index, $page1, $subfolder, $subfolderIndex, $subPage]);
 
-		$pageInfo1 = new PageInfo();
-		$pageInfo1->fromFile($file1, 1);
-		$pageInfo1->setParentId(101);
-		$pageInfos[] = $pageInfo1;
+		// With recursion the subfolder's pages are added below its index page
+		$expected = [
+			$this->buildExpectedPageInfo($index, 0, $collectivePath),
+			$this->buildExpectedPageInfo($page1, 101, $collectivePath),
+			$this->buildExpectedPageInfo($subfolderIndex, 101, $collectivePath),
+			$this->buildExpectedPageInfo($subPage, 103, $collectivePath),
+		];
+
+		self::assertEquals($expected, $this->service->getPagesFromFolder($this->collectiveId, $folder, $this->userId, true));
+	}
+
+	public function testGetPagesFromFolderWithMissingIndex(): void {
+		$collectivePath = '.Collectives/collective';
+
+		$mountPoint = $this->createMock(IMountPoint::class);
+		$mountPoint->method('getMountPoint')->willReturn('/files/user/.Collectives/collective/');
+
+		$folder = $this->createMock(Folder::class);
+		$folder->method('getId')->willReturn(100);
+		$folder->method('getInternalPath')->willReturn('');
+		$folder->method('getMountPoint')->willReturn($mountPoint);
+
+		$page1 = $this->fileInfo(1, 100, 'page1.md', 'page1.md');
+		$this->collectiveFolderManager->method('getFileCacheForCollective')
+			->willReturn([$page1]);
+
+		// No index page present, so a new one gets created for the entry folder
+		$folder->method('getFirstNodeById')->willReturn($folder);
 
 		$indexFile = $this->createMock(File::class);
-		$indexFile->method('getId')
-			->willReturn(101);
-		$indexFile->method('getName')
-			->willReturn('Readme.md');
-		$folder->method('get')
-			->willReturn($indexFile);
-		$indexFile->method('getParent')
-			->willReturn($folder);
-		$indexFile->method('getMountPoint')
-			->willReturn($mountPoint);
-		$indexFile->method('getInternalPath')
-			->willReturn('.Collectives/testfolder/Readme.md');
-		$indexFile->method('getMTime')
-			->willReturn(0);
-		$indexFile->method('getSize')
-			->willReturn(0);
-		$folder->method('newFile')
-			->willReturn($indexFile);
+		$indexFile->method('getId')->willReturn(101);
+		$indexFile->method('getName')->willReturn('Readme.md');
+		$indexFile->method('getInternalPath')->willReturn('Readme.md');
+		$indexFile->method('getMountPoint')->willReturn($mountPoint);
+		$indexFile->method('getMTime')->willReturn(0);
+		$indexFile->method('getSize')->willReturn(0);
+		$folder->method('newFile')->willReturn($indexFile);
 
 		$indexPageInfo = new PageInfo();
-		$indexPageInfo->fromFile($indexFile, 1);
-		$indexPageInfo->setParentId(101);
-		$indexPageInfo->setTitle('testfolder');
+		$indexPageInfo->fromFile($indexFile, 0, $this->userId);
 		$indexPageInfo->setSlug('free-123');
-		$indexPageInfo->setLastUserId('jane');
-		array_unshift($pageInfos, $indexPageInfo);
+		$indexPageInfo->setParentId(0);
 
-		self::assertEquals($pageInfos, $this->service->getPagesFromFolder($this->collectiveId, $folder, $this->userId, true));
+		$expected = [
+			$indexPageInfo,
+			$this->buildExpectedPageInfo($page1, 101, $collectivePath),
+		];
+
+		self::assertEquals($expected, $this->service->getPagesFromFolder($this->collectiveId, $folder, $this->userId, true));
 	}
 
 	public function testGetPageLink(): void {


### PR DESCRIPTION
### 📝 Summary

This is alternative approach to #2390 that fixes same performance issue (closes #2380).

Benefits comparing to previous implementation:
- no extra columns
- no migration to re-process already existent page
- no listeners
- much simpler implementation

So, we're just load all necessary pages via simple query `SELECT * FROM filecache WHERE storage_id = <storageId> AND path LIKE 'appdata_<instanceId>/collectives/<collectiveId>/%'`

#### 🖼️ Screenshots

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9942fd11-aaff-4ad0-9f6a-850dd0d5aaaa" />

Collective with 390 pages with various nesting level

🏚️ Before | 🏡 After
---|---
**6.31s** | **5.20s**
<img width="300" alt="image" src="https://github.com/user-attachments/assets/0555549b-7b77-4756-9e77-4fac42f768ba" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/00c6202d-7978-41c1-be79-580ba11779b6" />
**747** queries - depends on pages count and nesting level | **50** queries - more or less constant
<img width="300" alt="image" src="https://github.com/user-attachments/assets/835c6faf-5dbe-48fb-91da-c76991b1c2a9" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/fc5d7047-cb78-4025-b716-c3deccaba854" />

### 🚧 TODO
- [x] As a future improvement we can consider to add index to `filecache` table to `storage_id, path` columns (but this requires extra PR to nextcloud/server) - see comment https://github.com/nextcloud/collectives/pull/2549#issuecomment-4765551936

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
