### PR TITLE
Integrate semantic page comparison

### DIFF
--- a/cypress/e2e/page-versions.spec.js
+++ b/cypress/e2e/page-versions.spec.js
@@ -3,36 +3,436 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { createCollectiveShare } from '../../src/apis/collectives/shares.js'
+
+const HISTORICAL_SNAPSHOT_URL = /\/remote\.php\/dav\/versions\//
+const CURRENT_SNAPSHOT_URL = /\/remote\.php\/dav\/files\/.*[?&]timestamp=\d{13}(?:&|$)/
+
+function selectVersionAt(selectorIndex, optionIndex) {
+	cy.get('.version-comparison-dialog select').eq(selectorIndex).then(($select) => {
+		cy.wrap($select).select($select.find('option').eq(optionIndex).val())
+	})
+}
+
+function getVersionComparisonModal() {
+	return cy.get('.modal-container').filter(':has(.version-comparison-dialog)')
+}
+
+function appendQuarantinedVersionEntries(body) {
+	const entries = body.match(/<d:response>[\s\S]*?<\/d:response>/g) ?? []
+	const historicalEntries = entries
+		.filter((entry) => entry.includes('<d:getcontenttype>text/markdown</d:getcontenttype>'))
+		.map((entry) => ({
+			entry,
+			href: entry.match(/<d:href>([^<]+)<\/d:href>/)?.[1],
+			lastModified: Date.parse(entry.match(/<d:getlastmodified>([^<]+)<\/d:getlastmodified>/)?.[1]),
+		}))
+		.filter(({ href, lastModified }) => href && Number.isFinite(lastModified))
+		.toSorted((first, second) => first.lastModified - second.lastModified)
+	const { entry: duplicatedEntry, href } = historicalEntries[0] ?? {}
+	if (!duplicatedEntry || !href) {
+		throw new Error('Could not find a historical DAV version to duplicate')
+	}
+	const rawVersionId = href.split('/').at(-1)
+	const duplicateVersionId = decodeURIComponent(rawVersionId)
+	const encodedFirstCharacter = `%${rawVersionId.charCodeAt(0).toString(16).toUpperCase()}`
+	const duplicateEntry = duplicatedEntry.replace(
+		href,
+		`${href.slice(0, -rawVersionId.length)}${encodedFirstCharacter}${rawVersionId.slice(1)}`,
+	)
+	const reservedEntry = duplicatedEntry.replace(
+		/(<d:href>[^<]*\/)[^/<]+(<\/d:href>)/,
+		'$1current$2',
+	)
+	const mutatedBody = body.replace(
+		/(<\/(?:d:)?multistatus>)/i,
+		`${duplicateEntry}${reservedEntry}$1`,
+	)
+	if (mutatedBody === body) {
+		throw new Error('Could not append quarantined DAV versions')
+	}
+	return {
+		body: mutatedBody,
+		duplicateVersionId,
+	}
+}
+
+function closeSemanticComparison() {
+	getVersionComparisonModal()
+		.parents('.modal-mask')
+		.should('have.css', 'opacity', '1')
+	getVersionComparisonModal().find('button.modal-container__close').click()
+	cy.get('.version-comparison-dialog').should('not.exist')
+}
+
+function openVersionsSidebar() {
+	cy.get('body').should(($body) => {
+		expect(
+			$body.find('#tab-button-versions:visible, button.page-sidebar-button:visible').length,
+			'visible Versions tab or sidebar button',
+		).to.be.greaterThan(0)
+	}).then(($body) => {
+		if (!$body.find('#tab-button-versions:visible').length) {
+			cy.get('button.page-sidebar-button:visible').click()
+		}
+	})
+	cy.get('#tab-button-versions').should('be.visible').click()
+}
+
+function insertEditorContent(content, appendParagraph = false) {
+	cy.getEditorContent(true).should('be.visible')
+	cy.window({ log: false }).then((window) => {
+		const components = window.OCA?.Text?.editorComponents
+		if (!components) {
+			throw new Error('Text editor components are unavailable')
+		}
+		const component = Array.from(components)
+			.find((candidate) => candidate.active)
+		if (!component) {
+			throw new Error('No active Text editor component is available')
+		}
+		cy.wrap(component.whenSynced, { log: false }).then(() => {
+			const command = appendParagraph
+				? component.editor.chain().focus('end').insertContent({
+						type: 'paragraph',
+						content: [{ type: 'text', text: content }],
+					}).run()
+				: component.editor.commands.insertContent(content)
+			expect(command, 'editor content command').to.equal(true)
+		})
+	})
+}
+
+function assertMeasuredComparisonLayout(expectedMode) {
+	cy.get('.version-comparison-dialog .text-comparison').should(($comparison) => {
+		const width = $comparison[0].getBoundingClientRect().width
+		const measuredMode = width >= 760 ? 'paired' : 'single'
+		expect(width, 'measured comparison container width').to.be.greaterThan(0)
+		expect($comparison[0].scrollWidth, 'comparison horizontal overflow')
+			.to.be.at.most($comparison[0].clientWidth + 1)
+		expect($comparison.hasClass(`text-comparison--${measuredMode}`), `layout for ${width}px container`).to.equal(true)
+		expect(measuredMode, `expected mode for ${width}px container`).to.equal(expectedMode)
+	})
+}
+
+let usesLegacyViewer = false
+let publicSharePath = ''
+
+function assertViewerComparison(before, after) {
+	cy.get('#viewer .viewer--split > .viewer__file-wrapper:visible')
+		.should('have.length', 2)
+		.eq(0)
+		.should('contain', before)
+	cy.get('#viewer .viewer--split > .viewer__file-wrapper:visible')
+		.eq(1)
+		.should('contain', after)
+}
+
+function closeViewerComparison() {
+	cy.window().then((window) => window.OCA.Viewer.close())
+	cy.get('#viewer').should('not.exist')
+}
+
+const ROLLBACK_SECTION = `## Rollback ownership
+
+Maya owns rollback approval.
+
+Escalate checkout regressions to the release commander.`
+
+const EVIDENCE_SECTION = `## Audit archive
+
+Each decision receives a durable timestamp.
+
+Signed records remain with the project history.`
+
+const READINESS_SECTION = `## Regional readiness
+
+All checkout regions use the same health gate.
+
+Regional owners confirm capacity before launch.`
+
+const INITIAL_CONTENT = `---
+release: atlas-2.4
+status: draft
+owner: Maya Chen
+---
+
+# Atlas 2.4 release plan
+
+> Draft rollout window: Thursday, 18 July.
+
+## Objective
+
+Ship **Atlas 2.4** to a 10% pilot cohort while protecting checkout availability.
+
+Release owner: Maya Chen.
+
+Status cadence: every 15 minutes.
+
+All named owners have acknowledged the window.
+
+Status dashboard is available to the release team.
+
+The dashboard is reviewed before each traffic increase.
+
+Keep the [incident channel](https://chat.example.test/atlas) staffed during rollout.
+
+The incident commander acknowledges every escalation.
+
+Follow the [operator runbook](https://docs.example.test/atlas/draft).
+
+The release commander validates every operator handoff.
+
+Customer update is ready for review.
+
+Checkout remains available throughout the launch.
+
+${ROLLBACK_SECTION}
+
+${EVIDENCE_SECTION}
+
+${READINESS_SECTION}
+
+## Decision protocol
+
+The release commander records every traffic decision.
+
+## Rollout checklist
+
+- [x] Freeze schema changes
+- [ ] Confirm support coverage
+- [ ] Enable the pilot cohort
+
+## Schedule
+
+| Stage | Owner | Traffic |
+| --- | --- | --- |
+| Pilot | Maya | 10% |
+| General availability | Lee | Pending |
+
+Checkout remains available throughout the launch.
+
+::: info
+The checkout health gate must remain green for fifteen minutes.
+:::
+
+Health checks are sampled from every checkout region.
+
+<details>
+<summary>Escalation contacts</summary>
+Maya leads release decisions; Noor leads rollback execution.
+</details>
+
+## Guardrail
+
+\`\`\`js
+const rolloutPercent = 10
+const rollbackThreshold = 0.02
+\`\`\`
+
+Rollback if error rate exceeds \`2%\`.
+
+The rollout decision is recorded in the release evidence.[^atlas-draft]
+
+Visual evidence follows the signed release decision.
+
+![Atlas rollout dashboard](/core/img/logo/logo.svg)
+
+The image checksum is recorded separately.
+
+[^atlas-draft]: Draft approval requires checkout error rate below two percent.
+`
+
+const SECOND_CONTENT = INITIAL_CONTENT
+	.replace('# Atlas 2.4 release plan', '# Atlas 2.4 release plan #')
+	.replace('Status dashboard is available to the release team.', 'Status dashboard is available to the release team. ')
+	.replaceAll('\n', '\r\n')
+	.replace(/\r\n$/, '')
+
+const REVIEWED_CONTENT = INITIAL_CONTENT
+	.replace('status: draft', 'status: reviewed')
+	.replace('Draft rollout window', 'Reviewed rollout window')
+	.replace('10% pilot cohort', '15% reviewed cohort')
+	.replace('- [ ] Confirm support coverage', '- [x] Confirm support coverage')
+	.replace('| Pilot | Maya | 10% |', '| Pilot | Maya | 15% |')
+	.replace('const rolloutPercent = 10', 'const rolloutPercent = 15')
+
+const CURRENT_CONTENT = `---
+release: atlas-2.4
+status: launch-ready
+owner: Maya Chen and Noor Patel
+---
+
+# Atlas 2.4 launch plan
+
+> Approved rollout window: Friday, 19 July.
+
+## Objective
+
+Ship **Atlas 2.4** through a 25% progressive rollout while protecting checkout availability.
+
+Release owner: **Maya Chen**.
+
+Status cadence: *every 15 minutes*.
+
+All named owners have acknowledged the window.
+
+[Status dashboard](https://status.example.test/atlas) is available to the release team.
+
+The dashboard is reviewed before each traffic increase.
+
+Keep the incident channel staffed during rollout.
+
+The incident commander acknowledges every escalation.
+
+Follow the [operator runbook](https://docs.example.test/atlas/2.4).
+
+The release commander validates every operator handoff.
+
+Customer **launch update** is ready for publication.
+
+Checkout remains available throughout the launch.
+
+${EVIDENCE_SECTION}
+
+${READINESS_SECTION}
+
+${ROLLBACK_SECTION}
+
+## Decision protocol
+
+The release commander records every traffic decision.
+
+## Rollout checklist
+
+- [x] Freeze schema changes
+- [x] Confirm support coverage
+- [x] Enable the pilot cohort
+- [ ] Publish the customer update
+
+## Schedule
+
+| Stage | Owner | Traffic |
+| --- | --- | --- |
+| Canary | Maya | 25% |
+| General availability | Lee | 100% |
+| Rollback rehearsal | Noor | Complete |
+
+Checkout remains available throughout the launch.
+
+::: warn
+The checkout health gate must remain green for fifteen minutes.
+:::
+
+Health checks are sampled from every checkout region.
+
+<details>
+<summary>Escalation contacts</summary>
+Maya leads release decisions; Noor executes rollback and Lee owns customer communication.
+</details>
+
+## Guardrail
+
+\`\`\`js
+const rolloutPercent = 25
+const rollbackThreshold = 0.015
+\`\`\`
+
+Rollback if error rate exceeds \`1.5%\` for five minutes.
+
+The rollout decision is recorded in the release evidence.[^atlas-launch]
+
+Visual evidence follows the signed release decision.
+
+![Atlas launch control room](/core/img/logo/logo.svg)
+
+The image checksum is recorded separately.
+
+[^atlas-launch]: Launch approval requires checkout error rate below one and a half percent for five minutes.
+`
+
+const INITIAL_PHRASE = '10% pilot cohort'
+const REVIEWED_PHRASE = '15% reviewed cohort'
+const CURRENT_PHRASE = '25% progressive rollout'
+const RAPID_FIRST_PHRASE = 'Rapid comparison first save'
+const RAPID_SECOND_PHRASE = 'Rapid comparison second save'
+
 describe('Page versions', function() {
 	before(function() {
+		cy.env(['ncVersion']).then(({ ncVersion }) => {
+			usesLegacyViewer = ncVersion === 'stable34'
+		})
 		cy.loginAs('bob')
 		cy.deleteAndSeedCollective('Versions Collective')
 			.seedPage('Page', '', 'Readme.md')
+		cy.getCollectives()
+			.findBy({ name: 'Versions Collective' })
+			.seedPage('Fresh page', '', 'Readme.md')
+		cy.getCollectives()
+			.findBy({ name: 'Versions Collective' })
+			.seedPage('Restore page', '', 'Readme.md')
+		cy.getCollectives()
+			.findBy({ name: 'Versions Collective' })
+			.seedPage('Removed version page', '', 'Readme.md')
+		cy.getCollectives()
+			.findBy({ name: 'Versions Collective' })
+			.seedPage('Viewer fallback page', '', 'Readme.md')
+		// Left empty on purpose: this page's content is written through the
+		// editor so the save path itself is exercised, not a seeded write.
+		cy.getCollectives()
+			.findBy({ name: 'Versions Collective' })
+			.seedPage('Rapid compare page', '', 'Readme.md')
 
 		// A new version will not be created if the changes occur within less than one second of each other.
 		// eslint-disable-next-line cypress/no-unnecessary-waiting
-		cy.seedPageContent('Versions Collective/Page.md', 'v1')
+		cy.seedPageContent('Versions Collective/Page.md', INITIAL_CONTENT)
 			.wait(1100)
 		// eslint-disable-next-line cypress/no-unnecessary-waiting
-		cy.seedPageContent('Versions Collective/Page.md', 'v2')
+		cy.seedPageContent('Versions Collective/Page.md', SECOND_CONTENT)
 			.wait(1100)
 		// eslint-disable-next-line cypress/no-unnecessary-waiting
-		cy.seedPageContent('Versions Collective/Page.md', 'v3')
+		cy.seedPageContent('Versions Collective/Page.md', REVIEWED_CONTENT)
 			.wait(1100)
-		cy.seedPageContent('Versions Collective/Page.md', 'v4')
+		cy.seedPageContent('Versions Collective/Page.md', CURRENT_CONTENT)
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.seedPageContent('Versions Collective/Restore page.md', INITIAL_CONTENT)
+			.wait(1100)
+		cy.seedPageContent('Versions Collective/Restore page.md', CURRENT_CONTENT)
+		// Keep the removed-version request unique so the browser cache cannot bypass its intercept.
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.seedPageContent('Versions Collective/Removed version page.md', INITIAL_CONTENT)
+			.wait(1100)
+		cy.seedPageContent('Versions Collective/Removed version page.md', CURRENT_CONTENT)
+		// Keep the Viewer fallback snapshot unique so its request count cannot come from cache.
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.seedPageContent('Versions Collective/Viewer fallback page.md', INITIAL_CONTENT)
+			.wait(1100)
+		cy.seedPageContent('Versions Collective/Viewer fallback page.md', CURRENT_CONTENT)
+		cy.getCollectives()
+			.findBy({ name: 'Versions Collective' })
+			.then(({ circleId }) => cy.wrap({ id: circleId })
+				.circleAddMember('alice')
+				.circleSetMemberLevel(4))
+		cy.seedCollectivePermissions('Versions Collective', 'edit', 8)
+		cy.getCollectives()
+			.findBy({ name: 'Versions Collective' })
+			.then(({ id }) => createCollectiveShare(id))
+			.its('data.ocs.data.token')
+			.then((token) => {
+				publicSharePath = `/apps/collectives/p/${token}/Versions Collective/Page`
+			})
 	})
 
 	beforeEach(function() {
 		cy.loginAs('bob')
 		cy.visit('/apps/collectives/Versions Collective/Page')
 
-		cy.get('button.page-sidebar-button').click()
-		cy.get('#tab-button-versions').click()
+		openVersionsSidebar()
 	})
 
 	it('Lists versions', function() {
 		cy.getReadOnlyEditor()
-			.should('contain', 'v4')
+			.should('contain', CURRENT_PHRASE)
 
 		cy.get('.app-sidebar-tabs__content .version-list .list-item')
 			.should('have.length', 4)
@@ -44,6 +444,23 @@ describe('Page versions', function() {
 			.should('contain', 'Initial version')
 	})
 
+	it('Hides comparison when no historical version exists', function() {
+		cy.visit('/apps/collectives/Versions Collective/Fresh page')
+		cy.get('#tab-button-versions').click()
+		cy.get('.app-sidebar-tabs__content .version-list .list-item')
+			.should('have.length', 1)
+		cy.contains('button', 'Compare versions…').should('not.exist')
+	})
+
+	it('distinguishes every version selector option down to the second', function() {
+		cy.contains('button', 'Compare versions…').click()
+		cy.get('.version-comparison-dialog select').each(($select) => {
+			const labels = [...$select[0].options].map(({ text }) => text.trim())
+			expect(new Set(labels).size).to.equal(labels.length)
+			expect(labels.every((label) => /\d{1,2}:\d{2}:\d{2}/.test(label))).to.equal(true)
+		})
+	})
+
 	it('Open initial and current version', function() {
 		cy.get('.app-sidebar-tabs__content .version-list .list-item')
 			.contains('Initial version')
@@ -53,7 +470,7 @@ describe('Page versions', function() {
 			.find('.title-version')
 			.should('be.visible')
 		cy.getReadOnlyEditor()
-			.should('contain', 'v1')
+			.should('contain', INITIAL_PHRASE)
 
 		cy.get('.app-sidebar-tabs__content .version-list .list-item')
 			.contains('Current version')
@@ -63,7 +480,7 @@ describe('Page versions', function() {
 			.find('.title-version')
 			.should('not.exist')
 		cy.getReadOnlyEditor()
-			.should('contain', 'v4')
+			.should('contain', CURRENT_PHRASE)
 	})
 
 	it('Add label to version', function() {
@@ -82,47 +499,660 @@ describe('Page versions', function() {
 	})
 
 	it('Compare initial and current version', function() {
+		let beforeScrollTop
+		let afterScrollTop
+		if (usesLegacyViewer) {
+			cy.intercept('GET', HISTORICAL_SNAPSHOT_URL)
+				.as('viewerSnapshotRequest')
+		} else {
+			cy.intercept('GET', HISTORICAL_SNAPSHOT_URL)
+				.as('historicalSnapshotRequest')
+			cy.intercept('GET', CURRENT_SNAPSHOT_URL)
+				.as('currentSnapshotRequest')
+		}
+		cy.get('.search-dialog-container').should('not.exist')
 		cy.get('.app-sidebar-tabs__content .version-list .list-item')
 			.eq(3)
 			.find('.list-item-content__actions')
 			.click()
 
-		cy.clickMenuButton('Compare to current version')
+		cy.clickMenuButton('Compare with current version')
 
-		cy.get('#viewer .text-editor')
-			.should('contain', 'v1')
-		cy.get('#viewer .text-editor')
-			.should('contain', 'v4')
+		if (usesLegacyViewer) {
+			assertViewerComparison(INITIAL_PHRASE, CURRENT_PHRASE)
+			cy.get('@viewerSnapshotRequest.all').should('have.length', 1)
+			closeViewerComparison()
+		} else {
+			getVersionComparisonModal()
+				.parent()
+				.should('have.class', 'modal-wrapper--full')
+			getVersionComparisonModal().find('button[type="submit"]').should('not.exist')
+			cy.get('.version-comparison-dialog')
+				.should('have.css', 'display', 'flex')
+				.and('have.css', 'overflow', 'hidden')
+			cy.get('.version-comparison-dialog__comparison')
+				.should('have.css', 'display', 'flex')
+				.and('have.css', 'overflow', 'hidden')
+				.then(($host) => {
+					const host = $host[0].getBoundingClientRect()
+					const content = $host[0].parentElement.getBoundingClientRect()
+					expect(Math.abs(host.bottom - content.bottom), 'host fills remaining dialog height')
+						.to.be.lessThan(2)
+				})
+			cy.get('.version-comparison-dialog__selectors .text-comparison').should('not.exist')
+			cy.contains('.version-comparison-dialog [role="tab"]', 'Changes')
+				.should('have.attr', 'aria-selected', 'true')
+			assertMeasuredComparisonLayout('paired')
+			cy.get('.version-comparison-dialog .text-comparison__change-list')
+				.should('be.visible')
+				.and('contain', 'Moved section')
+				.and('contain', 'Bold added')
+				.and('contain', 'Italic added')
+				.and('contain', 'Link added')
+				.and('contain', 'Link removed')
+				.and('contain', 'Link target changed')
+				.and('contain', 'Task state changed')
+				.and('contain', 'Callout type changed')
+				.and('contain', 'Image description changed')
+				.and('contain', 'Footnote changed')
+			cy.get('.version-comparison-dialog [data-comparison-select]')
+				.should(($records) => {
+					expect($records.length).to.be.greaterThan(10)
+					expect($records.length).to.be.lessThan(35)
+				})
+			cy.contains('.version-comparison-dialog [data-comparison-select]', 'Quote changed — 3 edits')
+				.should('be.visible')
+			cy.get('.version-comparison-dialog .text-comparison__change-list')
+				.should('not.contain', 'Unknown change')
+			cy.get('.version-comparison-dialog [data-comparison-select]').each(($record) => {
+				cy.wrap($record)
+					.find('.text-comparison__change-label, .text-comparison__change-context, .text-comparison__preview')
+					.should('have.length', 3)
+			})
+			cy.get('.version-comparison-dialog .text-comparison__change-list [data-comparison-select]')
+				.its('length')
+				.then((unfilteredCount) => {
+					cy.contains('.version-comparison-dialog label', 'Hide formatting-only changes')
+						.find('input[type="checkbox"]')
+						.check()
+					cy.contains('.version-comparison-dialog label', 'Hide formatting-only changes')
+						.should('contain', '2 hidden')
+					cy.get('.version-comparison-dialog .text-comparison__change-list [data-comparison-select]')
+						.should('have.length', unfilteredCount - 2)
+					cy.contains('.version-comparison-dialog label', 'Hide formatting-only changes')
+						.find('input[type="checkbox"]')
+						.uncheck()
+				})
 
-		cy.get('#viewer .header-close')
-			.click()
-	})
+			cy.contains('.version-comparison-dialog [data-comparison-select]', 'Moved section')
+				.then(($record) => {
+					const changeId = $record.attr('data-comparison-select')
+					expect(changeId).to.be.a('string').and.not.be.empty
+					cy.wrap($record).click()
+					cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents')
+						.should('have.attr', 'aria-selected', 'true')
+					cy.get(`.version-comparison-dialog .text-comparison__document--before [data-comparison-change="${changeId}"]`)
+						.should('have.class', 'text-comparison-change--current')
+					cy.get(`.version-comparison-dialog .text-comparison__document--after [data-comparison-change="${changeId}"]`)
+						.should('have.class', 'text-comparison-change--current')
+				})
+			// Finish target navigation before testing manual scroll persistence.
+			cy.contains('.version-comparison-dialog [role="tab"]', 'Changes').click()
+			cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents').click()
+			cy.get('.version-comparison-dialog .text-comparison__document-scroller')
+				.should('have.length', 2)
+			cy.get('.version-comparison-dialog .text-comparison__document--before')
+				.should('contain', INITIAL_PHRASE)
+				.and('contain', 'Audit archive')
+			cy.get('.version-comparison-dialog .text-comparison__document--after')
+				.should('contain', CURRENT_PHRASE)
+				.and('contain', 'Audit archive')
+			cy.get('.version-comparison-dialog .ProseMirror')
+				.should('have.length', 2)
+				.find('table')
+				.should('have.length', 2)
+			cy.get('.version-comparison-dialog .text-comparison-change--empty[role="note"]')
+				.its('length')
+				.should('be.greaterThan', 0)
+			cy.get('.version-comparison-dialog .text-comparison__document--before .text-comparison__document-scroller')
+				.then(($scroller) => {
+					$scroller[0].scrollTo({ top: 80, behavior: 'instant' })
+					expect($scroller[0].scrollTop).to.be.greaterThan(0)
+				})
+			cy.get('.version-comparison-dialog .text-comparison__document--after .text-comparison__document-scroller')
+				.then(($scroller) => {
+					$scroller[0].scrollTo({ top: 240, behavior: 'instant' })
+					expect($scroller[0].scrollTop).to.be.greaterThan(80)
+				})
+			cy.get('.version-comparison-dialog .text-comparison__document--before .text-comparison__document-scroller')
+				.then(($scroller) => {
+					beforeScrollTop = $scroller[0].scrollTop
+				})
+			cy.get('.version-comparison-dialog .text-comparison__document--after .text-comparison__document-scroller')
+				.then(($scroller) => {
+					afterScrollTop = $scroller[0].scrollTop
+				})
+			cy.contains('.version-comparison-dialog [role="tab"]', 'Changes').click()
+			cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents').click()
+			cy.get('.version-comparison-dialog .text-comparison__document--before .text-comparison__document-scroller')
+				.should(($scroller) => {
+					expect($scroller[0].scrollTop).to.equal(beforeScrollTop)
+				})
+			cy.get('.version-comparison-dialog .text-comparison__document--after .text-comparison__document-scroller')
+				.should(($scroller) => {
+					expect($scroller[0].scrollTop).to.equal(afterScrollTop)
+				})
+			cy.get('.version-comparison-dialog .text-comparison__document figure[data-component="image-view"][data-attachment-type="image"]')
+				.should('have.length', 2)
+			cy.get('@historicalSnapshotRequest.all')
+				.should('have.length', 1)
+				.its('0.request.url')
+				.should('not.contain', 'timestamp=')
+			cy.get('@currentSnapshotRequest.all').should('have.length', 1)
+			cy.contains('.version-comparison-dialog [role="tab"]', 'Markdown source').click()
+			cy.get('.version-comparison-dialog .text-source-comparison')
+				.should('contain', 'status: draft')
+				.and('contain', 'status: launch-ready')
+			cy.viewport(768, 900)
+			assertMeasuredComparisonLayout('single')
 
-	it('Restore initial version', function() {
+			closeSemanticComparison()
+			cy.viewport(1280, 900)
+		}
+
+		// Reopening reuses immutable history but constructs a fresh comparison with current content.
 		cy.get('.app-sidebar-tabs__content .version-list .list-item')
 			.eq(3)
+			.find('.list-item-content__actions')
+			.click()
+		cy.clickMenuButton('Compare with current version')
+		if (usesLegacyViewer) {
+			assertViewerComparison(INITIAL_PHRASE, CURRENT_PHRASE)
+			closeViewerComparison()
+		} else {
+			cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+			assertMeasuredComparisonLayout('paired')
+			cy.get('@historicalSnapshotRequest.all').should('have.length', 1)
+			cy.get('@currentSnapshotRequest.all').should('have.length', 2)
+			closeSemanticComparison()
+		}
+		cy.get('.search-dialog-container').should('not.exist')
+		cy.get('#tab-button-attachments').click()
+		cy.get('.app-sidebar-tabs__content').should('contain', 'No attachments')
+	})
+
+	it('Compares two historical versions and normalizes chronology', function() {
+		cy.contains('button', 'Compare versions…').click()
+		// Deliberately choose the later snapshot in Earlier and vice versa.
+		selectVersionAt(0, 1)
+		selectVersionAt(1, 3)
+		getVersionComparisonModal().find('button[type="submit"]').click()
+
+		if (usesLegacyViewer) {
+			assertViewerComparison(INITIAL_PHRASE, REVIEWED_PHRASE)
+			closeViewerComparison()
+		} else {
+			cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents').click()
+			cy.get('.version-comparison-dialog .text-comparison__document--before')
+				.should('contain', INITIAL_PHRASE)
+			cy.get('.version-comparison-dialog .text-comparison__document--after')
+				.should('contain', REVIEWED_PHRASE)
+			cy.get('.version-comparison-dialog select').eq(0).should(($select) => {
+				expect($select.val()).to.match(/^version:[^/\\]+$/)
+			})
+		}
+	})
+
+	it('shows syntax-only Markdown differences without inventing rendered changes', function() {
+		cy.contains('button', 'Compare versions…').click()
+		selectVersionAt(0, 3)
+		selectVersionAt(1, 2)
+		getVersionComparisonModal().find('button[type="submit"]').click()
+
+		if (usesLegacyViewer) {
+			assertViewerComparison(INITIAL_PHRASE, INITIAL_PHRASE)
+			closeViewerComparison()
+			return
+		}
+
+		cy.get('.version-comparison-dialog .text-comparison')
+			.should('contain', 'No rendered differences — Markdown syntax differs.')
+			.and('not.contain', 'Moved section')
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Markdown source').click()
+		cy.get('.version-comparison-dialog .text-source-comparison')
+			.should('contain', '# Atlas 2.4 release plan #')
+			.and('contain', 'Line endings changed: LF → CRLF')
+			.and('contain', 'CRLF')
+			.and('contain', 'Trailing whitespace')
+			.and('contain', 'No newline at end of file')
+		closeSemanticComparison()
+	})
+
+	it('quarantines duplicate DAV identities without disabling valid versions', function() {
+		let duplicateVersionId
+		cy.intercept('PROPFIND', '**/remote.php/dav/versions/**', (request) => {
+			request.continue((response) => {
+				const mutated = appendQuarantinedVersionEntries(response.body)
+				duplicateVersionId = mutated.duplicateVersionId
+				response.body = mutated.body
+			})
+		}).as('versionsWithQuarantinedEntries')
+		cy.visit('/apps/collectives/Versions Collective/Page')
+		openVersionsSidebar()
+		cy.wait('@versionsWithQuarantinedEntries')
+
+		cy.then(() => {
+			cy.get('.app-sidebar-tabs__content .version-list .version')
+				.filter((_index, element) => element.dataset.versionId === String(duplicateVersionId))
+				.should('have.length', 2)
+				.first()
+				.find('.list-item-content__actions')
+				.click()
+			cy.clickMenuButton('Compare with current version')
+			cy.contains('.toast-error', 'This page version cannot be used for comparison.')
+				.should('be.visible')
+				.find('.toast-close')
+				.click()
+			cy.get('.version-comparison-dialog').should('not.exist')
+		})
+
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal()
+			.find('[role="status"]')
+			.filter(':contains("Some page versions could not be used for comparison.")')
+			.should('have.length', 1)
+		cy.get('.version-comparison-dialog select').each(($select) => {
+			cy.wrap($select).find('option').should('have.length', 4)
+			cy.wrap($select).find('option[value="version:current"]').should('have.length', 1)
+		})
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		if (usesLegacyViewer) {
+			assertViewerComparison(REVIEWED_PHRASE, CURRENT_PHRASE)
+			closeViewerComparison()
+		} else {
+			cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+			closeSemanticComparison()
+		}
+	})
+
+	it('does not expose version comparison on public pages', function() {
+		if (usesLegacyViewer) {
+			// Preview mode no longer creates a legacy editing session that can race logout.
+			cy.get('[data-cy-collectives="editor"] .ProseMirror').should('not.exist')
+		}
+		cy.logout()
+		cy.visit(publicSharePath)
+		cy.getReadOnlyEditor().should('contain', CURRENT_PHRASE)
+		cy.get('#tab-button-versions').should('not.exist')
+	})
+
+	it('Blocks comparing a version with itself', function() {
+		cy.contains('button', 'Compare versions…').click()
+		selectVersionAt(0, 1)
+		selectVersionAt(1, 1)
+		cy.get('.version-comparison-dialog')
+			.should('contain', 'Select two different versions.')
+		getVersionComparisonModal().find('button[type="submit"]')
+			.should('be.disabled')
+	})
+
+	it('Uses an accessible Before and After toggle on mobile', function() {
+		cy.viewport(768, 900)
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		if (usesLegacyViewer) {
+			cy.get('.version-comparison-dialog')
+				.should('contain', 'Version comparison requires a newer version of the Text app on mobile.')
+				.find('[role="tablist"]')
+				.should('not.exist')
+		} else {
+			cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents').click()
+			cy.get('.version-comparison-dialog .text-comparison')
+				.should('have.class', 'text-comparison--single')
+			assertMeasuredComparisonLayout('single')
+			cy.get('.version-comparison-dialog .text-comparison__documents')
+				.should('have.css', 'display', 'flex')
+			cy.get('.version-comparison-dialog .text-comparison__document-grid')
+				.should('have.css', 'display', 'block')
+			cy.get('.version-comparison-dialog [role="tablist"]').should('be.visible')
+			cy.get('.version-comparison-dialog [role="tab"]').contains('Before')
+				.trigger('keydown', { key: 'ArrowRight' })
+			cy.get('.version-comparison-dialog [role="tab"][aria-selected="true"]')
+				.should('contain', 'After')
+			cy.get('.version-comparison-dialog [role="tabpanel"]:visible')
+				.should('contain', CURRENT_PHRASE)
+			cy.viewport(320, 900)
+			cy.contains('.version-comparison-dialog .text-comparison__navigation button', 'Next')
+				.should('be.visible')
+				.then(($button) => {
+					expect($button[0].getBoundingClientRect().right).to.be.at.most(320)
+				})
+			cy.get('.version-comparison-dialog .text-comparison')
+				.should(($comparison) => {
+					expect($comparison[0].scrollWidth).to.be.at.most($comparison[0].clientWidth + 1)
+				})
+		}
+	})
+
+	it('uses the comparison container width independently of the desktop viewport', function() {
+		if (usesLegacyViewer) {
+			return
+		}
+		cy.viewport(1440, 900)
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		assertMeasuredComparisonLayout('paired')
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents').click()
+		cy.get('.version-comparison-dialog .text-comparison__document-grid')
+			.should('have.css', 'display', 'grid')
+		getVersionComparisonModal().then(($modal) => {
+			$modal[0].style.width = '960px'
+		})
+		assertMeasuredComparisonLayout('paired')
+		getVersionComparisonModal().then(($modal) => {
+			$modal[0].style.width = ''
+		})
+		assertMeasuredComparisonLayout('paired')
+	})
+
+	it('uses a callable semantic factory despite an unexpected Text API version', function() {
+		if (usesLegacyViewer) {
+			return
+		}
+		cy.window().then((window) => {
+			window.OCA.Text.apiVersion = 'unexpected'
+		})
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		cy.get('#viewer').should('not.exist')
+	})
+
+	it('falls back to Viewer when the advertised semantic factory is missing', function() {
+		if (usesLegacyViewer) {
+			return
+		}
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL).as('viewerSnapshotRequest')
+		cy.visit('/apps/collectives/Versions Collective/Viewer fallback page')
+		openVersionsSidebar()
+		cy.window().then((window) => {
+			window.OCA.Text.apiVersion = '1.5'
+			cy.stub(window.OCA.Text, 'createMarkdownContentComparison').value(undefined)
+		})
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog').should('not.exist')
+		assertViewerComparison(INITIAL_PHRASE, CURRENT_PHRASE)
+		cy.get('@viewerSnapshotRequest.all').should('have.length', 1)
+		closeViewerComparison()
+	})
+
+	it('Shows a removed-version error without mounting one side and retries', function() {
+		if (usesLegacyViewer) {
+			cy.window().its('OCA.Text.createMarkdownContentComparison').should('not.exist')
+			return
+		}
+
+		cy.intercept({
+			method: 'GET',
+			times: 1,
+			url: HISTORICAL_SNAPSHOT_URL,
+		}, { statusCode: 404 }).as('removedVersion')
+
+		cy.visit('/apps/collectives/Versions Collective/Removed version page')
+		openVersionsSidebar()
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.wait('@removedVersion')
+		cy.get('.version-comparison-dialog [role="alert"]')
+			.should('contain', 'One of the selected versions has expired or was removed.')
+		cy.get('.version-comparison-dialog .text-comparison').should('not.exist')
+
+		getVersionComparisonModal().contains('button', 'Retry').click()
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+	})
+
+	it('Shows a permission error when both snapshots are unavailable', function() {
+		if (usesLegacyViewer) {
+			cy.window().its('OCA.Text.createMarkdownContentComparison').should('not.exist')
+			return
+		}
+
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL, { statusCode: 403 })
+			.as('deniedSnapshots')
+
+		cy.contains('button', 'Compare versions…').click()
+		selectVersionAt(0, 1)
+		selectVersionAt(1, 3)
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.wait('@deniedSnapshots')
+		cy.wait('@deniedSnapshots')
+		cy.get('.version-comparison-dialog [role="alert"]')
+			.should('contain', 'You do not have permission to load the selected versions.')
+		cy.get('.version-comparison-dialog .text-comparison').should('not.exist')
+		cy.get('#viewer').should('not.exist')
+	})
+
+	it('Shows a network error without mounting one side', function() {
+		if (usesLegacyViewer) {
+			cy.window().its('OCA.Text.createMarkdownContentComparison').should('not.exist')
+			return
+		}
+
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL, (request) => {
+			request.destroy()
+		}).as('networkFailure')
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.wait('@networkFailure')
+		cy.get('.version-comparison-dialog [role="alert"]')
+			.should('contain', 'Could not load the selected versions because of a network error.')
+		cy.get('.version-comparison-dialog .text-comparison').should('not.exist')
+		cy.get('#viewer').should('not.exist')
+	})
+
+	it('cancels a delayed comparison when navigating to another page', function() {
+		if (usesLegacyViewer) {
+			return
+		}
+
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL, {
+			delay: 1200,
+			body: 'Delayed snapshot',
+		}).as('delayedSnapshot')
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog__loading').should('be.visible')
+		cy.contains('.app-content-list-item a', 'Fresh page').click({ force: true })
+		cy.location('pathname').should('contain', '/Fresh-page')
+		cy.getReadOnlyEditor().should('be.visible')
+		// Wait beyond the intercepted response to prove stale completion stays ignored.
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.wait(1400)
+		cy.get('.version-comparison-dialog').should('not.exist')
+		cy.get('.text-comparison').should('not.exist')
+	})
+
+	it('Reports semantic comparison initialization failures', function() {
+		if (usesLegacyViewer) {
+			cy.window().its('OCA.Text.createMarkdownContentComparison').should('not.exist')
+			return
+		}
+
+		cy.window().then((window) => {
+			cy.stub(window.OCA.Text, 'createMarkdownContentComparison')
+				.rejects(new Error('comparison failed'))
+		})
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog [role="alert"]')
+			.should('contain', 'Could not initialize version comparison.')
+		cy.get('.version-comparison-dialog .text-comparison').should('not.exist')
+	})
+
+	it('Compares versions for a read-only member', function() {
+		cy.loginAs('alice')
+		cy.visit('/apps/collectives/Versions Collective/Page')
+		cy.get('button.titleform-button').should('not.exist')
+		cy.getReadOnlyEditor().should('contain', CURRENT_PHRASE)
+		cy.get('button.page-sidebar-button').click()
+		cy.get('#tab-button-versions').click()
+		cy.get('.app-sidebar-tabs__content .version-list .list-item')
+			.contains('Initial version')
+			.closest('.list-item')
+			.find('.list-item-content__actions')
+			.click()
+		cy.contains('button', 'Name this version').should('not.exist')
+		cy.contains('button', 'Restore version').should('not.exist')
+		cy.contains('button', 'Delete version').should('not.exist')
+		cy.clickMenuButton('Compare with current version')
+
+		if (usesLegacyViewer) {
+			assertViewerComparison(INITIAL_PHRASE, CURRENT_PHRASE)
+			closeViewerComparison()
+		} else {
+			cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		}
+	})
+
+	it('Restores initial version after leaving edit mode during member and editor setup', function() {
+		let notifyMemberRequestStarted
+		let releaseMemberRequests = false
+		const heldMemberRequests = []
+		const memberRequestStarted = new Cypress.Promise((resolve) => {
+			notifyMemberRequestStarted = resolve
+		})
+		cy.intercept('GET', '**/circles/circles/*/members?**', (request) => {
+			notifyMemberRequestStarted()
+			if (releaseMemberRequests) {
+				request.continue()
+				return
+			}
+			return new Cypress.Promise((resolve) => {
+				heldMemberRequests.push(() => {
+					request.continue()
+					resolve()
+				})
+			})
+		})
+		cy.visit('/apps/collectives/Versions Collective/Restore page')
+		let editorSetupStarted
+		let editorDestroyed
+		let releaseEditorSetup
+		cy.window().then((window) => {
+			const createEditor = window.OCA.Text.createEditor
+			let notifyEditorDestroyed
+			editorDestroyed = new Cypress.Promise((resolve) => {
+				notifyEditorDestroyed = resolve
+			})
+			const setupHold = new Cypress.Promise((resolve) => {
+				releaseEditorSetup = resolve
+			})
+			editorSetupStarted = new Cypress.Promise((resolve) => {
+				window.OCA.Text.createEditor = async (options) => {
+					const editorPromise = createEditor(options)
+					resolve()
+					await setupHold
+					const editor = await editorPromise
+					const destroy = editor.destroy.bind(editor)
+					editor.destroy = () => {
+						try {
+							return destroy()
+						} finally {
+							notifyEditorDestroyed()
+						}
+					}
+					return editor
+				}
+			})
+		})
+		cy.get('button.titleform-button').should('contain', 'Edit').click()
+		cy.then(() => memberRequestStarted)
+		cy.then(() => editorSetupStarted)
+		cy.get('button.titleform-button').should('contain', 'Preview').click()
+		cy.then(() => releaseEditorSetup())
+		cy.then(() => {
+			releaseMemberRequests = true
+			heldMemberRequests.splice(0).forEach((release) => release())
+		})
+		cy.then(() => editorDestroyed)
+		cy.get('[data-cy-collectives="editor"] .ProseMirror').should('not.exist')
+
+		openVersionsSidebar()
+		cy.get('.app-sidebar-tabs__content .version-list .list-item')
+			.contains('Initial version')
+			.closest('.list-item')
 			.find('.list-item-content__actions')
 			.click()
 
 		cy.intercept('MOVE', '**/dav/versions/**').as('moveVersion')
 		cy.clickMenuButton('Restore version')
 		cy.wait('@moveVersion')
+		cy.contains('.toast-success', 'Restored').should('be.visible')
+		cy.get('.toast-success', { timeout: 15000 }).should('not.exist')
 
-		cy.reload()
-		cy.getReadOnlyEditor()
-			.should('contain', 'v1')
+		// NC34 can retain the pre-restore reader response in the browser cache.
+		cy.reload(true)
+		cy.get('[data-cy-collectives="reader"]', { timeout: 15000 })
+			.should('contain', INITIAL_PHRASE)
+			.and('not.contain', CURRENT_PHRASE)
+	})
+
+	it('compares a version saved moments earlier without a reload', function() {
+		cy.visit('/apps/collectives/Versions Collective/Rapid compare page')
+		insertEditorContent(RAPID_FIRST_PHRASE)
+		// Wait for the existing editor-content mirror before this version-refresh test leaves edit mode.
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.wait(250)
+		cy.intercept('POST', '**/apps/text/session/*/save').as('firstRapidSave')
+		cy.switchToPreviewMode()
+		cy.wait('@firstRapidSave')
+
+		// A version is only created when two writes are more than a second apart.
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.wait(1100)
+
+		cy.switchToEditMode()
+		insertEditorContent(RAPID_SECOND_PHRASE, true)
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.wait(250)
+		cy.intercept('POST', '**/apps/text/session/*/save').as('secondRapidSave')
+		cy.switchToPreviewMode()
+		cy.wait('@secondRapidSave')
+
+		// No reload between the save and the comparison: the sidebar has to be
+		// listing the versions that save actually produced, not the ones from
+		// before it.
+		openVersionsSidebar()
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+
+		if (usesLegacyViewer) {
+			assertViewerComparison(RAPID_FIRST_PHRASE, RAPID_SECOND_PHRASE)
+			closeViewerComparison()
+		} else {
+			cy.get('.version-comparison-dialog .text-comparison__change-list', { timeout: 15000 })
+				.should('be.visible')
+			cy.get('.version-comparison-dialog').should('not.contain', 'expired or was removed')
+			closeSemanticComparison()
+		}
 	})
 
 	it('Delete version', function() {
 		cy.get('.app-sidebar-tabs__content .version-list .list-item')
-			.eq(2)
-			.find('.list-item-content__actions')
-			.click()
+			.then(($versions) => {
+				cy.wrap($versions)
+					.filter(':not(:first)')
+					.first()
+					.find('.list-item-content__actions')
+					.click()
 
-		cy.intercept('MOVE', '**/dav/versions/**').as('moveVersion')
-		cy.clickMenuButton('Delete version')
+				cy.intercept('DELETE', '**/dav/versions/**').as('deleteVersion')
+				cy.clickMenuButton('Delete version')
+				cy.wait('@deleteVersion')
 
-		cy.get('.app-sidebar-tabs__content .version-list .list-item')
-			.should('have.length', 3)
+				cy.get('.app-sidebar-tabs__content .version-list .list-item')
+					.should('have.length', $versions.length - 1)
+			})
 	})
 })

--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -41,7 +41,6 @@ import { useCirclesStore } from '../../stores/circles.js'
 import { useCollectivesStore } from '../../stores/collectives.js'
 import { usePagesStore } from '../../stores/pages.js'
 import { useRootStore } from '../../stores/root.js'
-import { useVersionsStore } from '../../stores/versions.js'
 import { encodeAttachmentFilename } from '../../util/attachmentFilename.ts'
 
 export default {
@@ -69,13 +68,14 @@ export default {
 			document.documentElement.style.setProperty('--text-container-width', value + 'px')
 		})
 		const davContent = ref('')
-		const { contentLoaded, editor, editorContent, editorEl, pageContent, setupEditor } = useEditor(davContent)
+		const { contentLoaded, destroyEditor, editor, editorContent, editorEl, pageContent, setupEditor } = useEditor(davContent)
 		const { pageInfoBarPage, reader, readerEl, setupReader } = useReader(pageContent)
-		return { contentLoaded, davContent, editor, editorContent, editorEl, pageContent, pageInfoBarPage, reader, readerEl, setupEditor, setupReader, textContainer, width }
+		return { contentLoaded, davContent, destroyEditor, editor, editorContent, editorEl, pageContent, pageInfoBarPage, reader, readerEl, setupEditor, setupReader, textContainer, width }
 	},
 
 	data() {
 		return {
+			editorSetupPromise: null,
 			textEditWatcher: null,
 		}
 	},
@@ -94,7 +94,10 @@ export default {
 		]),
 
 		showEditor() {
-			return this.currentCollectiveCanEdit && !this.loading('editor') && this.isTextEdit
+			return this.currentCollectiveCanEdit
+				&& this.editor
+				&& !this.loading('editor')
+				&& this.isTextEdit
 		},
 	},
 
@@ -116,26 +119,36 @@ export default {
 
 	async mounted() {
 		const readerPromise = this.setupReader(this.currentPage)
-		const editorPromise = this.setupEditor()
 		const pageContentPromise = this.getPageContent()
-		Promise.all([readerPromise, editorPromise, pageContentPromise]).then(() => {
-			this.initEditMode()
-		})
 
 		this.textEditWatcher = this.$watch('isTextEdit', async (val) => {
-			if (val === false) {
-				this.stopEdit()
-			} else if (val === true) {
-				// Load full circle members for autocomplete when entering edit mode
-				const circlesStore = useCirclesStore()
-				if (!circlesStore.currentCircleMembersFullyLoaded && !this.isPublic) {
-					await this.getCircleMembers(this.currentCollective.circleId)
-				}
+			if (!val) {
+				await this.stopEdit()
+				return
+			}
+
+			const editorPromise = this.ensureEditor()
+			const circlesStore = useCirclesStore()
+			if (!circlesStore.currentCircleMembersFullyLoaded && !this.isPublic) {
+				await Promise.all([
+					editorPromise,
+					this.getCircleMembers(this.currentCollective.circleId),
+				])
+			} else {
+				await editorPromise
 			}
 		})
 		subscribe('collectives:attachment:insert', this.insertAttachment)
 		subscribe('collectives:attachment:replaceFilename', this.replaceAttachmentFilename)
 		subscribe('collectives:attachment:removeReferences', this.removeAttachmentReferences)
+
+		await Promise.all([readerPromise, pageContentPromise])
+		this.initEditMode()
+		if (this.isTextEdit) {
+			await this.ensureEditor()
+		} else {
+			this.done('editor')
+		}
 	},
 
 	beforeUnmount() {
@@ -149,9 +162,29 @@ export default {
 		t,
 
 		...mapActions(useRootStore, ['load', 'done']),
-		...mapActions(useVersionsStore, ['getVersions']),
 		...mapActions(usePagesStore, ['setTextEdit', 'setTextPreview', 'touchPage']),
 		...mapActions(useCirclesStore, ['getCircleMembers']),
+
+		async ensureEditor() {
+			if (this.editor) {
+				return
+			}
+			const setupPromise = this.editorSetupPromise ?? (() => {
+				this.load('editor')
+				return this.setupEditor()
+			})()
+			this.editorSetupPromise = setupPromise
+			try {
+				await setupPromise
+			} finally {
+				if (this.editorSetupPromise === setupPromise) {
+					this.editorSetupPromise = null
+				}
+			}
+			if (!this.isTextEdit && this.editor) {
+				await this.destroyEditor()
+			}
+		},
 
 		insertAttachment({ name }) {
 			// inspired by the fixedEncodeURIComponent function suggested in
@@ -220,12 +253,11 @@ export default {
 						this.setTextEdit()
 					})
 
-				// Touch page to update last changed timestamp
-				this.touchPage()
-
-				// Update loaded versions
-				if (!this.isPublic && this.hasVersionsLoaded) {
-					this.getVersions(this.currentPage.id)
+				// Touch the page before reading the versions created by this save.
+				try {
+					await this.touchPage()
+				} catch {
+					// A failed metadata touch must not undo the completed document save.
 				}
 			}
 		},

--- a/src/components/PageSidebar.vue
+++ b/src/components/PageSidebar.vue
@@ -39,7 +39,7 @@
 			<SidebarTabSharing v-if="showingSidebar" :pageId="currentPageId" />
 		</NcAppSidebarTab>
 		<NcAppSidebarTab
-			v-if="!isPublic && currentCollectiveCanEdit"
+			v-if="!isPublic"
 			id="versions"
 			:order="3"
 			:name="t('collectives', 'Versions')">
@@ -90,10 +90,7 @@ export default {
 
 	computed: {
 		...mapState(useRootStore, ['activeSidebarTab', 'isPublic', 'showingSidebar']),
-		...mapState(useCollectivesStore, [
-			'currentCollectiveCanEdit',
-			'currentCollectiveCanShare',
-		]),
+		...mapState(useCollectivesStore, ['currentCollectiveCanShare']),
 
 		...mapState(usePagesStore, ['currentPage', 'currentPageId', 'title']),
 

--- a/src/components/PageSidebar/SidebarTabVersions.vue
+++ b/src/components/PageSidebar/SidebarTabVersions.vue
@@ -24,6 +24,16 @@
 
 		<!-- versions list -->
 		<div v-else-if="!loading('versions') && sortedVersions.length">
+			<NcButton
+				v-if="hasComparableHistoricalVersions"
+				wide
+				class="versions-container__compare"
+				@click="onOpenComparisonSelector">
+				<template #icon>
+					<FileCompareIcon :size="22" />
+				</template>
+				{{ t('collectives', 'Compare versions…') }}
+			</NcButton>
 			<ul :aria-label="t('collectives', 'Page versions')" class="version-list">
 				<VersionEntry
 					v-for="version in sortedVersions"
@@ -58,23 +68,35 @@
 			v-model:open="showVersionLabelForm"
 			:versionLabel="editedVersion.label"
 			@labelUpdate="onLabelUpdate" />
+
+		<VersionComparisonDialog
+			ref="comparisonDialog"
+			:currentVersion
+			:versions
+			:filePath="`/${currentPageFilePath}`"
+			:shareToken="shareTokenParam" />
 	</div>
 </template>
 
 <script>
 import { t } from '@nextcloud/l10n'
 import { mapActions, mapState } from 'pinia'
+import NcButton from '@nextcloud/vue/components/NcButton'
 import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import AlertOctagonIcon from 'vue-material-design-icons/AlertOctagonOutline.vue'
 import BackupRestoreIcon from 'vue-material-design-icons/BackupRestore.vue'
+import FileCompareIcon from 'vue-material-design-icons/FileCompare.vue'
 import OfflineContent from './OfflineContent.vue'
+import VersionComparisonDialog from './VersionComparisonDialog.vue'
 import VersionEntry from './VersionEntry.vue'
 import VersionLabelDialog from './VersionLabelDialog.vue'
 import { useNetworkState } from '../../composables/useNetworkState.ts'
 import { useCollectivesStore } from '../../stores/collectives.js'
+import { usePagesStore } from '../../stores/pages.js'
 import { useRootStore } from '../../stores/root.js'
 import { useVersionsStore } from '../../stores/versions.js'
+import { createVersionComparisonState } from '../../util/versionComparison.js'
 
 export default {
 	name: 'SidebarTabVersions',
@@ -84,7 +106,10 @@ export default {
 		NcEmptyContent,
 		NcLoadingIcon,
 		BackupRestoreIcon,
+		FileCompareIcon,
+		NcButton,
 		OfflineContent,
+		VersionComparisonDialog,
 		VersionEntry,
 		VersionLabelDialog,
 	},
@@ -108,6 +133,7 @@ export default {
 
 	data() {
 		return {
+			loadGeneration: 0,
 			loadPending: true,
 			error: '',
 			showVersionLabelForm: false,
@@ -116,7 +142,8 @@ export default {
 	},
 
 	computed: {
-		...mapState(useRootStore, ['loading']),
+		...mapState(useRootStore, ['loading', 'shareTokenParam']),
+		...mapState(usePagesStore, ['currentPageFilePath']),
 		...mapState(useCollectivesStore, ['currentCollectiveCanEdit']),
 		...mapState(useVersionsStore, [
 			'currentVersion',
@@ -146,6 +173,11 @@ export default {
 				.reduce((a, b) => Math.min(a, b))
 		},
 
+		hasComparableHistoricalVersions() {
+			return createVersionComparisonState(this.currentVersion, this.versions)
+				.options.some(({ kind }) => kind === 'historical')
+		},
+
 		isCurrent() {
 			return (mtime) => mtime === this.pageMtime
 		},
@@ -161,7 +193,17 @@ export default {
 
 	watch: {
 		pageId: function() {
+			this.$refs.comparisonDialog?.routeContextChanged()
 			this.getPageVersions()
+		},
+
+		// The page changed on disk, so the versions listed beside it are stale.
+		// Without this the list survives a save, and comparing against it asks
+		// for a revision the server never had.
+		pageTimestamp: function(value, previous) {
+			if (value && value !== previous) {
+				this.getPageVersions()
+			}
 		},
 
 		networkOnline: function(val) {
@@ -191,20 +233,32 @@ export default {
 		 * Get versions of a page
 		 */
 		async getPageVersions() {
+			const generation = ++this.loadGeneration
+			const pageId = this.pageId
 			this.loadPending = true
 			if (!this.networkOnline) {
+				this.done('versions')
 				return
 			}
 
 			this.load('versions')
+			this.error = ''
 			try {
-				await this.getVersions(this.pageId)
+				await this.getVersions(pageId)
+				if (generation !== this.loadGeneration || pageId !== this.pageId) {
+					return
+				}
 				this.loadPending = false
 			} catch (e) {
+				if (generation !== this.loadGeneration || pageId !== this.pageId) {
+					return
+				}
 				this.error = t('collectives', 'Could not get page versions')
 				console.error('Failed to get page versions', e)
 			} finally {
-				this.done('versions')
+				if (generation === this.loadGeneration) {
+					this.done('versions')
+				}
 			}
 		},
 
@@ -235,7 +289,11 @@ export default {
 		},
 
 		onCompareVersion(version) {
-			window.OCA.Viewer.compare(this.currentVersion, this.versions.find((v) => v.source === version.source))
+			this.$refs.comparisonDialog.openFor(version)
+		},
+
+		onOpenComparisonSelector() {
+			this.$refs.comparisonDialog.openSelector()
 		},
 
 		async onRestoreVersion(version) {
@@ -248,3 +306,9 @@ export default {
 	},
 }
 </script>
+
+<style scoped lang="scss">
+.versions-container__compare {
+	margin-block-end: 8px;
+}
+</style>

--- a/src/components/PageSidebar/VersionComparisonDialog.vue
+++ b/src/components/PageSidebar/VersionComparisonDialog.vue
@@ -1,0 +1,521 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcDialog
+		:open="open"
+		isForm
+		:size="comparisonDialogSize()"
+		contentClasses="version-comparison-dialog"
+		:name="t('collectives', 'Compare versions')"
+		@submit="compareSelected"
+		@update:open="onOpenUpdate">
+		<div class="version-comparison-dialog__selectors">
+			<label class="version-comparison-dialog__field">
+				<span class="version-comparison-dialog__field-label">
+					<span class="version-comparison-dialog__indicator" aria-hidden="true" />
+					{{ t('collectives', 'Earlier') }}
+				</span>
+				<select
+					v-model="earlierKey"
+					:disabled="status === 'loading'"
+					@change="resetResult">
+					<option
+						v-for="option in comparisonOptions"
+						:key="option.key"
+						:value="option.key">
+						{{ optionLabel(option) }}
+					</option>
+				</select>
+			</label>
+			<label class="version-comparison-dialog__field version-comparison-dialog__field--later">
+				<span class="version-comparison-dialog__field-label">
+					<span class="version-comparison-dialog__indicator" aria-hidden="true" />
+					{{ t('collectives', 'Later') }}
+				</span>
+				<select
+					v-model="laterKey"
+					:disabled="status === 'loading'"
+					@change="resetResult">
+					<option
+						v-for="option in comparisonOptions"
+						:key="option.key"
+						:value="option.key">
+						{{ optionLabel(option) }}
+					</option>
+				</select>
+			</label>
+		</div>
+
+		<NcNoteCard
+			v-if="comparisonOptionState.quarantined.length"
+			class="version-comparison-dialog__message"
+			type="warning"
+			role="status"
+			:text="t('collectives', 'Some page versions could not be used for comparison.')" />
+		<NcNoteCard
+			v-if="sameSelection"
+			class="version-comparison-dialog__message"
+			type="info"
+			role="status"
+			:text="t('collectives', 'Select two different versions.')" />
+		<NcNoteCard
+			v-if="unsupportedMessage"
+			class="version-comparison-dialog__message"
+			type="info"
+			role="status"
+			:text="unsupportedMessage" />
+		<NcNoteCard
+			v-if="errorMessage"
+			class="version-comparison-dialog__message"
+			type="error"
+			role="alert"
+			:text="errorMessage" />
+		<div v-if="status === 'loading'" class="version-comparison-dialog__loading" role="status">
+			<NcLoadingIcon :size="32" />
+			<span>{{ t('collectives', 'Loading versions…') }}</span>
+		</div>
+		<div
+			ref="comparisonEl"
+			class="version-comparison-dialog__comparison"
+			:aria-busy="status === 'loading'" />
+
+		<template v-if="status !== 'ready'" #actions>
+			<NcButton
+				v-if="status === 'error'"
+				variant="primary"
+				type="button"
+				@click="compareSelected">
+				{{ t('collectives', 'Retry') }}
+			</NcButton>
+			<NcButton
+				v-if="status === 'idle' || status === 'loading'"
+				variant="primary"
+				type="submit"
+				:disabled="!canCompare || status === 'loading'">
+				{{ t('collectives', 'Compare') }}
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script>
+import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+import { t } from '@nextcloud/l10n'
+import moment from '@nextcloud/moment'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
+import { markRaw } from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcDialog from '@nextcloud/vue/components/NcDialog'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import {
+	ComparisonRequestManager,
+	ComparisonSnapshotError,
+	createVersionComparisonState,
+	CURRENT_VERSION_KEY,
+	loadVersionComparisonSnapshots,
+	normalizeVersionComparisonPair,
+	selectVersionComparisonRenderer,
+	VersionComparisonSnapshotCache,
+} from '../../util/versionComparison.js'
+
+export default {
+	name: 'VersionComparisonDialog',
+
+	components: {
+		NcButton,
+		NcDialog,
+		NcLoadingIcon,
+		NcNoteCard,
+	},
+
+	props: {
+		currentVersion: {
+			type: Object,
+			required: true,
+		},
+
+		versions: {
+			type: Array,
+			required: true,
+		},
+
+		filePath: {
+			type: String,
+			required: true,
+		},
+
+		shareToken: {
+			type: String,
+			default: null,
+		},
+	},
+
+	setup() {
+		return {
+			historicalSnapshotCache: markRaw(new VersionComparisonSnapshotCache()),
+			isMobile: useIsMobile(),
+			requestManager: new ComparisonRequestManager(),
+		}
+	},
+
+	data() {
+		return {
+			comparisonInstance: null,
+			earlierKey: '',
+			errorMessage: '',
+			laterKey: '',
+			open: false,
+			status: 'idle',
+			unsupportedMessage: '',
+		}
+	},
+
+	computed: {
+		comparisonOptionState() {
+			return createVersionComparisonState(this.currentVersion, this.versions)
+		},
+
+		comparisonOptions() {
+			return this.comparisonOptionState.options
+		},
+
+		earlier() {
+			return this.comparisonOptions.find(({ key }) => key === this.earlierKey)
+		},
+
+		later() {
+			return this.comparisonOptions.find(({ key }) => key === this.laterKey)
+		},
+
+		sameSelection() {
+			return Boolean(this.earlierKey && this.earlierKey === this.laterKey)
+		},
+
+		canCompare() {
+			return Boolean(this.earlier
+				&& this.later
+				&& ['current', 'historical'].includes(this.earlier.kind)
+				&& ['current', 'historical'].includes(this.later.kind)
+				&& !this.sameSelection)
+		},
+	},
+
+	beforeUnmount() {
+		this.cleanup()
+		this.historicalSnapshotCache.clear()
+	},
+
+	methods: {
+		t,
+
+		comparisonDialogSize() {
+			return typeof window.OCA?.Text?.createMarkdownContentComparison === 'function'
+				? 'full'
+				: 'large'
+		},
+
+		openSelector() {
+			const historical = this.comparisonOptions.find(({ kind }) => kind === 'historical')
+			if (!historical) {
+				return
+			}
+			this.earlierKey = historical.key
+			this.laterKey = CURRENT_VERSION_KEY
+			this.resetResult()
+			this.open = true
+		},
+
+		openFor(version) {
+			const selected = this.comparisonOptions.find(({ fileVersion }) => fileVersion === String(version.fileVersion))
+			if (!selected) {
+				showError(t('collectives', 'This page version cannot be used for comparison.'))
+				return
+			}
+			this.earlierKey = selected.key
+			this.laterKey = CURRENT_VERSION_KEY
+			this.resetResult()
+			this.open = true
+			this.$nextTick(this.compareSelected)
+		},
+
+		onOpenUpdate(open) {
+			this.open = open
+			if (!open) {
+				this.cleanup()
+			}
+		},
+
+		optionLabel(option) {
+			const timestamp = t('collectives', '{date} at {time}', {
+				date: moment(option.mtime).format('LL'),
+				time: moment(option.mtime).format('LTS'),
+			})
+			if (option.kind === 'current') {
+				return t('collectives', 'Current version — {timestamp}', { timestamp })
+			}
+			return option.label
+				? t('collectives', '{label} — {timestamp}', { label: option.label, timestamp })
+				: timestamp
+		},
+
+		async compareSelected() {
+			if (!this.canCompare) {
+				return
+			}
+			const pair = normalizeVersionComparisonPair(this.earlier, this.later)
+			this.earlierKey = pair.earlier.key
+			this.laterKey = pair.later.key
+			this.destroyComparison()
+			this.errorMessage = ''
+			this.unsupportedMessage = ''
+
+			const comparisonFactory = window.OCA?.Text?.createMarkdownContentComparison
+			const renderer = selectVersionComparisonRenderer({
+				comparisonFactory,
+				viewerCompare: window.OCA?.Viewer?.compare,
+				isMobile: this.isMobile,
+			})
+			if (renderer === 'unsupported') {
+				this.status = 'unsupported'
+				this.unsupportedMessage = this.isMobile
+					? t('collectives', 'Version comparison requires a newer version of the Text app on mobile.')
+					: t('collectives', 'Version comparison is not supported by the installed Text app.')
+				return
+			}
+			if (renderer === 'viewer') {
+				window.OCA.Viewer.compare(
+					{ ...pair.later.fileInfo },
+					{ ...pair.earlier.fileInfo },
+				)
+				this.onOpenUpdate(false)
+				return
+			}
+
+			const request = this.requestManager.begin()
+			let pendingInstance = null
+			this.status = 'loading'
+			try {
+				const contents = await loadVersionComparisonSnapshots(
+					pair,
+					this.fetchSnapshot,
+					request.signal,
+				)
+				if (!this.requestManager.isCurrent(request.generation)) {
+					return
+				}
+
+				await this.$nextTick()
+				const comparisonHost = document.createElement('div')
+				pendingInstance = await comparisonFactory({
+					...contents,
+					el: comparisonHost,
+					fileId: this.currentVersion.fileId,
+					filePath: this.filePath,
+					shareToken: this.shareToken,
+					openLinkHandler: window.OCA?.Collectives?.openLink,
+				})
+				if (!this.requestManager.isCurrent(request.generation)) {
+					pendingInstance.destroy()
+					return
+				}
+				this.$refs.comparisonEl.replaceChildren(...comparisonHost.childNodes)
+				this.comparisonInstance = markRaw(pendingInstance)
+				pendingInstance = null
+				this.status = 'ready'
+			} catch (error) {
+				pendingInstance?.destroy()
+				if (!this.requestManager.isCurrent(request.generation) || this.isCancellation(error)) {
+					return
+				}
+				this.status = 'error'
+				this.errorMessage = error instanceof ComparisonSnapshotError
+					? this.snapshotErrorMessage(error)
+					: t('collectives', 'Could not initialize version comparison.')
+			}
+		},
+
+		routeContextChanged() {
+			this.open = false
+			this.cleanup()
+			this.historicalSnapshotCache.clear()
+		},
+
+		async fetchSnapshot(snapshot, signal) {
+			return this.historicalSnapshotCache.load(snapshot, async (requestedSnapshot, requestedSignal) => {
+				const config = {
+					signal: requestedSignal,
+					transformResponse: [(content) => content],
+				}
+				if (requestedSnapshot.kind === 'current') {
+					config.params = { timestamp: Date.now() }
+				}
+				const response = await axios.get(requestedSnapshot.url, config)
+				return response.data
+			}, signal)
+		},
+
+		snapshotErrorMessage(error) {
+			const statuses = error.reasons.map((reason) => reason?.response?.status)
+			if (statuses.includes(403)) {
+				return error.reasons.length === 2
+					? t('collectives', 'You do not have permission to load the selected versions.')
+					: t('collectives', 'You do not have permission to load one of the selected versions.')
+			}
+			if (statuses.some((status) => status === 404 || status === 410)) {
+				return error.reasons.length === 2
+					? t('collectives', 'The selected versions have expired or were removed.')
+					: t('collectives', 'One of the selected versions has expired or was removed.')
+			}
+			return t('collectives', 'Could not load the selected versions because of a network error.')
+		},
+
+		isCancellation(error) {
+			return error?.name === 'AbortError'
+				|| error?.name === 'CanceledError'
+				|| axios.isCancel(error)
+		},
+
+		resetResult() {
+			this.destroyComparison()
+			this.requestManager.cancel()
+			this.errorMessage = ''
+			this.unsupportedMessage = ''
+			this.status = 'idle'
+		},
+
+		destroyComparison() {
+			this.comparisonInstance?.destroy()
+			this.comparisonInstance = null
+			this.$refs.comparisonEl?.replaceChildren()
+		},
+
+		cleanup() {
+			this.requestManager.cancel()
+			this.destroyComparison()
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+// Deliberate layout maximum: keeps the side-by-side comparison readable on ultra-wide screens.
+$comparison-max-inline-size: 1600px;
+// Deliberate layout maximum: keeps the two version pickers close together instead of edge to edge.
+$selectors-max-inline-size: 1040px;
+
+:deep(.dialog__content.version-comparison-dialog) {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	inline-size: 100%;
+	max-inline-size: $comparison-max-inline-size;
+	min-height: 0;
+	block-size: 100%;
+	margin-inline: auto;
+	overflow: hidden;
+}
+
+.version-comparison-dialog {
+	&__selectors {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		align-items: end;
+		flex: 0 0 auto;
+		gap: calc(3 * var(--default-grid-baseline));
+		inline-size: 100%;
+		max-inline-size: $selectors-max-inline-size;
+		margin-inline: auto;
+		padding-inline: calc(3 * var(--default-grid-baseline));
+		padding-block-end: calc(2 * var(--default-grid-baseline));
+
+		select {
+			display: block;
+			width: 100%;
+			min-height: var(--default-clickable-area);
+			padding-inline: calc(3 * var(--default-grid-baseline)) calc(9 * var(--default-grid-baseline));
+			border-color: var(--color-border-maxcontrast);
+			border-radius: var(--border-radius-element);
+			background-color: var(--color-main-background);
+			font-size: var(--default-font-size);
+			line-height: var(--default-line-height);
+			color: var(--color-main-text);
+		}
+	}
+
+	&__field {
+		display: block;
+		inline-size: 100%;
+	}
+
+	&__field-label {
+		display: flex;
+		align-items: center;
+		gap: calc(2 * var(--default-grid-baseline));
+		margin-block-end: var(--default-grid-baseline);
+		font-size: var(--font-size-small);
+		font-weight: var(--font-weight-element);
+		line-height: var(--default-line-height);
+		color: var(--color-text-maxcontrast);
+	}
+
+	// Decorative rank marker: muted bar for the earlier version, primary dot for the later one.
+	&__indicator {
+		display: block;
+		flex: 0 0 auto;
+		block-size: calc(0.5 * var(--default-grid-baseline));
+		inline-size: calc(2.5 * var(--default-grid-baseline));
+		border-radius: var(--border-radius-pill);
+		background-color: var(--color-text-maxcontrast);
+	}
+
+	&__field--later {
+		.version-comparison-dialog__field-label {
+			color: var(--color-main-text);
+		}
+
+		.version-comparison-dialog__indicator {
+			block-size: calc(2 * var(--default-grid-baseline));
+			inline-size: calc(2 * var(--default-grid-baseline));
+			background-color: var(--color-primary-element);
+		}
+	}
+
+	&__message {
+		margin-block: calc(3 * var(--default-grid-baseline));
+	}
+
+	&__loading {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: calc(2 * var(--default-grid-baseline));
+		flex: 1 1 auto;
+		min-height: 160px;
+	}
+
+	&__comparison {
+		display: flex;
+		box-sizing: border-box;
+		flex: 1 1 auto;
+		inline-size: 100%;
+		min-inline-size: 0;
+		min-height: 0;
+		overflow: hidden;
+
+		&:not(:empty) {
+			border-block-start: 1px solid var(--color-border);
+		}
+	}
+}
+
+@media (max-width: 600px) {
+	.version-comparison-dialog__selectors {
+		grid-template-columns: 1fr;
+	}
+}
+</style>

--- a/src/components/PageSidebar/VersionEntry.vue
+++ b/src/components/PageSidebar/VersionEntry.vue
@@ -7,6 +7,7 @@
 	<NcListItem
 		:name="version.basename"
 		class="version"
+		:data-version-id="version.fileVersion"
 		:class="{ active: isSelected }"
 		:active="isSelected"
 		forceDisplayActions
@@ -67,6 +68,7 @@
 		<!-- Actions -->
 		<template #actions>
 			<NcActionButton
+				v-if="canEdit"
 				closeAfterClick
 				@click="$emit('startLabelUpdate')">
 				<template #icon>
@@ -81,7 +83,7 @@
 				<template #icon>
 					<FileCompareIcon :size="22" />
 				</template>
-				{{ t('collectives', 'Compare to current version') }}
+				{{ t('collectives', 'Compare with current version') }}
 			</NcActionButton>
 			<NcActionButton
 				v-if="!isCurrent && canEdit"

--- a/src/composables/useEditor.ts
+++ b/src/composables/useEditor.ts
@@ -63,9 +63,7 @@ export function useEditor(davContent: Ref<string>) {
 		return !!pageContent.value || !rootStore.loading('pageContent')
 	})
 
-	onBeforeUnmount(() => {
-		editorPromise?.then((ed) => ed.destroy())
-	})
+	onBeforeUnmount(destroyEditor)
 
 	watch(showCurrentPageOutline, (value) => {
 		editor.value?.setShowOutline(value)
@@ -138,9 +136,21 @@ export function useEditor(davContent: Ref<string>) {
 		editor.value = markRaw(await editorPromise as TextEditorInstance)
 	}
 
+	/** Destroy the current or pending editor and clear its delayed state. */
+	async function destroyEditor() {
+		const pendingEditor = editorPromise
+		editorPromise = null
+		const instance = await pendingEditor
+		updateEditorContentDebounced.clear()
+		editor.value = null
+		editorContent.value = null
+		instance?.destroy()
+	}
+
 	return {
 		contentLoaded,
 		davContent,
+		destroyEditor,
 		editor,
 		editorEl,
 		editorContent,

--- a/src/stores/versions.js
+++ b/src/stores/versions.js
@@ -15,13 +15,13 @@ import { usePagesStore } from './pages.js'
 
 export const useVersionsStore = defineStore('versions', {
 	state: () => ({
+		loadedPageId: null,
+		requestGeneration: 0,
 		selectedVersion: null,
 		versions: [],
 	}),
 
 	getters: {
-		hasVersionsLoaded: (state) => !!state.versions.length,
-
 		currentVersion: () => {
 			const collectivesStore = useCollectivesStore()
 			const pagesStore = usePagesStore()
@@ -51,11 +51,17 @@ export const useVersionsStore = defineStore('versions', {
 		},
 
 		async getVersions(pageId) {
+			const generation = ++this.requestGeneration
 			const response = await davApi.getVersions(pageId)
-			this.versions = response.data
+			const versions = response.data
 				// filter out root
 				.filter(({ mime }) => mime !== '')
 				.map((version) => this.formatVersion(version, pageId))
+			if (generation === this.requestGeneration) {
+				this.versions = versions
+				this.loadedPageId = pageId
+			}
+			return versions
 		},
 
 		formatVersion(version, pageId) {

--- a/src/tests/util/versionComparison.spec.js
+++ b/src/tests/util/versionComparison.spec.js
@@ -1,0 +1,255 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+	ComparisonRequestManager,
+	ComparisonSnapshotError,
+	createVersionComparisonState,
+	loadVersionComparisonSnapshots,
+	normalizeVersionComparisonPair,
+	selectVersionComparisonRenderer,
+	VersionComparisonSnapshotCache,
+} from '../../util/versionComparison.js'
+
+const current = {
+	label: '',
+	mtime: 3000,
+	source: '/current',
+	url: '/current',
+}
+const old = {
+	fileVersion: '1',
+	label: 'Old',
+	mtime: 1000,
+	source: '/old',
+	url: '/old',
+}
+const middle = {
+	fileVersion: '2',
+	label: 'Middle',
+	mtime: 2000,
+	source: '/middle',
+	url: '/middle',
+}
+
+describe('version comparison pair model', () => {
+	it.each([
+		['callable factory on desktop', false, vi.fn(), vi.fn(), 'semantic'],
+		['callable factory on mobile', true, vi.fn(), vi.fn(), 'semantic'],
+		['Viewer on desktop', false, undefined, vi.fn(), 'viewer'],
+		['Viewer on mobile', true, undefined, vi.fn(), 'unsupported'],
+		['no available renderer', false, undefined, undefined, 'unsupported'],
+	])('selects the renderer for %s', (_name, isMobile, comparisonFactory, viewerCompare, expected) => {
+		expect(selectVersionComparisonRenderer({ comparisonFactory, viewerCompare, isMobile }))
+			.toBe(expected)
+	})
+
+	it('uses stable selector keys without source paths', () => {
+		const { options } = createVersionComparisonState(current, [old, current, middle])
+		expect(options.map(({ key }) => key)).toEqual([
+			'current',
+			'version:2',
+			'version:1',
+		])
+		expect(options.map(({ key }) => key).join()).not.toContain('/middle')
+		expect(options[0].fileInfo).toBe(current)
+	})
+
+	it('quarantines malformed and duplicate identities without hiding valid options', () => {
+		const valid = { ...middle, fileVersion: 'valid' }
+		const duplicateFirst = { ...old, fileVersion: 'duplicate' }
+		const duplicateSecond = { ...middle, fileVersion: 'duplicate', mtime: 2500 }
+		const { options, quarantined } = createVersionComparisonState(current, [
+			current,
+			valid,
+			{ ...old, fileVersion: '' },
+			{ ...old, fileVersion: undefined, mtime: 1100 },
+			{ ...old, fileVersion: 'current', mtime: 1300 },
+			duplicateFirst,
+			duplicateSecond,
+		])
+
+		expect(options.map(({ key }) => key)).toEqual(['current', 'version:valid', 'version:current'])
+		expect(quarantined.map(({ reason }) => reason)).toEqual([
+			'invalid',
+			'invalid',
+			'duplicate',
+			'duplicate',
+		])
+	})
+
+	it.each([
+		['current to old', current, old],
+		['old to old', middle, old],
+		['reversed selection', old, middle],
+	])('normalizes chronology for %s', (_name, firstVersion, secondVersion) => {
+		const { options } = createVersionComparisonState(current, [old, middle])
+		const byVersion = (version) => options.find(({ fileInfo }) => fileInfo === version)
+		const pair = normalizeVersionComparisonPair(byVersion(firstVersion), byVersion(secondVersion))
+		expect(pair.earlier.mtime).toBeLessThan(pair.later.mtime)
+	})
+
+	it('uses locale-independent keys to order snapshots with the same timestamp', () => {
+		const first = { ...old, fileVersion: 'z' }
+		const second = { ...old, fileVersion: 'ä' }
+		const { options } = createVersionComparisonState(current, [first, second])
+		const pair = normalizeVersionComparisonPair(options[1], options[2])
+
+		expect(pair.earlier.key).toBe('version:z')
+		expect(pair.later.key).toBe('version:ä')
+	})
+
+	it('blocks identical selection', () => {
+		const [option] = createVersionComparisonState(current, [old]).options
+		expect(() => normalizeVersionComparisonPair(option, option)).toThrow('distinct')
+	})
+})
+
+describe('snapshot loading', () => {
+	it('loads both persisted snapshots before returning either', async () => {
+		const { options } = createVersionComparisonState(current, [old])
+		const pair = normalizeVersionComparisonPair(options[0], options[1])
+		const fetchSnapshot = vi.fn(async ({ url }) => `${url} content`)
+		await expect(loadVersionComparisonSnapshots(pair, fetchSnapshot)).resolves.toEqual({
+			afterContent: '/current content',
+			beforeContent: '/old content',
+		})
+		expect(fetchSnapshot).toHaveBeenCalledTimes(2)
+	})
+
+	it.each([
+		['one failed snapshot', ['/old']],
+		['both failed snapshots', ['/old', '/current']],
+	])('mounts neither side when %s', async (_name, failures) => {
+		const { options } = createVersionComparisonState(current, [old])
+		const pair = normalizeVersionComparisonPair(options[0], options[1])
+		const fetchSnapshot = vi.fn(async ({ url }) => {
+			if (failures.includes(url)) {
+				throw new Error(url)
+			}
+			return url
+		})
+		await expect(loadVersionComparisonSnapshots(pair, fetchSnapshot))
+			.rejects.toBeInstanceOf(ComparisonSnapshotError)
+	})
+
+	it('attempts both snapshots when one loader throws synchronously', async () => {
+		const { options } = createVersionComparisonState(current, [old])
+		const pair = normalizeVersionComparisonPair(options[0], options[1])
+		const fetchSnapshot = vi.fn(({ url }) => {
+			if (url === '/old') {
+				throw new Error(url)
+			}
+			return Promise.resolve(url)
+		})
+		await expect(loadVersionComparisonSnapshots(pair, fetchSnapshot))
+			.rejects.toBeInstanceOf(ComparisonSnapshotError)
+		expect(fetchSnapshot).toHaveBeenCalledTimes(2)
+	})
+
+	it('aborts and ignores a stale request after reversed completion', async () => {
+		const requests = new ComparisonRequestManager()
+		const accepted = []
+		let resolveFirst
+		let resolveSecond
+		const firstResult = new Promise((resolve) => {
+			resolveFirst = resolve
+		})
+		const secondResult = new Promise((resolve) => {
+			resolveSecond = resolve
+		})
+		const first = requests.begin()
+		const firstCompletion = firstResult.then((value) => {
+			if (requests.isCurrent(first.generation)) {
+				accepted.push(value)
+			}
+		})
+		const second = requests.begin()
+		const secondCompletion = secondResult.then((value) => {
+			if (requests.isCurrent(second.generation)) {
+				accepted.push(value)
+			}
+		})
+		expect(first.signal.aborted).toBe(true)
+		expect(requests.isCurrent(first.generation)).toBe(false)
+		expect(requests.isCurrent(second.generation)).toBe(true)
+		resolveSecond('second')
+		await secondCompletion
+		resolveFirst('first')
+		await firstCompletion
+		expect(accepted).toEqual(['second'])
+		requests.cancel()
+		expect(second.signal.aborted).toBe(true)
+		expect(requests.isCurrent(second.generation)).toBe(false)
+	})
+})
+
+describe('comparison snapshot cache', () => {
+	it('reuses only successful immutable historical bodies', async () => {
+		const cache = new VersionComparisonSnapshotCache()
+		const historical = createVersionComparisonState(current, [old]).options[1]
+		const fetchSnapshot = vi.fn().mockResolvedValue('historical content')
+
+		await expect(cache.load(historical, fetchSnapshot)).resolves.toBe('historical content')
+		await expect(cache.load(historical, fetchSnapshot)).resolves.toBe('historical content')
+		expect(fetchSnapshot).toHaveBeenCalledOnce()
+	})
+
+	it('always reloads current content', async () => {
+		const cache = new VersionComparisonSnapshotCache()
+		const currentSnapshot = createVersionComparisonState(current, [old]).options[0]
+		const fetchSnapshot = vi.fn()
+			.mockResolvedValueOnce('first current content')
+			.mockResolvedValueOnce('second current content')
+
+		await expect(cache.load(currentSnapshot, fetchSnapshot)).resolves.toBe('first current content')
+		await expect(cache.load(currentSnapshot, fetchSnapshot)).resolves.toBe('second current content')
+		expect(fetchSnapshot).toHaveBeenCalledTimes(2)
+	})
+
+	it('does not cache failures, aborted completions, or in-flight work', async () => {
+		const cache = new VersionComparisonSnapshotCache()
+		const historical = createVersionComparisonState(current, [old]).options[1]
+		const failure = vi.fn()
+			.mockRejectedValueOnce(new Error('failed'))
+			.mockResolvedValueOnce('retried content')
+		await expect(cache.load(historical, failure)).rejects.toThrow('failed')
+		await expect(cache.load(historical, failure)).resolves.toBe('retried content')
+		expect(failure).toHaveBeenCalledTimes(2)
+
+		cache.clear()
+		const controller = new AbortController()
+		const aborted = vi.fn().mockImplementation(async () => {
+			controller.abort()
+			return 'stale content'
+		})
+		await expect(cache.load(historical, aborted, controller.signal)).resolves.toBe('stale content')
+		await cache.load(historical, aborted)
+		expect(aborted).toHaveBeenCalledTimes(2)
+
+		cache.clear()
+		let resolveFirst
+		const first = new Promise((resolve) => {
+			resolveFirst = resolve
+		})
+		const concurrent = vi.fn().mockReturnValue(first)
+		const firstLoad = cache.load(historical, concurrent)
+		const secondLoad = cache.load(historical, concurrent)
+		expect(concurrent).toHaveBeenCalledTimes(2)
+		resolveFirst('concurrent content')
+		await Promise.all([firstLoad, secondLoad])
+	})
+
+	it('clears historical bodies between page contexts', async () => {
+		const cache = new VersionComparisonSnapshotCache()
+		const historical = createVersionComparisonState(current, [old]).options[1]
+		const fetchSnapshot = vi.fn().mockResolvedValue('historical content')
+		await cache.load(historical, fetchSnapshot)
+		cache.clear()
+		await cache.load(historical, fetchSnapshot)
+		expect(fetchSnapshot).toHaveBeenCalledTimes(2)
+	})
+})

--- a/src/util/versionComparison.js
+++ b/src/util/versionComparison.js
@@ -1,0 +1,213 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export const CURRENT_VERSION_KEY = 'current'
+
+/**
+ * Select the supported renderer without using the Text API version as a gate.
+ *
+ * @param {object} options Options
+ * @param {function(object): Promise<object>|undefined} options.comparisonFactory Semantic comparison factory
+ * @param {function(object, object): void|undefined} options.viewerCompare Viewer comparison function
+ * @param {boolean} options.isMobile Whether the device is mobile
+ * @return {'semantic'|'viewer'|'unsupported'} Renderer
+ */
+export function selectVersionComparisonRenderer({ comparisonFactory, viewerCompare, isMobile }) {
+	if (typeof comparisonFactory === 'function') {
+		return 'semantic'
+	}
+	if (!isMobile && typeof viewerCompare === 'function') {
+		return 'viewer'
+	}
+	return 'unsupported'
+}
+
+/**
+ * Build local selector options and quarantine unusable historical identities.
+ *
+ * @param {object} currentVersion Persisted current version
+ * @param {object[]} versions Historical version list
+ * @return {{options: object[], quarantined: object[]}} Selector state
+ */
+export function createVersionComparisonState(currentVersion, versions) {
+	const current = {
+		fileInfo: currentVersion,
+		fileVersion: null,
+		key: CURRENT_VERSION_KEY,
+		kind: 'current',
+		label: currentVersion.label,
+		mtime: currentVersion.mtime,
+		url: currentVersion.source ?? currentVersion.url,
+	}
+	const candidates = versions.filter((version) => version.mtime !== currentVersion.mtime)
+	const identityCounts = candidates.reduce((counts, version) => {
+		if (isValidHistoricalIdentity(version.fileVersion)) {
+			counts.set(version.fileVersion, (counts.get(version.fileVersion) ?? 0) + 1)
+		}
+		return counts
+	}, new Map())
+	const duplicateIdentities = new Set([...identityCounts]
+		.filter(([, count]) => count > 1)
+		.map(([fileVersion]) => fileVersion))
+	const quarantined = []
+	const historical = candidates
+		.flatMap((version) => {
+			const fileVersion = version.fileVersion
+			const reason = !isValidHistoricalIdentity(fileVersion)
+				? 'invalid'
+				: duplicateIdentities.has(fileVersion)
+					? 'duplicate'
+					: null
+			if (reason) {
+				quarantined.push({ fileVersion, reason })
+				return []
+			}
+			return [{
+				fileInfo: version,
+				fileVersion,
+				key: `version:${fileVersion}`,
+				kind: 'historical',
+				label: version.label,
+				mtime: version.mtime,
+				url: version.source ?? version.url,
+			}]
+		})
+		.toSorted(compareSnapshots)
+
+	return {
+		options: [current, ...historical.reverse()],
+		quarantined,
+	}
+}
+
+/** @param {unknown} fileVersion DAV version basename */
+function isValidHistoricalIdentity(fileVersion) {
+	return typeof fileVersion === 'string' && fileVersion.length > 0
+}
+
+/**
+ * Return a pair in chronological Earlier/After order.
+ *
+ * @param {object} first First selection
+ * @param {object} second Second selection
+ * @return {{earlier: object, later: object}} Normalized pair
+ */
+export function normalizeVersionComparisonPair(first, second) {
+	if (!first || !second || first.key === second.key) {
+		throw new TypeError('Two distinct versions are required')
+	}
+	return compareSnapshots(first, second) <= 0
+		? { earlier: first, later: second }
+		: { earlier: second, later: first }
+}
+
+/**
+ * Compare snapshot chronology.
+ *
+ * @param {object} first First snapshot
+ * @param {object} second Second snapshot
+ * @return {number} Sort result
+ */
+function compareSnapshots(first, second) {
+	if (first.mtime !== second.mtime) {
+		return first.mtime - second.mtime
+	}
+	if (first.kind !== second.kind) {
+		return first.kind === 'current' ? 1 : -1
+	}
+	return first.key < second.key ? -1 : first.key > second.key ? 1 : 0
+}
+
+export class ComparisonSnapshotError extends Error {
+	constructor(before, after) {
+		super('One or more comparison snapshots could not be loaded')
+		this.name = 'ComparisonSnapshotError'
+		this.before = before
+		this.after = after
+	}
+
+	get reasons() {
+		return [this.before, this.after]
+			.filter(({ status }) => status === 'rejected')
+			.map(({ reason }) => reason)
+	}
+}
+
+/**
+ * Load both snapshots and retain both rejection reasons.
+ *
+ * @param {{earlier: object, later: object}} pair Snapshot pair
+ * @param {function(object, AbortSignal=): Promise<string>} fetchSnapshot Snapshot loader
+ * @param {AbortSignal|undefined} signal Cancellation signal
+ * @return {Promise<{beforeContent: string, afterContent: string}>} Both contents
+ */
+export async function loadVersionComparisonSnapshots(pair, fetchSnapshot, signal) {
+	const [before, after] = await Promise.allSettled([
+		Promise.resolve().then(() => fetchSnapshot(pair.earlier, signal)),
+		Promise.resolve().then(() => fetchSnapshot(pair.later, signal)),
+	])
+	if (before.status === 'rejected' || after.status === 'rejected') {
+		throw new ComparisonSnapshotError(before, after)
+	}
+	return {
+		afterContent: after.value,
+		beforeContent: before.value,
+	}
+}
+
+/** Cache only successfully loaded immutable historical snapshot bodies. */
+export class VersionComparisonSnapshotCache {
+	#contents = new Map()
+
+	/**
+	 * Load one snapshot without caching current, failed, aborted, or in-flight work.
+	 *
+	 * @param {object} snapshot Snapshot metadata
+	 * @param {function(object, AbortSignal=): Promise<string>} fetchSnapshot Snapshot loader
+	 * @param {AbortSignal|undefined} signal Cancellation signal
+	 * @return {Promise<string>} Snapshot body
+	 */
+	async load(snapshot, fetchSnapshot, signal) {
+		if (snapshot.kind === 'historical' && this.#contents.has(snapshot.fileVersion)) {
+			return this.#contents.get(snapshot.fileVersion)
+		}
+
+		const content = await fetchSnapshot(snapshot, signal)
+		if (snapshot.kind === 'historical' && !signal?.aborted) {
+			this.#contents.set(snapshot.fileVersion, content)
+		}
+		return content
+	}
+
+	clear() {
+		this.#contents.clear()
+	}
+}
+
+/** Abort superseded work and identify stale async completions. */
+export class ComparisonRequestManager {
+	#controller = null
+	#generation = 0
+
+	begin() {
+		this.#controller?.abort()
+		this.#controller = new AbortController()
+		const generation = ++this.#generation
+		return {
+			generation,
+			signal: this.#controller.signal,
+		}
+	}
+
+	isCurrent(generation) {
+		return generation === this.#generation
+	}
+
+	cancel() {
+		this.#controller?.abort()
+		this.#controller = null
+		this.#generation++
+	}
+}


### PR DESCRIPTION
**In one sentence:** Collectives now opens the Text semantic comparison when comparing page versions, with the old Viewer path kept as fallback.

## What and why

Comparing two versions of a page today opens both documents in Viewer, side by side, with no highlighting. That is two documents in one window, not a comparison. This PR wires Collectives to the semantic comparison Text now provides — and keeps the old path working where it must.

## What's in this PR

- A version-pair model and a dialog that loads **both snapshots before mounting either side** — a half-mounted comparison looks like a comparison and is not one
- Capability detection (a function check, not a version pin) with the existing Viewer fallback unchanged
- Explicit refusal on mobile, where the fallback could only show one document
- An edit-mode lifecycle fix in its own commit (see below)

![The existing stock Viewer fallback: two documents, no highlighting](https://raw.githubusercontent.com/hweihwang/collectives/demo-assets/13-stock-viewer-fallback-desktop.png)
![The new comparison dialog: 25 grouped semantic changes with before/after previews](https://raw.githubusercontent.com/hweihwang/collectives/demo-assets/01-hero-changes-wide.png)
*The whole argument for this PR: the same pair, before and after. The fallback still works — it's just no longer the comparison experience.*

![Mobile: explicit unsupported message instead of one document posed as a comparison](https://raw.githubusercontent.com/hweihwang/collectives/demo-assets/12-mobile-fallback-explicit-unsupported.png)
*On mobile the dialog refuses rather than degrade. The dialog keeps full height, so most of the image is empty — that's real modal behaviour.*

## Design notes

- **The compatibility fix.** Upstream `b7042764` made the `isTextEdit` watcher async and added member loading inside it; combined with this branch's lazy editor creation, a member request still in flight could create an editor after edit mode ended — and a hidden editor can write back stale content over a version restore. `ensureEditor()` now reuses one in-flight setup promise, runs setup in parallel with member loading, and destroys the editor if edit mode ended during setup. A browser test holds both async paths, leaves edit mode, then restores a version and confirms the restored content survives.
- Version freshness moved to the versions tab, so comparing right after a save can't request a revision the server never had.

## Stack

Requires the Text stack: nextcloud/text#9043 → #9044 → #9045 → #9046 (all four merge and release first). Followed by #2698. Review focus: `src/components/Page/TextEditor.vue`, `src/composables/useEditor.ts`.

## Verification

`lint` (tsc + eslint) passes; unit suite 26/26. Recorded live end-to-end runs at this tip: NC35 28/28 and NC34 28/28 (stock Viewer `8b68b1bd`). A fresh pass with current Viewer `master` (`33dc36ba`) is due before this leaves draft — the stack uses the stock `compare()` API, so no Viewer change is involved.

## AI assistance

Commits carry `Assisted-by: Codex:gpt-5.6-sol`; an independent review pass was run with Claude Opus 5, who flagged the stale stock-Viewer commit in the earlier E2E record. Description drafted with Hermes (deepseek-v4-pro) from my notes, then reviewed by me.

## Related

- https://github.com/nextcloud/collectives/issues/599

No closing keyword — the stack completes this issue at the final unit.
