### PR TITLE
fix(PagePicker): better priority and title when inside Collectives

### DIFF
--- a/lib/Reference/SearchablePageReferenceProvider.php
+++ b/lib/Reference/SearchablePageReferenceProvider.php
@@ -29,11 +29,13 @@ use OCP\Collaboration\Reference\LinkReferenceProvider;
 use OCP\Collaboration\Reference\Reference;
 use OCP\IDateTimeFormatter;
 use OCP\IL10N;
+use OCP\IRequest;
 use OCP\IURLGenerator;
 use Throwable;
 
 class SearchablePageReferenceProvider extends ADiscoverableReferenceProvider implements ISearchableReferenceProvider, IPublicReferenceProvider {
 	private const RICH_OBJECT_TYPE = Application::APP_NAME . '_page';
+	private bool $inCollectives = false;
 
 	public function __construct(
 		private readonly CollectiveService $collectiveService,
@@ -45,8 +47,12 @@ class SearchablePageReferenceProvider extends ADiscoverableReferenceProvider imp
 		private readonly ReferenceManager $referenceManager,
 		private readonly LinkReferenceProvider $linkReferenceProvider,
 		private readonly CollectiveShareService $collectiveShareService,
+		IRequest $request,
 		private readonly ?string $userId,
 	) {
+		if (str_starts_with((string)$request->getPathInfo(), '/apps/collectives')) {
+			$this->inCollectives = true;
+		}
 	}
 
 	public function getId(): string {
@@ -54,10 +60,16 @@ class SearchablePageReferenceProvider extends ADiscoverableReferenceProvider imp
 	}
 
 	public function getTitle(): string {
+		if ($this->inCollectives) {
+			return $this->l10n->t('Link to page in collective');
+		}
 		return $this->l10n->t('Collective pages');
 	}
 
 	public function getOrder(): int {
+		if ($this->inCollectives) {
+			return -1;
+		}
 		return 10;
 	}
 

--- a/playwright/e2e/page-picker.spec.ts
+++ b/playwright/e2e/page-picker.spec.ts
@@ -127,3 +127,19 @@ test.describe('Custom page picker - cross-collective search', () => {
 		await expect(landingPageItem).toBeVisible()
 	})
 })
+
+test.describe('Smart picker - provider order witin Collectives', () => {
+	test.beforeEach(async ({ user, page, collective, editor }) => {
+		const sourcePage = await collective.createPage({ title: 'Source page', user, page })
+		await sourcePage.open(true)
+		editor.setMode(true)
+	})
+
+	test('lists Collective pages first with changed provider title', async ({ page, editor }) => {
+		await editor.getContent().press('/')
+
+		const options = page.locator('.suggestion-list__item')
+		await expect(options.first()).toContainText('Link to page in collective')
+		expect(await options.count()).toBeGreaterThan(1)
+	})
+})

--- a/tests/Unit/Search/SearchablePageReferenceProviderTest.php
+++ b/tests/Unit/Search/SearchablePageReferenceProviderTest.php
@@ -19,6 +19,7 @@ use OCP\Collaboration\Reference\IPublicReferenceProvider;
 use OCP\Collaboration\Reference\LinkReferenceProvider;
 use OCP\IDateTimeFormatter;
 use OCP\IL10N;
+use OCP\IRequest;
 use OCP\IURLGenerator;
 use Test\TestCase;
 
@@ -26,6 +27,7 @@ class SearchablePageReferenceProviderTest extends TestCase {
 	private SearchablePageReferenceProvider $provider;
 	private CollectiveService $collectiveService;
 	private CollectiveShareService $collectiveShareService;
+	private IRequest $request;
 	protected function setUp(): void {
 		parent::setUp();
 		$this->needsIPublicReferenceProvider();
@@ -44,6 +46,7 @@ class SearchablePageReferenceProviderTest extends TestCase {
 		$referenceManager = $this->createMock(ReferenceManager::class);
 		$linkReferenceProvider = $this->createMock(LinkReferenceProvider::class);
 		$this->collectiveShareService = $this->createMock(CollectiveShareService::class);
+		$this->request = $this->createMock(IRequest::class);
 		$uid = 'jane';
 		$this->provider = new SearchablePageReferenceProvider(
 			$this->collectiveService,
@@ -55,6 +58,7 @@ class SearchablePageReferenceProviderTest extends TestCase {
 			$referenceManager,
 			$linkReferenceProvider,
 			$this->collectiveShareService,
+			$this->request,
 			$uid,
 		);
 	}
@@ -191,6 +195,7 @@ class SearchablePageReferenceProviderTest extends TestCase {
 			$this->createMock(ReferenceManager::class),
 			$this->createMock(LinkReferenceProvider::class),
 			$this->collectiveShareService,
+			$this->request,
 			'jane',
 		);
 


### PR DESCRIPTION
List the page picker first in the smart picker when called from inside the Collectives app. Also use more descriptive title in this case.

Contributes to https://github.com/nextcloud/text/issues/8802

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1056" height="600" alt="image" src="https://github.com/user-attachments/assets/a55db0bb-9362-433d-85cb-8c0351a87471" /> | <img width="1056" height="600" alt="image" src="https://github.com/user-attachments/assets/2845f563-5ff4-402c-b568-7ab87b384a10" />

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests

### 🤖 AI (if applicable)

- [x] The content of this PR was fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
