### PR TITLE
fix: stop navigation when page creation fails

### DIFF
--- a/src/mixins/pageMixin.js
+++ b/src/mixins/pageMixin.js
@@ -66,6 +66,7 @@ export default {
 			} catch (e) {
 				console.error(e)
 				showError(t('collectives', 'Could not create the page'))
+				return
 			}
 
 			await this.$router.push(this.newPagePath)


### PR DESCRIPTION
### 📝 Summary

* Resolves: # <!-- related GitHub issue -->

<!-- Write a summary of your change and some reasoning if needed -->

Prevent Collectives from navigating to a new-page route when the page creation request fails.

Related to #2167.

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [x] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required

### 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI tools
- [ ] The AI-generated content was reviewed, comprehended and tested by a human
