### PR TITLE
chore(CI): make psalm migrations run on forks

### DIFF
--- a/.github/workflows/psalm-migrations.yml
+++ b/.github/workflows/psalm-migrations.yml
@@ -39,10 +39,21 @@ jobs:
           ref: 'v${{ steps.collectives_app.outputs.version }}'
           persist-credentials: false
 
-      - name: Checkout migrations from main branch
+      - name: Checkout migrations from this branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: tmp
+          sparse-checkout: lib/Migration
+
+      - name: Copy over migrations
         run: |
-          git fetch origin ${{ env.BRANCH }}
-          git checkout origin/${{ env.BRANCH }} -- lib/Migration
+          rm -rf lib/Migration
+          cp tmp/lib/Migration lib/Migration -r
+          rm -rf tmp
+
+      - name: Git status
+        run: |
+          git status
 
       - name: Get php version
         id: versions


### PR DESCRIPTION
### 📝 Summary

* Resolves: CI failures such as https://github.com/nextcloud/collectives/actions/runs/28421419294/job/84215169350?pr=2604

<!-- Write a summary of your change and some reasoning if needed -->

#### 🖼️ Screenshots

🏚️ Before | 🏡 After (happy path) | 🏡 After (catching error)
---|---|---
<img width="494" height="217" alt="grafik" src="https://github.com/user-attachments/assets/af967b08-d741-42bf-a9f0-512b97a1ad3e" /> | <img width="671" height="670" alt="grafik" src="https://github.com/user-attachments/assets/99ee0e81-a8ed-46e4-a3c0-dca83718e329" /> | <img width="671" height="670" alt="grafik" src="https://github.com/user-attachments/assets/0fb8c445-9ec2-4245-8930-b3896ae83454" />

### 🚧 TODO

- [x] confirm this works on this PR

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests - tested with this PR
- [x] Documentation is not required
