### PR TITLE
chore: Add dummy implementation of getCacheableRootsForUser

### DIFF
--- a/lib/Trash/PageTrashBackend.php
+++ b/lib/Trash/PageTrashBackend.php
@@ -649,4 +649,9 @@ class PageTrashBackend implements ITrashBackend {
 		}
 		return $trashFilename;
 	}
+
+	public function getCacheableRootsForUser(IUser $user): array {
+		// TODO provide an actual implementation
+		return [];
+	}
 }


### PR DESCRIPTION
### 📝 Summary

See https://github.com/nextcloud/server/pull/54317

Unfortunately I don't have the capacity to provide an actual implementation of the method for collectives. But the dummy implementation at least ensure collectives continue working as before

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required

### 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI tools
- [ ] The AI-generated content was reviewed, comprehended and tested by a human
