### PR TITLE
fix: show absolute timestamp on hover

### DIFF
--- a/src/components/LastUserBubble.vue
+++ b/src/components/LastUserBubble.vue
@@ -11,7 +11,7 @@
 		<NcUserBubble
 			:displayName="lastUserDisplayName"
 			:user="lastUserId" />
-		<span class="timestamp">
+		<span class="timestamp" :title="lastUpdateTitle">
 			{{ lastUpdate }}
 		</span>
 	</div>
@@ -54,6 +54,10 @@ export default {
 	computed: {
 		lastUpdate() {
 			return moment.unix(this.timestamp).fromNow()
+		},
+
+		lastUpdateTitle() {
+			return moment.unix(this.timestamp).format('LLL')
 		},
 	},
 

--- a/src/components/Page/LandingPageWidgets/RecentPageTile.vue
+++ b/src/components/Page/LandingPageWidgets/RecentPageTile.vue
@@ -24,7 +24,7 @@
 					:displayName="page.lastUserDisplayName || ''"
 					disableMenu
 					:size="24" />
-				<span class="timestamp">
+				<span class="timestamp" :title="lastUpdateTitle">
 					{{ lastUpdate }}
 				</span>
 			</div>
@@ -81,6 +81,10 @@ export default {
 
 		lastUpdate() {
 			return moment.unix(this.page.timestamp).fromNow()
+		},
+
+		lastUpdateTitle() {
+			return moment.unix(this.page.timestamp).format('LLL')
 		},
 	},
 }

--- a/src/components/Page/NcActionLastUser.vue
+++ b/src/components/Page/NcActionLastUser.vue
@@ -62,7 +62,6 @@ export default {
 	border-radius: 0;
 	background-color: transparent;
 	box-shadow: none;
-	cursor: default;
 	font-weight: normal;
 	font-size: var(--default-font-size);
 	line-height: var(--default-clickable-area);

--- a/src/components/Page/NcActionLastUser.vue
+++ b/src/components/Page/NcActionLastUser.vue
@@ -5,13 +5,13 @@
 
 <template>
 	<li v-if="lastUserDisplayName" class="action action--user-bubble">
-		<button class="action-button action-button--user-bubble" type="button">
+		<div class="action-button action-button--user-bubble">
 			<ClockIcon :size="20" />
 			<LastUserBubble
 				:lastUserId
 				:lastUserDisplayName
 				:timestamp />
-		</button>
+		</div>
 	</li>
 </template>
 
@@ -47,14 +47,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.action--user-bubble {
-	pointer-events: none;
-}
-
-.action--user-bubble :deep(.timestamp) {
-	pointer-events: auto;
-}
-
 .action-button--user-bubble {
 	display: flex;
 	align-items: flex-start;
@@ -70,6 +62,7 @@ export default {
 	border-radius: 0;
 	background-color: transparent;
 	box-shadow: none;
+	cursor: default;
 	font-weight: normal;
 	font-size: var(--default-font-size);
 	line-height: var(--default-clickable-area);

--- a/src/components/Page/NcActionLastUser.vue
+++ b/src/components/Page/NcActionLastUser.vue
@@ -51,6 +51,10 @@ export default {
 	pointer-events: none;
 }
 
+.action--user-bubble :deep(.timestamp) {
+	pointer-events: auto;
+}
+
 .action-button--user-bubble {
 	display: flex;
 	align-items: flex-start;


### PR DESCRIPTION
Summary

- Add an absolute timestamp title to the relative last-updated display.
- Allow the timestamp text in the action menu item to receive hover events for the native tooltip.

Testing

- git diff --check
- npx eslint --ext .vue src/components/LastUserBubble.vue src/components/Page/NcActionLastUser.vue --max-warnings=0
- npx stylelint src/components/LastUserBubble.vue src/components/Page/NcActionLastUser.vue

Closes #2597