### PR TITLE
fix: render search dialog query without escaped quotes

### DIFF
--- a/src/components/Page/SearchDialog.vue
+++ b/src/components/Page/SearchDialog.vue
@@ -43,7 +43,7 @@
 				{{ t('collectives', 'Found {matches} matches for "{query}"', {
 					matches: results.totalMatches ?? 0,
 					query: searchQuery,
-				}) }}
+				}, { escape: false }) }}
 			</span>
 
 			<span v-else>
@@ -51,7 +51,7 @@
 					index: results.matchIndex + 1,
 					matches: results.totalMatches,
 					query: searchQuery,
-				}) }}
+				}, { escape: false }) }}
 			</span>
 		</div>
 


### PR DESCRIPTION
Summary
- Render search dialog query placeholders without l10n HTML entity escaping so quoted searches display with literal quote characters.

Testing
- `git diff --check`

Closes #2576