### PR TITLE
chore(test) mention search for members more stricly

### DIFF
--- a/playwright/e2e/page-content.spec.ts
+++ b/playwright/e2e/page-content.spec.ts
@@ -56,8 +56,9 @@ test.describe('Page content', () => {
 
 		editor.setMode(true)
 		await editor.getContent().fill('@')
-		for (const userId of [user.account.userId, ...extraMemberIds]) {
-			await expect(editor.getMentionSuggestions()).toContainText(userId)
-		}
+		await expect(editor.getMentionSuggestions({ limit: 3 })).toHaveText([
+			user.account.userId,
+			...extraMemberIds.sort(),
+		])
 	})
 })

--- a/playwright/support/sections/EditorSection.ts
+++ b/playwright/support/sections/EditorSection.ts
@@ -135,7 +135,11 @@ export class EditorSection {
 			.click()
 	}
 
-	public getMentionSuggestions(): Locator {
-		return this.page.getByRole('tooltip').locator('.suggestion-list')
+	public getMentionSuggestions({ limit }: { limit?: number } = {}): Locator {
+		// only pick the first `limit` elements
+		const limitSelector = limit
+			? `:nth-child(-n+${limit})`
+			: ''
+		return this.page.getByRole('tooltip').locator('.suggestion-list__item' + limitSelector)
 	}
 }


### PR DESCRIPTION
Make sure the members are actually top of the list.

Before this test was passing randomly
even though the functionality was missing on stable32.

With few users on the instance, chances were all members would be in the search result.

Tests for https://github.com/nextcloud/text/pull/8784.
