### PR TITLE
fix(EmojiHelper): check if PCRE version has Extended_Pictographic support

### DIFF
--- a/lib/Service/EmojiHelper.php
+++ b/lib/Service/EmojiHelper.php
@@ -14,6 +14,15 @@ namespace OCA\Collectives\Service;
  */
 class EmojiHelper {
 	public const MAX_LENGTH = 8;
+	private static ?bool $hasExtendedPictographic = null;
+
+	/**
+	 * PCRE2 < 10.35 lacks Extended_Pictographic property
+	 */
+	private static function supportsExtendedPictographic(): bool {
+		self::$hasExtendedPictographic ??= @preg_match('/\p{Extended_Pictographic}/u', '😀') === 1;
+		return self::$hasExtendedPictographic;
+	}
 
 	/**
 	 * @throws UnprocessableEntityException
@@ -31,11 +40,13 @@ class EmojiHelper {
 			throw new UnprocessableEntityException('Emoji validation is not available');
 		}
 
+		// Enforce a single visual character
 		if (grapheme_strlen($emoji) !== 1) {
 			throw new UnprocessableEntityException('Emoji must be a single emoji character');
 		}
 
-		if (preg_match('/\p{Extended_Pictographic}/u', $emoji) !== 1) {
+		// Enforce a pictographic character (i.e. an emoji)
+		if (self::supportsExtendedPictographic() && preg_match('/\p{Extended_Pictographic}/u', $emoji) !== 1) {
 			throw new UnprocessableEntityException('Emoji is not valid');
 		}
 


### PR DESCRIPTION
Fixes creating collectives with an emoji on systems with PCRE < 10.35.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
