### PR TITLE
chore(playwright): use `list` reporter when run locally

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,7 @@ import { defineConfig, devices } from '@playwright/test'
  */
 const LOCAL_CONFIG = {
 	// Just the html report with the traces
-	reporter: 'html',
+	reporter: 'list',
 } as const
 
 /**


### PR DESCRIPTION
Spawning the browser to show HTML report after failed tests turned out to be rather annoying to me.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
