### PR TITLE
fix(files): Collectives banner activation for matching folder paths

### DIFF
--- a/src/views/FileListInfo.vue
+++ b/src/views/FileListInfo.vue
@@ -89,7 +89,12 @@ export default {
 		},
 
 		setActive() {
-			this.active = collectivesFolder && collectivesFolder !== '/' && this.internalPath.startsWith(collectivesFolder)
+			const folder = collectivesFolder?.replace(/\/$/, '')
+			this.active = Boolean(
+				folder
+				&& folder !== '/'
+				&& (this.internalPath === folder || this.internalPath.startsWith(folder + '/')),
+			)
 		},
 	},
 }


### PR DESCRIPTION
### 📝 Summary

* Resolves: # <!-- related GitHub issue -->

<!-- Write a summary of your change and some reasoning if needed -->

Fixes a potential issue where the Collectives Files banner could be activated for paths that only partially matched the configured Collectives folder.

The previous `startsWith()` check could treat a folder such as `/Collectives-old` as being inside `/Collectives`. 

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required

### 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI tools
- [ ] The AI-generated content was reviewed, comprehended and tested by a human
