### PR TITLE
enh: improve fulltext search

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -339,7 +339,7 @@ Cypress.Commands.add('seedCircle', (name, config = null) => {
 			if (!circle) {
 				const response = await axios.post(
 					url,
-					{ name, personal: false, local: true },
+					{ name, personal: false },
 				)
 				circleId = response.data.ocs.data.id
 			} else {

--- a/lib/Search/FileSearch/Db/SearchDocMapper.php
+++ b/lib/Search/FileSearch/Db/SearchDocMapper.php
@@ -45,7 +45,6 @@ class SearchDocMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('d.file_id')
 			->selectAlias($qb->func()->sum('d.hit_count'), 'total_hits')
-			->selectAlias($qb->createFunction('MIN(w.term)'), 'matched_term')
 			->from($this->tableName, 'd')
 			->innerJoin('d', 'collectives_s_words', 'w', $qb->expr()->eq('d.word_id', 'w.id'))
 			->where($qb->expr()->eq('d.collective_id', $qb->createNamedParameter($collectiveId, IQueryBuilder::PARAM_INT)))

--- a/lib/Search/FileSearch/Db/SearchWordMapper.php
+++ b/lib/Search/FileSearch/Db/SearchWordMapper.php
@@ -27,7 +27,7 @@ class SearchWordMapper extends QBMapper {
 		parent::__construct($db, 'collectives_s_words', SearchWord::class);
 	}
 
-	public function upsert(int $collectiveId, string $term, string $stem, int $numHits, int $numFiles): SearchWord {
+	public function upsert(int $collectiveId, string $term, ?string $stem, int $numHits, int $numFiles): SearchWord {
 		$word = $this->findByCollectiveAndTerm($collectiveId, $term);
 
 		if ($word !== null) {

--- a/lib/Search/FileSearch/FileIndexer.php
+++ b/lib/Search/FileSearch/FileIndexer.php
@@ -22,6 +22,7 @@ use OCP\Files\NotFoundException;
 
 class FileIndexer {
 	private const LANGUAGE_DETECTION_LIMIT = 2000;
+	private const STEM_MAX_DISTANCE = 3;
 
 	public function __construct(
 		private readonly SearchWordMapper $wordMapper,
@@ -80,7 +81,9 @@ class FileIndexer {
 		foreach ($tokens as $token) {
 			$term = mb_substr($token, 0, 50);
 			$termCounts[$term] = ($termCounts[$term] ?? 0) + 1;
-			$termStems[$term] = $this->stemmer->stem($token, $language);
+			$stem = $this->stemmer->stem($token, $language);
+			$isUsefulStem = $stem !== $term && levenshtein($token, $stem) <= self::STEM_MAX_DISTANCE;
+			$termStems[$term] = $isUsefulStem ? $stem : null;
 		}
 
 		unset($content, $tokens);

--- a/lib/Search/FileSearch/FileSearcher.php
+++ b/lib/Search/FileSearch/FileSearcher.php
@@ -20,6 +20,9 @@ class FileSearcher {
 	private const SEARCH_LIMIT = 50;
 	private const FUZZY_PREFIX_LENGTH = 3;
 	public const FUZZY_MAX_DISTANCE = 1;
+	private const MATCH_TYPE_EXACT = 3;
+	private const MATCH_TYPE_PREFIX = 2;
+	private const MATCH_TYPE_STEM = 1;
 
 	public function __construct(
 		private readonly SearchWordMapper $wordMapper,
@@ -31,82 +34,43 @@ class FileSearcher {
 	) {
 	}
 
-	private function mergeResults(array $results, array $newResults): array {
-		$existingFileIds = array_column($results, 'file_id');
-		foreach ($newResults as $result) {
-			if (!in_array($result['file_id'], $existingFileIds)) {
-				$results[] = $result;
-			}
-		}
-		return $results;
-	}
-
 	public function search(int $collectiveId, string $query): array {
-		$tokens = $this->tokenizer->tokenize($query);
+		$languages = $this->fileMapper->getLanguagesByCollective($collectiveId) ?: [null];
+
+		$tokens = null;
+		foreach ($languages as $language) {
+			$languageTokens = $this->tokenizer->tokenize($query, $language);
+			$tokens = $tokens === null ? $languageTokens : array_intersect($tokens, $languageTokens);
+		}
+		$tokens = array_values($tokens ?? []);
+
 		if (empty($tokens)) {
 			return [];
 		}
 
-		// step 1: exact match on term
-		$exactWordIds = [];
+		$tokenResults = [];
+		$fileIdSets = [];
+
 		foreach ($tokens as $token) {
-			$exactWord = $this->wordMapper->findByCollectiveAndTerm($collectiveId, $token);
-			if ($exactWord !== null) {
-				$exactWordIds[] = $exactWord->getId();
+			$result = $this->findWordIdsForToken($collectiveId, $token, $languages);
+			if (empty($result['wordIds'])) {
+				continue;
 			}
+			$docs = $this->docMapper->findDocumentsByWords($collectiveId, $result['wordIds'], self::SEARCH_LIMIT);
+			$tokenResults[] = ['matchType' => $result['matchType'], 'docs' => $docs];
+			$fileIdSets[] = array_column($docs, 'file_id');
 		}
 
-		$results = !empty($exactWordIds)
-			? $this->docMapper->findDocumentsByWords($collectiveId, $exactWordIds, self::SEARCH_LIMIT)
-			: [];
-
-		$remainingLimit = self::SEARCH_LIMIT - count($results);
-		if ($remainingLimit <= 0) {
-			return $results;
+		if (empty($fileIdSets)) {
+			return [];
 		}
 
-		// step 2: prefix match on term
-		$prefixWordIds = [];
-		foreach ($tokens as $token) {
-			$prefixWords = $this->wordMapper->findByCollectiveAndPrefix($collectiveId, $token, $remainingLimit);
-			foreach ($prefixWords as $word) {
-				if (!in_array($word->getId(), $exactWordIds)) {
-					$prefixWordIds[] = $word->getId();
-				}
-			}
+		$matchingFileIds = array_intersect(...$fileIdSets);
+		if (empty($matchingFileIds)) {
+			return [];
 		}
 
-		$prefixWordIds = array_unique($prefixWordIds);
-		$prefixResults = !empty($prefixWordIds)
-			? $this->docMapper->findDocumentsByWords($collectiveId, $prefixWordIds, $remainingLimit)
-			: [];
-		$results = $this->mergeResults($results, $prefixResults);
-
-		$remainingLimit = self::SEARCH_LIMIT - count($results);
-		if ($remainingLimit <= 0) {
-			return $results;
-		}
-
-		// step 3: stem match with fuzzy fallback
-		$languages = $this->fileMapper->getLanguagesByCollective($collectiveId) ?: [null];
-		$stemWordIds = [];
-		foreach ($tokens as $token) {
-			foreach ($languages as $language) {
-				$stem = $this->stemmer->stem($token, $language);
-				$stemWords = $this->wordMapper->findByCollectiveAndStem($collectiveId, $stem)
-					?: $this->fuzzySearchWord($collectiveId, $token);
-				foreach ($stemWords as $word) {
-					$stemWordIds[] = $word->getId();
-				}
-			}
-		}
-
-		$stemWordIds = array_unique($stemWordIds);
-		$stemResults = !empty($stemWordIds)
-			? $this->docMapper->findDocumentsByWords($collectiveId, $stemWordIds, $remainingLimit)
-			: [];
-
-		return $this->mergeResults($results, $stemResults);
+		return $this->rankResults($tokenResults, $matchingFileIds);
 	}
 
 	public function rankByBigrams(string $query, array $files): array {
@@ -159,5 +123,56 @@ class FileSearcher {
 		}
 
 		return $matches;
+	}
+
+	private function findWordIdsForToken(int $collectiveId, string $token, array $languages): array {
+		// step 1: exact match
+		$exactWord = $this->wordMapper->findByCollectiveAndTerm($collectiveId, $token);
+
+		// step 2: prefix match
+		$prefixWords = $this->wordMapper->findByCollectiveAndPrefix($collectiveId, $token, self::SEARCH_LIMIT);
+
+		if ($exactWord !== null || !empty($prefixWords)) {
+			$wordIds = array_unique(array_map(fn ($w) => $w->getId(), $prefixWords));
+			if ($exactWord !== null && !in_array($exactWord->getId(), $wordIds)) {
+				$wordIds[] = $exactWord->getId();
+			}
+			$matchType = $exactWord !== null ? self::MATCH_TYPE_EXACT : self::MATCH_TYPE_PREFIX;
+			return ['wordIds' => $wordIds, 'matchType' => $matchType];
+		}
+
+		// step 3: stem match with fuzzy fallback
+		$wordIds = [];
+		foreach ($languages as $language) {
+			$stem = $this->stemmer->stem($token, $language);
+			$stemWords = $this->wordMapper->findByCollectiveAndStem($collectiveId, $stem)
+				?: $this->fuzzySearchWord($collectiveId, $token);
+			foreach ($stemWords as $word) {
+				$wordIds[] = $word->getId();
+			}
+		}
+		return ['wordIds' => array_unique($wordIds), 'matchType' => self::MATCH_TYPE_STEM];
+	}
+
+	private function rankResults(array $tokenResults, array $matchingFileIds): array {
+		$fileScores = [];
+		$allDocs = [];
+
+		foreach ($tokenResults as $tokenResult) {
+			foreach ($tokenResult['docs'] as $doc) {
+				$fileId = $doc['file_id'];
+				if (!in_array($fileId, $matchingFileIds)) {
+					continue;
+				}
+				$fileScores[$fileId] = ($fileScores[$fileId] ?? 0)
+					+ $tokenResult['matchType']
+					+ log1p((int)$doc['total_hits']);
+				$allDocs[$fileId] ??= $doc;
+			}
+		}
+
+		usort($allDocs, fn ($a, $b) => ($fileScores[$b['file_id']] ?? 0) <=> ($fileScores[$a['file_id']] ?? 0));
+
+		return array_slice($allDocs, 0, self::SEARCH_LIMIT);
 	}
 }

--- a/lib/Search/FileSearch/FileSearcher.php
+++ b/lib/Search/FileSearch/FileSearcher.php
@@ -57,15 +57,16 @@ class FileSearcher {
 			$isLastToken = $index === $lastIndex;
 			$result = $this->findWordIdsForToken($collectiveId, $token, $languages, $isLastToken);
 			if (empty($result['wordIds'])) {
-				continue;
+				return [];
 			}
+
 			$docs = $this->docMapper->findDocumentsByWords($collectiveId, $result['wordIds'], self::TOKEN_CANDIDATE_LIMIT);
+			if (empty($docs)) {
+				return [];
+			}
+
 			$tokenResults[] = ['matchType' => $result['matchType'], 'docs' => $docs];
 			$fileIdSets[] = array_column($docs, 'file_id');
-		}
-
-		if (empty($fileIdSets)) {
-			return [];
 		}
 
 		$matchingFileIds = array_intersect(...$fileIdSets);
@@ -171,7 +172,7 @@ class FileSearcher {
 				}
 				$fileScores[$fileId] = ($fileScores[$fileId] ?? 0)
 					+ $tokenResult['matchType']
-					+ log1p((int)$doc['total_hits']);
+					* log1p((int)$doc['total_hits']);
 				$allDocs[$fileId] ??= $doc;
 			}
 		}

--- a/lib/Search/FileSearch/FileSearcher.php
+++ b/lib/Search/FileSearch/FileSearcher.php
@@ -17,9 +17,10 @@ use OCA\Collectives\Search\FileSearch\Tokenizer\ClauseTokenizer;
 use OCA\Collectives\Search\FileSearch\Tokenizer\WordTokenizer;
 
 class FileSearcher {
-	private const SEARCH_LIMIT = 50;
+	private const TOKEN_CANDIDATE_LIMIT = 500;
+	private const SEARCH_RESULT_LIMIT = 50;
 	private const FUZZY_PREFIX_LENGTH = 3;
-	public const FUZZY_MAX_DISTANCE = 1;
+	private const FUZZY_MAX_DISTANCE = 1;
 	private const MATCH_TYPE_EXACT = 3;
 	private const MATCH_TYPE_PREFIX = 2;
 	private const MATCH_TYPE_STEM = 1;
@@ -50,13 +51,15 @@ class FileSearcher {
 
 		$tokenResults = [];
 		$fileIdSets = [];
+		$lastIndex = array_key_last($tokens);
 
-		foreach ($tokens as $token) {
-			$result = $this->findWordIdsForToken($collectiveId, $token, $languages);
+		foreach ($tokens as $index => $token) {
+			$isLastToken = $index === $lastIndex;
+			$result = $this->findWordIdsForToken($collectiveId, $token, $languages, $isLastToken);
 			if (empty($result['wordIds'])) {
 				continue;
 			}
-			$docs = $this->docMapper->findDocumentsByWords($collectiveId, $result['wordIds'], self::SEARCH_LIMIT);
+			$docs = $this->docMapper->findDocumentsByWords($collectiveId, $result['wordIds'], self::TOKEN_CANDIDATE_LIMIT);
 			$tokenResults[] = ['matchType' => $result['matchType'], 'docs' => $docs];
 			$fileIdSets[] = array_column($docs, 'file_id');
 		}
@@ -112,7 +115,7 @@ class FileSearcher {
 		}
 
 		$prefix = mb_substr($term, 0, self::FUZZY_PREFIX_LENGTH);
-		$candidates = $this->wordMapper->findByCollectiveAndPrefix($collectiveId, $prefix, self::SEARCH_LIMIT);
+		$candidates = $this->wordMapper->findByCollectiveAndPrefix($collectiveId, $prefix, self::TOKEN_CANDIDATE_LIMIT);
 
 		$matches = [];
 		foreach ($candidates as $candidate) {
@@ -125,13 +128,15 @@ class FileSearcher {
 		return $matches;
 	}
 
-	private function findWordIdsForToken(int $collectiveId, string $token, array $languages): array {
+	private function findWordIdsForToken(int $collectiveId, string $token, array $languages, bool $isLastToken = false): array {
 		// step 1: exact match
 		$exactWord = $this->wordMapper->findByCollectiveAndTerm($collectiveId, $token);
+		if ($exactWord !== null && !$isLastToken) {
+			return ['wordIds' => [$exactWord->getId()], 'matchType' => self::MATCH_TYPE_EXACT];
+		}
 
 		// step 2: prefix match
-		$prefixWords = $this->wordMapper->findByCollectiveAndPrefix($collectiveId, $token, self::SEARCH_LIMIT);
-
+		$prefixWords = $this->wordMapper->findByCollectiveAndPrefix($collectiveId, $token, self::TOKEN_CANDIDATE_LIMIT);
 		if ($exactWord !== null || !empty($prefixWords)) {
 			$wordIds = array_unique(array_map(fn ($w) => $w->getId(), $prefixWords));
 			if ($exactWord !== null && !in_array($exactWord->getId(), $wordIds)) {
@@ -173,6 +178,6 @@ class FileSearcher {
 
 		usort($allDocs, fn ($a, $b) => ($fileScores[$b['file_id']] ?? 0) <=> ($fileScores[$a['file_id']] ?? 0));
 
-		return array_slice($allDocs, 0, self::SEARCH_LIMIT);
+		return array_slice($allDocs, 0, self::SEARCH_RESULT_LIMIT);
 	}
 }

--- a/lib/Search/PageContentProvider.php
+++ b/lib/Search/PageContentProvider.php
@@ -38,6 +38,7 @@ class PageContentProvider implements IProvider {
 		private readonly SearchService $indexedSearchService,
 		private readonly LoggerInterface $logger,
 		private readonly IAppManager $appManager,
+		private readonly WordTokenizer $tokenizer,
 	) {
 	}
 
@@ -87,13 +88,11 @@ class PageContentProvider implements IProvider {
 					continue;
 				}
 
-				$pages[$fileId] = ['file' => $fileEntry, 'matched_term' => $fileData['matched_term']];
+				$pages[$fileId] = $fileEntry;
 				$collectiveMap[$fileId] = $collective;
 			}
 		}
 
-		$pageData = $pages;
-		$pages = array_map(fn ($p) => $p['file'], $pages);
 		$pages = $this->indexedSearchService->rankByBigrams($query->getTerm(), $pages);
 
 		$pageSearchResults = [];
@@ -112,9 +111,7 @@ class PageContentProvider implements IProvider {
 
 			$content = $page->getContent();
 			$normalizedContent = WordTokenizer::normalize($content);
-
-			$pos = mb_stripos($normalizedContent, $pageData[$page->getId()]['matched_term'] ?? $query->getTerm());
-			$pos = $pos !== false ? $pos : 0;
+			$pos = $this->findSnippetPosition($normalizedContent, $query->getTerm());
 
 			$pageSearchResults[] = new SearchResultEntry(
 				'',
@@ -137,5 +134,46 @@ class PageContentProvider implements IProvider {
 		} catch (Exception) {
 			return null;
 		}
+	}
+
+	private function findSnippetPosition(string $content, string $query): int {
+		// try exact phrase first
+		$pos = mb_stripos($content, $query);
+		if ($pos !== false) {
+			return $pos;
+		}
+
+		// fall back to finding section with most tokens
+		$tokens = $this->tokenizer->tokenize($query);
+		$positions = [];
+		foreach ($tokens as $token) {
+			$offset = 0;
+			while (($pos = mb_stripos($content, $token, $offset)) !== false) {
+				$positions[] = $pos;
+				$offset = $pos + 1;
+			}
+		}
+
+		if (empty($positions)) {
+			return 0;
+		}
+
+		sort($positions);
+		$bestStart = $positions[0];
+		$bestScore = 0;
+
+		foreach ($positions as $startPos) {
+			$score = count(array_filter($tokens, function ($token) use ($content, $startPos) {
+				$pos = mb_stripos($content, $token, $startPos);
+				return $pos !== false && $pos <= $startPos + 200;
+			}));
+
+			if ($score > $bestScore || ($score === $bestScore && $startPos < $bestStart)) {
+				$bestScore = $score;
+				$bestStart = $startPos;
+			}
+		}
+
+		return $bestStart;
 	}
 }

--- a/tests/Unit/Search/PageContentProviderTest.php
+++ b/tests/Unit/Search/PageContentProviderTest.php
@@ -11,6 +11,7 @@ namespace Unit\Service;
 
 use OC\Search\SearchQuery;
 use OCA\Collectives\Db\Collective;
+use OCA\Collectives\Search\FileSearch\Tokenizer\WordTokenizer;
 use OCA\Collectives\Search\PageContentProvider;
 use OCA\Collectives\Service\CollectiveHelper;
 use OCA\Collectives\Service\PageService;
@@ -60,6 +61,8 @@ class PageContentProviderTest extends TestCase {
 		$appManager = $this->createMock(IAppManager::class);
 		$appManager->method('isEnabledForUser')
 			->willReturn(true);
+		/** @var WordTokenizer&MockObject $tokenizer */
+		$tokenizer = $this->createMock(WordTokenizer::class);
 
 		$this->provider = new PageContentProvider(
 			$l10n,
@@ -68,7 +71,8 @@ class PageContentProviderTest extends TestCase {
 			$pageService,
 			$indexedSearchService,
 			$logger,
-			$appManager
+			$appManager,
+			$tokenizer
 		);
 	}
 


### PR DESCRIPTION
Fixes #2559

### 📝 Summary
Collectives fulltext search improvements with a focus on sentence search, stem distance limiting and result ranking.

### Changes
- AND search for multi-token queries, only return documents containing all search terms
- improved multi-token ranking using a match type scoring across all matched tokens
- stem distance limit, stems too far from the original token are not indexed anymore, reducing noise
- improve snippet preview, shows the exact phrase if found, otherwise the section containing the most matched tokens
- prefix match always runs alongside exact match for the last token, to prevent short tokens from blocking results

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
