### PR TITLE
feat: Optimize users fetching by moving member management to the Circles

### DIFF
--- a/src/components/Member/CurrentMembers.vue
+++ b/src/components/Member/CurrentMembers.vue
@@ -101,7 +101,7 @@ export default {
 		isCurrentUser() {
 			return (item) => {
 				return item.userId === this.currentUser
-					|| item.singleId === item.circle.initiator.singleId
+					|| item.singleId === item.circle?.initiator?.singleId
 			}
 		},
 	},

--- a/src/components/Page/LandingPageWidgets/MembersWidget.vue
+++ b/src/components/Page/LandingPageWidgets/MembersWidget.vue
@@ -38,6 +38,8 @@
 					variant="tertiary"
 					:title="showMembersTitle"
 					:aria-label="showMembersAriaLabel"
+					:href="circlesMembersUrl"
+					:target="circlesMembersUrl ? '_blank' : undefined"
 					@click="openCollectiveMembers()">
 					<template #icon>
 						<AccountMultiplePlusIcon v-if="isAdmin" :size="16" />
@@ -67,6 +69,7 @@ import { CIRCLE_MEMBERS_PARTIAL_LIMIT, circlesMemberTypes } from '../../../const
 import { useCirclesStore } from '../../../stores/circles.js'
 import { useCollectivesStore } from '../../../stores/collectives.js'
 import { usePagesStore } from '../../../stores/pages.js'
+import { hasMembersManagementInCircles } from '../../../util/circles.ts'
 import { circleMemberType } from '../../../util/circles.ts'
 
 export default {
@@ -96,7 +99,6 @@ export default {
 
 	computed: {
 		...mapState(useCirclesStore, [
-			'circleMembers',
 			'circleMembersSorted',
 		]),
 
@@ -163,16 +165,11 @@ export default {
 				: t('collectives', 'Show all members of the collective')
 		},
 
-		teamUrl() {
-			return generateUrl('/apps/contacts/circle/{teamId}', { teamId: this.currentCollective.circleId })
-		},
-
-		hasContactsApp() {
-			return 'contacts' in window.OC.appswebroots
-		},
-
-		showTeamOverviewButton() {
-			return this.hasContactsApp && this.circleMembers(this.currentCollective.circleId).length > 1
+		circlesMembersUrl() {
+			if (!this.isAdmin || !hasMembersManagementInCircles()) {
+				return null
+			}
+			return generateUrl('/apps/circles/teams/team/{circleId}/settings', { circleId: this.currentCollective.circleId })
 		},
 	},
 
@@ -221,6 +218,9 @@ export default {
 		},
 
 		openCollectiveMembers() {
+			if (this.circlesMembersUrl) {
+				return
+			}
 			this.setMembersCollectiveId(this.currentCollective.id)
 		},
 

--- a/src/stores/circles.js
+++ b/src/stores/circles.js
@@ -8,7 +8,7 @@ import { generateOcsUrl } from '@nextcloud/router'
 import { useLocalStorage } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { circlesMemberTypes } from '../constants.js'
-import { sortMembersByLevelAndType } from '../util/circles.ts'
+import { hasMembersManagementInCircles, sortMembersByLevelAndType } from '../util/circles.ts'
 import { useCollectivesStore } from './collectives.js'
 import { useRootStore } from './root.js'
 
@@ -127,7 +127,8 @@ export const useCirclesStore = defineStore('circles', {
 			}
 			this.circlesMembersPending[circleId] = true
 			try {
-				const response = await axios.get(generateOcsUrl(`apps/circles/circles/${circleId}/members?fullDetails=true&limit=${limit}`))
+				const fullDetails = hasMembersManagementInCircles() ? '' : 'fullDetails=true&'
+				const response = await axios.get(generateOcsUrl(`apps/circles/circles/${circleId}/members?${fullDetails}limit=${limit}`))
 				this.circlesMembers[circleId] = response.data.ocs.data
 				if (limit === 0) {
 					this.circlesMembersFullyLoaded[circleId] = true

--- a/src/util/circles.ts
+++ b/src/util/circles.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { getCapabilities } from '@nextcloud/capabilities'
 import { circlesMemberTypes } from '../constants.js'
 
 type Circle = {
@@ -59,4 +60,12 @@ export function sortMembersByLevelAndType(m1: CircleMember, m2: CircleMember): n
 
 	// Sort by display name
 	return m1.displayName.localeCompare(m2.displayName)
+}
+
+/**
+ * Check whether the Circles app provides its own members management UI (v35+).
+ */
+export function hasMembersManagementInCircles(): boolean {
+	const version = (getCapabilities() as { circles?: { version?: string } })?.circles?.version
+	return version ? parseInt(version.split('.')[0], 10) >= 35 : false
 }


### PR DESCRIPTION
## 📝 Summary

This is a continuation of the work started in #2518 and #2443 to optimize the members list in Collectives.

`nextcloud/circles` v35 now provides its own [members management UI](https://github.com/nextcloud/circles/pull/2561), so Collectives no longer needs to duplicate that functionality. This PR detects that capability and, when it is available, turns the `MembersWidget` members button into a link that opens the Circles team settings in a new tab. For older Circles versions the existing member management popup is preserved unchanged.

### Benefits
- Smaller member-management surface in Collectives.
- Faster member fetches because `fullDetails=true` is skipped when the Circles app already provides the management UI.
- No behavior change for users on older Circles versions.

### 🖼️ Screenshots
🏚️ Before | 🏡 After
---|---
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ac427098-b562-4368-ba38-c722cbfc6f82" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/9cf44892-9ed3-458a-b7b0-ba7d42b94f68" />

## :question: Open question
- [ ] Should we preserve members list popup for members that has no access to the member management (e.g. moderators)?

<img width="300" alt="image" src="https://github.com/user-attachments/assets/9b541c1b-49b1-4964-934d-44492985a430" />


## 🚧 TODO
- [ ] Manually test more scenarios (WIP)
- [ ] Fix Cypress test for a new behavior

## 🏁 Checklist

- [ ] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [ ] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
