### PR TITLE
chore(npm): allow scripts of known NPM dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,14 @@
   "engines": {
     "node": "^24.0.0",
     "npm": "^11.3.0"
+  },
+  "allowScripts": {
+    "@parcel/watcher": true,
+    "core-js": true,
+    "cpu-features": true,
+    "cypress": true,
+    "esbuild": true,
+    "protobufjs": true,
+    "ssh2": true
   }
 }


### PR DESCRIPTION
Starting with NPM v12, scripts defined by dependencies need to be allowed explicitely to protect against supply-chain attacks.

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
