### PR TITLE
Integrate semantic page comparison

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'cypress'
 import cypressSplit from 'cypress-split'
 import vitePreprocessor from 'cypress-vite'
@@ -12,7 +13,7 @@ export default defineConfig({
 	viewportHeight: 900,
 	e2e: {
 		setupNodeEvents(on, config) {
-			on('file:preprocessor', vitePreprocessor({ configFile: false }))
+			on('file:preprocessor', vitePreprocessor({ configFile: false, plugins: [vue()] }))
 			cypressSplit(on, config)
 			return config
 		},

--- a/cypress/e2e/page-versions-components.cy.js
+++ b/cypress/e2e/page-versions-components.cy.js
@@ -1,0 +1,273 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createPinia, setActivePinia } from 'pinia'
+import { createApp, h, nextTick, ref } from 'vue'
+import { createRouter, createWebHistory } from 'vue-router'
+import SidebarTabVersions from '../../src/components/PageSidebar/SidebarTabVersions.vue'
+import VersionComparisonDialog from '../../src/components/PageSidebar/VersionComparisonDialog.vue'
+import { useCollectivesStore } from '../../src/stores/collectives.js'
+import { usePagesStore } from '../../src/stores/pages.js'
+import { useRootStore } from '../../src/stores/root.js'
+import { useVersionsStore } from '../../src/stores/versions.js'
+import { VERSION_COMPARISON_LIMITS } from '../../src/util/versionComparison.js'
+
+async function waitFor(condition, message = 'Expected component state was not reached') {
+	for (let attempt = 0; attempt < 100; attempt++) {
+		if (condition()) {
+			return
+		}
+		await new Promise((resolve) => setTimeout(resolve))
+	}
+	throw new Error(typeof message === 'function' ? message() : message)
+}
+
+function deferred() {
+	let resolve
+	const promise = new Promise((resolvePromise) => {
+		resolve = resolvePromise
+	})
+	return { promise, resolve }
+}
+
+async function mountSidebarTabVersions(getVersions) {
+	document.head.setAttribute('data-user', 'component-user')
+	document.head.setAttribute('data-user-displayname', 'Component User')
+	window.history.replaceState({}, '', '/Atlas/Page')
+	const router = createRouter({
+		history: createWebHistory(),
+		routes: [{ path: '/:pathMatch(.*)*', component: { render: () => null } }],
+	})
+	const pinia = createPinia()
+	setActivePinia(pinia)
+	const rootStore = useRootStore()
+	const collectivesStore = useCollectivesStore()
+	const pagesStore = usePagesStore()
+	const versionsStore = useVersionsStore()
+	rootStore.$patch({ collectiveId: 1, pageId: 7, showingSidebar: true })
+	collectivesStore.collectivesState = [{ id: 1, name: 'Atlas', canEdit: true, canShare: true, isPageShare: false }]
+	pagesStore.allPages = {
+		1: [{ id: 7, parentId: 0, title: 'Page', fileName: 'Readme.md', timestamp: 1, size: 10 }],
+	}
+	Object.defineProperty(versionsStore, 'currentVersion', {
+		configurable: true,
+		value: { fileId: 7, mtime: 1000, size: 10, source: '/current', url: '/current' },
+	})
+	versionsStore.getVersions = getVersions
+	const pageId = ref(7)
+	const component = ref()
+	const element = document.createElement('div')
+	document.body.append(element)
+	const app = createApp({
+		render: () => h(SidebarTabVersions, {
+			ref: component,
+			pageId: pageId.value,
+			pageTimestamp: 1,
+		}),
+	})
+	app.use(pinia)
+	app.use(router)
+	app.mount(element)
+	await router.isReady()
+	await nextTick()
+	return { app, component, element, pageId, rootStore }
+}
+
+async function mountVersionComparisonDialog(currentVersion, versions) {
+	const pinia = createPinia()
+	setActivePinia(pinia)
+	const versionsStore = useVersionsStore(pinia)
+	window.history.replaceState({}, '', '/Atlas/Page')
+	const router = createRouter({
+		history: createWebHistory(),
+		routes: [{ path: '/:pathMatch(.*)*', component: { render: () => null } }],
+	})
+	const component = ref()
+	const element = document.createElement('div')
+	document.body.append(element)
+	const app = createApp({
+		render: () => h(VersionComparisonDialog, {
+			ref: component,
+			currentVersion,
+			versions,
+			filePath: '/Atlas/Page.md',
+		}),
+	})
+	app.use(pinia)
+	app.use(router)
+	app.mount(element)
+	await router.isReady()
+	await nextTick()
+	Object.defineProperty(document.documentElement, 'clientWidth', { configurable: true, value: Cypress.config('viewportWidth') })
+	window.dispatchEvent(new Event('resize'))
+	return { app, component, element, router, versionsStore }
+}
+
+function comparisonFixture(size = 10) {
+	const currentVersion = { fileId: 7, mtime: 3000, size, source: '/current?file=7', url: '/current?file=7' }
+	const historical = { fileVersion: '1', label: 'Old', mtime: 1000, size, source: '/historical?file=7', url: '/historical?file=7' }
+	const currentSnapshot = { ...currentVersion, fileVersion: '3', isCurrentSnapshot: true }
+	return { currentVersion, historical, versions: [historical, currentSnapshot] }
+}
+
+describe('Mounted page version components', () => {
+	it('keeps the active page loading while a stale page request completes', () => {
+		cy.then(async () => {
+			const consoleError = Cypress.sinon.spy(console, 'error')
+			const first = deferred()
+			const second = deferred()
+			const getVersions = Cypress.sinon.stub()
+			getVersions.withArgs(7).returns(first.promise)
+			getVersions.withArgs(8).returns(second.promise)
+			const mounted = await mountSidebarTabVersions(getVersions)
+
+			mounted.pageId.value = 8
+			await waitFor(() => getVersions.callCount === 2)
+			first.resolve([])
+			await first.promise
+			await nextTick()
+			expect(mounted.component.value.loadPending).to.equal(true)
+			expect(mounted.rootStore.loading('versions')).to.equal(true)
+
+			second.resolve([])
+			await second.promise
+			await waitFor(() => mounted.rootStore.loading('versions') === false)
+			expect(mounted.component.value.loadPending).to.equal(false)
+			expect(mounted.rootStore.loading('versions')).to.equal(false)
+			expect(mounted.component.value.error).to.equal('')
+			expect(consoleError).not.to.have.been.calledWithMatch('Failed to get page versions')
+
+			mounted.app.unmount()
+			mounted.element.remove()
+			consoleError.restore()
+		})
+	})
+
+	it('reports an expired selection when current preparation removes its historical version', () => {
+		cy.then(async () => {
+			const fixture = comparisonFixture()
+			window.OCA ??= {}
+			const createComparison = Cypress.sinon.stub().resolves({ destroy: Cypress.sinon.stub() })
+			window.OCA.Text = { createMarkdownContentComparison: createComparison }
+			const fetchSnapshot = Cypress.sinon.stub(window, 'fetch')
+			const mounted = await mountVersionComparisonDialog(fixture.currentVersion, fixture.versions)
+			mounted.versionsStore.registerCurrentSnapshotPreparer(Cypress.sinon.stub().resolves([fixture.versions[1]]))
+
+			try {
+				mounted.component.value.openSelector()
+				await waitFor(() => [...document.querySelectorAll('.modal-wrapper button')]
+					.some(({ textContent }) => textContent.trim() === 'Compare'))
+				const compare = [...document.querySelectorAll('.modal-wrapper button')]
+					.find(({ textContent }) => textContent.trim() === 'Compare')
+				compare.click()
+
+				await waitFor(() => document.querySelector('.version-comparison-dialog [role="alert"]'))
+				expect(document.querySelector('.version-comparison-dialog [role="alert"]').textContent)
+					.to.contain('One of the selected versions has expired or was removed.')
+				expect(fetchSnapshot).not.to.have.been.called
+				expect(createComparison).not.to.have.been.called
+				expect(new URL(window.location.href).searchParams.has('compareFrom')).to.equal(false)
+				expect(new URL(window.location.href).searchParams.has('compareTo')).to.equal(false)
+			} finally {
+				mounted.app.unmount()
+				mounted.element.remove()
+				fetchSnapshot.restore()
+			}
+		})
+	})
+
+	it('publishes fresh bounded current previews and retries through the mounted dialog', () => {
+		cy.then(async () => {
+			const fixture = comparisonFixture(VERSION_COMPARISON_LIMITS.maximumSnapshotBytes + 1)
+			window.OCA ??= {}
+			window.OCA.Text = { createMarkdownContentComparison: Cypress.sinon.stub() }
+			let currentLoads = 0
+			const fetchSnapshot = Cypress.sinon.stub(window, 'fetch').callsFake(async (url) => {
+				const content = String(url).includes('/current')
+					? `fresh-current-${++currentLoads}`
+					: 'historical-preview'
+				return new Response(content)
+			})
+			const mounted = await mountVersionComparisonDialog(fixture.currentVersion, fixture.versions)
+			const prepare = Cypress.sinon.stub().resolves(fixture.versions)
+			mounted.versionsStore.registerCurrentSnapshotPreparer(prepare)
+
+			mounted.component.value.openFor(fixture.historical)
+			await waitFor(
+				() => document.querySelectorAll('.version-comparison-dialog__preview').length === 2,
+				() => `Expected two previews; prepare calls: ${prepare.callCount}; fetch calls: ${fetchSnapshot.callCount}; dialog: ${document.querySelector('.version-comparison-dialog')?.textContent}`,
+			)
+			expect(document.querySelector('.version-comparison-dialog').textContent).to.contain('fresh-current-1')
+			const urls = fetchSnapshot.args.map(([url]) => String(url))
+			expect(urls).to.include('/historical?file=7')
+			const currentUrl = new URL(urls.find((url) => url.includes('/current')))
+			expect(currentUrl.searchParams.get('file')).to.equal('7')
+			expect(currentUrl.searchParams.get('timestamp')).to.match(/^\d{13}$/)
+			expect(fetchSnapshot.args.every(([, options]) => options.headers.Range === `bytes=0-${VERSION_COMPARISON_LIMITS.maximumPreviewBytes - 1}`)).to.equal(true)
+
+			const retry = [...document.querySelectorAll('button')]
+				.find((button) => button.textContent.includes('Retry'))
+			expect(retry).to.not.equal(undefined)
+			retry.click()
+			await waitFor(
+				() => document.querySelector('.version-comparison-dialog').textContent.includes('fresh-current-2'),
+				`Expected retry preview; fetch calls: ${fetchSnapshot.callCount}`,
+			)
+			expect(prepare.callCount).to.equal(2)
+
+			mounted.app.unmount()
+			mounted.element.remove()
+			fetchSnapshot.restore()
+		})
+	})
+
+	it('uses the Text renderer size selected at compare time', () => {
+		cy.then(async () => {
+			const fixture = comparisonFixture()
+			window.OCA ??= {}
+			window.OCA.Text = {}
+			const fetchSnapshot = Cypress.sinon.stub(window, 'fetch').callsFake(async () => {
+				let sent = false
+				return {
+					body: { getReader: () => ({
+						cancel: async () => {},
+						read: async () => {
+							if (sent) {
+								return { done: true }
+							}
+							sent = true
+							return { done: false, value: new TextEncoder().encode('snapshot') }
+						},
+					}) },
+					headers: new Headers(),
+					ok: true,
+					status: 200,
+				}
+			})
+			const mounted = await mountVersionComparisonDialog(fixture.currentVersion, fixture.versions)
+			mounted.versionsStore.registerCurrentSnapshotPreparer(Cypress.sinon.stub().resolves(fixture.versions))
+			try {
+				mounted.component.value.openSelector()
+				await waitFor(() => [...document.querySelectorAll('.modal-wrapper button')]
+					.some(({ textContent }) => textContent.trim() === 'Compare'))
+				const createComparison = Cypress.sinon.stub().resolves({ destroy: Cypress.sinon.stub() })
+				window.OCA.Text.createMarkdownContentComparison = createComparison
+				const compare = [...document.querySelectorAll('.modal-wrapper button')]
+					.find(({ textContent }) => textContent.trim() === 'Compare')
+				compare.click()
+
+				await waitFor(
+					() => createComparison.calledOnce,
+					() => `Expected factory call; fetch calls: ${fetchSnapshot.callCount}; dialog: ${document.querySelector('.modal-wrapper')?.textContent}`,
+				)
+				expect(document.querySelector('.modal-wrapper--full')).not.to.equal(null)
+			} finally {
+				mounted.app.unmount()
+				mounted.element.remove()
+				fetchSnapshot.restore()
+			}
+		})
+	})
+})

--- a/cypress/e2e/page-versions.spec.js
+++ b/cypress/e2e/page-versions.spec.js
@@ -87,7 +87,7 @@ describe('Page versions', function() {
 			.find('.list-item-content__actions')
 			.click()
 
-		cy.clickMenuButton('Compare to current version')
+		cy.clickMenuButton('Compare with current version')
 
 		cy.get('#viewer .text-editor')
 			.should('contain', 'v1')

--- a/src/components/Page/TextEditor.vue
+++ b/src/components/Page/TextEditor.vue
@@ -77,6 +77,7 @@ export default {
 	data() {
 		return {
 			textEditWatcher: null,
+			unregisterCurrentSnapshotPreparer: null,
 		}
 	},
 
@@ -115,6 +116,7 @@ export default {
 	},
 
 	async mounted() {
+		this.unregisterCurrentSnapshotPreparer = this.registerCurrentSnapshotPreparer(() => this.prepareCurrentEditorSnapshot())
 		const readerPromise = this.setupReader(this.currentPage)
 		const editorPromise = this.setupEditor()
 		const pageContentPromise = this.getPageContent()
@@ -139,6 +141,7 @@ export default {
 	},
 
 	beforeUnmount() {
+		this.unregisterCurrentSnapshotPreparer?.()
 		unsubscribe('collectives:attachment:removeReferences', this.removeAttachmentReferences)
 		unsubscribe('collectives:attachment:replaceFilename', this.replaceAttachmentFilename)
 		unsubscribe('collectives:attachment:insert', this.insertAttachment)
@@ -149,7 +152,7 @@ export default {
 		t,
 
 		...mapActions(useRootStore, ['load', 'done']),
-		...mapActions(useVersionsStore, ['getVersions']),
+		...mapActions(useVersionsStore, ['getVersions', 'registerCurrentSnapshotPreparer']),
 		...mapActions(usePagesStore, ['setTextEdit', 'setTextPreview', 'touchPage']),
 		...mapActions(useCirclesStore, ['getCircleMembers']),
 
@@ -200,6 +203,13 @@ export default {
 			return this.editor.save()
 		},
 
+		async prepareCurrentEditorSnapshot() {
+			if (this.isTextEdit && this.editor && await this.saveEditor() !== true) {
+				throw new Error('Could not save the current page before comparison.')
+			}
+			return this.getVersions(this.currentPage.id)
+		},
+
 		async stopEdit() {
 			// switch back to edit if there's no content
 			if (!this.pageContent?.trim()) {
@@ -222,11 +232,6 @@ export default {
 
 				// Touch page to update last changed timestamp
 				this.touchPage()
-
-				// Update loaded versions
-				if (!this.isPublic && this.hasVersionsLoaded) {
-					this.getVersions(this.currentPage.id)
-				}
 			}
 		},
 

--- a/src/components/PageSidebar/SidebarTabVersions.vue
+++ b/src/components/PageSidebar/SidebarTabVersions.vue
@@ -24,6 +24,16 @@
 
 		<!-- versions list -->
 		<div v-else-if="!loading('versions') && sortedVersions.length">
+			<NcButton
+				v-if="hasComparableHistoricalVersions"
+				wide
+				class="versions-container__compare"
+				@click="onOpenComparisonSelector">
+				<template #icon>
+					<FileCompareIcon :size="22" />
+				</template>
+				{{ t('collectives', 'Compare versions…') }}
+			</NcButton>
 			<ul :aria-label="t('collectives', 'Page versions')" class="version-list">
 				<VersionEntry
 					v-for="version in sortedVersions"
@@ -36,7 +46,7 @@
 					:canEdit="currentCollectiveCanEdit"
 					@click="onOpenVersion(version)"
 					@startLabelUpdate="onStartLabelUpdate(version)"
-					@compare="onCompareVersion(version)"
+					@compare="onCompareVersion(version, $event)"
 					@restore="onRestoreVersion(version)"
 					@delete="onDeleteVersion(version)" />
 			</ul>
@@ -58,23 +68,36 @@
 			v-model:open="showVersionLabelForm"
 			:versionLabel="editedVersion.label"
 			@labelUpdate="onLabelUpdate" />
+
+		<VersionComparisonDialog
+			ref="comparisonDialog"
+			:currentVersion
+			:versions
+			:filePath="`/${currentPageFilePath}`"
+			@retryRoute="onRetryComparisonRoute" />
 	</div>
 </template>
 
 <script>
 import { t } from '@nextcloud/l10n'
 import { mapActions, mapState } from 'pinia'
+import NcButton from '@nextcloud/vue/components/NcButton'
 import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import AlertOctagonIcon from 'vue-material-design-icons/AlertOctagonOutline.vue'
 import BackupRestoreIcon from 'vue-material-design-icons/BackupRestore.vue'
+import FileCompareIcon from 'vue-material-design-icons/FileCompare.vue'
 import OfflineContent from './OfflineContent.vue'
+import VersionComparisonDialog from './VersionComparisonDialog.vue'
 import VersionEntry from './VersionEntry.vue'
 import VersionLabelDialog from './VersionLabelDialog.vue'
 import { useNetworkState } from '../../composables/useNetworkState.ts'
 import { useCollectivesStore } from '../../stores/collectives.js'
+import { usePagesStore } from '../../stores/pages.js'
 import { useRootStore } from '../../stores/root.js'
 import { useVersionsStore } from '../../stores/versions.js'
+import { createVersionComparisonState } from '../../util/versionComparison.js'
+import { parseVersionComparisonRoute } from '../../util/versionComparisonRoute.js'
 
 export default {
 	name: 'SidebarTabVersions',
@@ -84,7 +107,10 @@ export default {
 		NcEmptyContent,
 		NcLoadingIcon,
 		BackupRestoreIcon,
+		FileCompareIcon,
+		NcButton,
 		OfflineContent,
+		VersionComparisonDialog,
 		VersionEntry,
 		VersionLabelDialog,
 	},
@@ -109,6 +135,7 @@ export default {
 	data() {
 		return {
 			loadPending: true,
+			loadGeneration: 0,
 			error: '',
 			showVersionLabelForm: false,
 			editedVersion: null,
@@ -117,9 +144,11 @@ export default {
 
 	computed: {
 		...mapState(useRootStore, ['loading']),
+		...mapState(usePagesStore, ['currentPageFilePath']),
 		...mapState(useCollectivesStore, ['currentCollectiveCanEdit']),
 		...mapState(useVersionsStore, [
 			'currentVersion',
+			'loadedPageId',
 			'selectedVersion',
 			'versions',
 		]),
@@ -146,6 +175,11 @@ export default {
 				.reduce((a, b) => Math.min(a, b))
 		},
 
+		hasComparableHistoricalVersions() {
+			return createVersionComparisonState(this.currentVersion, this.versions)
+				.options.some(({ kind }) => kind === 'historical')
+		},
+
 		isCurrent() {
 			return (mtime) => mtime === this.pageMtime
 		},
@@ -161,8 +195,17 @@ export default {
 
 	watch: {
 		pageId: function() {
+			this.$refs.comparisonDialog?.closeDialog()
 			this.getPageVersions()
 		},
+
+		pageTimestamp: function(value, previous) {
+			if (value && value !== previous) {
+				this.getPageVersions()
+			}
+		},
+
+		'$route.fullPath': 'syncComparisonRoute',
 
 		networkOnline: function(val) {
 			if (val && this.loadPending) {
@@ -191,20 +234,34 @@ export default {
 		 * Get versions of a page
 		 */
 		async getPageVersions() {
+			const pageId = this.pageId
+			const generation = ++this.loadGeneration
 			this.loadPending = true
 			if (!this.networkOnline) {
+				this.done('versions')
 				return
 			}
 
 			this.load('versions')
+			this.error = ''
 			try {
-				await this.getVersions(this.pageId)
+				await this.getVersions(pageId)
+				if (generation !== this.loadGeneration) {
+					return
+				}
 				this.loadPending = false
+				await this.$nextTick()
+				this.syncComparisonRoute()
 			} catch (e) {
+				if (generation !== this.loadGeneration) {
+					return
+				}
 				this.error = t('collectives', 'Could not get page versions')
 				console.error('Failed to get page versions', e)
 			} finally {
-				this.done('versions')
+				if (generation === this.loadGeneration) {
+					this.done('versions')
+				}
 			}
 		},
 
@@ -234,8 +291,28 @@ export default {
 			}
 		},
 
-		onCompareVersion(version) {
-			window.OCA.Viewer.compare(this.currentVersion, this.versions.find((v) => v.source === version.source))
+		onCompareVersion(version, event) {
+			this.$refs.comparisonDialog.openFor(version, event.currentTarget)
+		},
+
+		onOpenComparisonSelector(event) {
+			this.$refs.comparisonDialog.openSelector(event.currentTarget)
+		},
+
+		async onRetryComparisonRoute() {
+			await this.getPageVersions()
+		},
+
+		syncComparisonRoute() {
+			const comparisonRoute = parseVersionComparisonRoute(this.$route.query)
+			if (comparisonRoute.kind === 'absent') {
+				this.$refs.comparisonDialog?.closeFromRoute()
+				return
+			}
+			if (comparisonRoute.kind !== 'valid' || this.loadPending || this.loadedPageId !== this.pageId) {
+				return
+			}
+			this.$nextTick(() => this.$refs.comparisonDialog?.openRoutedPair(comparisonRoute))
 		},
 
 		async onRestoreVersion(version) {
@@ -248,3 +325,9 @@ export default {
 	},
 }
 </script>
+
+<style scoped lang="scss">
+.versions-container__compare {
+	margin-block-end: 8px;
+}
+</style>

--- a/src/components/PageSidebar/VersionComparisonDialog.vue
+++ b/src/components/PageSidebar/VersionComparisonDialog.vue
@@ -1,0 +1,620 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcDialog
+		:open="open"
+		isForm
+		:size="dialogSize"
+		contentClasses="version-comparison-dialog"
+		:name="t('collectives', 'Compare versions')"
+		@submit="compareSelected"
+		@update:open="onOpenUpdate">
+		<div class="version-comparison-dialog__selectors">
+			<label
+				v-for="side in ['earlier', 'later']"
+				:key="side"
+				class="field"
+				:class="{ 'field--later': side === 'later' }">
+				<span class="field-label">
+					<span class="indicator" aria-hidden="true" />
+					{{ side === 'earlier' ? t('collectives', 'Earlier') : t('collectives', 'Later') }}
+				</span>
+				<select
+					v-model="selection[side]"
+					:disabled="status === 'loading'"
+					@change="onSelectionChange">
+					<option
+						v-for="option in displayed"
+						:key="option.key"
+						:value="option.key">
+						{{ optionLabel(option) }}
+					</option>
+				</select>
+			</label>
+			<NcButton
+				v-if="canCopy"
+				class="copy"
+				variant="tertiary"
+				type="button"
+				@click="copyComparisonLink">
+				<template #icon>
+					<ContentCopyIcon :size="20" />
+				</template>
+				{{ t('collectives', 'Copy comparison link') }}
+			</NcButton>
+		</div>
+
+		<NcNoteCard
+			v-if="optionState.quarantinedCount"
+			class="message"
+			type="warning"
+			role="status"
+			:text="t('collectives', 'Some page versions could not be used for comparison.')" />
+		<NcNoteCard
+			v-if="selection.earlier && selection.earlier === selection.later"
+			class="message"
+			type="info"
+			role="status"
+			:text="t('collectives', 'Select two different versions.')" />
+		<NcNoteCard
+			v-if="message"
+			class="message"
+			:type="status === 'unsupported' ? 'info' : 'error'"
+			:role="status === 'unsupported' ? 'status' : 'alert'"
+			:text="message" />
+		<section
+			v-if="previews.length"
+			class="previews"
+			:aria-label="t('collectives', 'Bounded version previews')">
+			<article v-for="snapshot in previews" :key="snapshot.key" class="version-comparison-dialog__preview">
+				<strong>{{ optionLabel(snapshot) }}</strong>
+				<p v-if="snapshot.previewError" role="status">
+					{{ t('collectives', 'Could not load a preview for this version.') }}
+				</p>
+				<pre v-else>{{ snapshot.preview }}</pre>
+				<div class="preview-actions">
+					<a :href="snapshot.url" target="_blank" rel="noopener noreferrer">
+						{{ t('collectives', 'Open version') }}
+					</a>
+					<a :href="snapshot.url" download>
+						{{ t('collectives', 'Download version') }}
+					</a>
+				</div>
+			</article>
+		</section>
+		<div v-if="status === 'loading'" class="version-comparison-dialog__loading" role="status">
+			<NcLoadingIcon :size="32" />
+			<span>{{ t('collectives', 'Loading versions…') }}</span>
+		</div>
+		<div
+			ref="host"
+			class="version-comparison-dialog__comparison"
+			:aria-busy="status === 'loading'" />
+
+		<template v-if="status !== 'ready'" #actions>
+			<NcButton
+				v-if="status === 'error'"
+				variant="primary"
+				type="button"
+				@click="retryComparison">
+				{{ t('collectives', 'Retry') }}
+			</NcButton>
+			<NcButton
+				v-if="status === 'idle' || status === 'loading'"
+				variant="primary"
+				type="submit"
+				:disabled="!canCompare || status === 'loading'">
+				{{ t('collectives', 'Compare') }}
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script setup>
+/* eslint-disable jsdoc/require-jsdoc */
+import { showError, showSuccess } from '@nextcloud/dialogs'
+import { t } from '@nextcloud/l10n'
+import moment from '@nextcloud/moment'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
+import { computed, nextTick, onBeforeUnmount, reactive, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcDialog from '@nextcloud/vue/components/NcDialog'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
+import { useVersionsStore } from '../../stores/versions.js'
+import {
+	classifyComparisonSnapshotError as classifyError,
+	createComparisonRequestManager as createRequests,
+	createVersionComparisonState as createState,
+	CURRENT_VERSION_KEY as CURRENT,
+	isVersionComparisonCancellation as isCancellation,
+	ComparisonSnapshotLimitError as LimitError,
+	loadBoundedSnapshotBody as loadBody,
+	loadBoundedSnapshotPreview as loadPreview,
+	loadVersionComparisonSnapshots as loadSnapshots,
+	normalizeVersionComparisonPair as normalizePair,
+	CurrentSnapshotPreparationError as PreparationError,
+	prepareVersionComparisonPair as preparePair,
+	selectVersionComparisonRenderer as selectRenderer,
+	VersionComparisonSnapshotCache as SnapshotCache,
+	ComparisonSnapshotError as SnapshotError,
+} from '../../util/versionComparison.js'
+import {
+	COMPARE_FROM_QUERY as FROM,
+	COMPARISON_HISTORY_STATE as HISTORY,
+	parseVersionComparisonRoute as parseRoute,
+	resolveVersionComparisonRoute as resolveRoute,
+	COMPARE_TO_QUERY as TO,
+	withoutVersionComparisonRoute as withoutRoute,
+	withVersionComparisonRoute as withRoute,
+} from '../../util/versionComparisonRoute.js'
+
+const props = defineProps({
+	currentVersion: { type: Object, required: true },
+	versions: { type: Array, required: true },
+	filePath: { type: String, required: true },
+})
+const emit = defineEmits(['retryRoute'])
+const route = useRoute()
+const router = useRouter()
+const versionsStore = useVersionsStore()
+const isMobile = useIsMobile()
+const cache = new SnapshotCache()
+const requests = createRequests()
+const host = ref(null)
+const selection = reactive({ earlier: '', later: '' })
+const previews = ref([])
+const message = ref('')
+const missing = ref([])
+const open = ref(false)
+const routeTask = ref(null)
+const status = ref('idle')
+const shown = ref('')
+let comparison = null
+let opener = null
+
+const optionState = computed(() => createState(props.currentVersion, props.versions))
+const options = computed(() => optionState.value.options)
+const displayed = computed(() => [...options.value, ...missing.value])
+const earlier = computed(() => displayed.value.find(({ key }) => key === selection.earlier))
+const later = computed(() => displayed.value.find(({ key }) => key === selection.later))
+const canCompare = computed(() => [earlier.value, later.value].every((option) => ['current', 'historical'].includes(option?.kind)) && selection.earlier !== selection.later)
+const canCopy = computed(() => {
+	const parsed = parseRoute(route.query)
+	return status.value === 'ready' && shown.value && parsed.kind === 'valid' && pairKey(parsed.from, parsed.to) === shown.value
+})
+const dialogSize = ref('large')
+
+onBeforeUnmount(() => cleanup())
+
+function openSelector(source) {
+	const historical = options.value.find(({ kind }) => kind === 'historical')
+	if (historical) {
+		openManual(historical, source)
+	}
+}
+function openFor(version, source) {
+	const selected = options.value.find(({ fileVersion }) => fileVersion === String(version.fileVersion))
+	if (!selected) {
+		showError(t('collectives', 'This page version cannot be used for comparison.'))
+		return
+	}
+	openManual(selected, source)
+	nextTick(compareSelected)
+}
+function openManual(selected, source = document.activeElement) {
+	opener = source
+	selection.earlier = selected.key
+	selection.later = CURRENT
+	resetResult()
+	open.value = true
+}
+async function openRoutedPair(pair) {
+	const signature = pairKey(pair.from, pair.to)
+	const active = status.value === 'ready' ? shown.value : routeTask.value && pairKey(routeTask.value.from, routeTask.value.to)
+	if (open.value && ['idle', 'loading', 'ready'].includes(status.value) && signature === active) {
+		return
+	}
+	resetResult()
+	open.value = true
+	routeTask.value = { ...pair }
+	const ambiguous = new Set(optionState.value.ambiguousRouteIds)
+	const resolved = resolveRoute(options.value, pair)
+	missing.value = resolved.missing.map((routeId) => ({
+		key: `${ambiguous.has(routeId) ? 'ambiguous' : 'missing'}:${routeId}`,
+		kind: ambiguous.has(routeId) ? 'ambiguous' : 'missing',
+		label: ambiguous.has(routeId)
+			? t('collectives', 'Ambiguous version')
+			: t('collectives', 'Unavailable version ({version})', { version: routeId }),
+		routeId,
+	}))
+	const optionFor = (routeId, resolvedOption) => resolvedOption ?? missing.value.find((option) => option.routeId === routeId)
+	selection.earlier = optionFor(pair.from, resolved.first).key
+	selection.later = optionFor(pair.to, resolved.second).key
+
+	if (resolved.missing.some((routeId) => ambiguous.has(routeId))) {
+		fail(t('collectives', 'The version comparison link is ambiguous and could not be opened.'))
+	} else if (resolved.missing.length) {
+		fail(resolved.missing.length === 2
+			? t('collectives', 'The selected versions have expired or were removed.')
+			: t('collectives', 'One of the selected versions has expired or was removed.'))
+	} else if (!resolved.invalid) {
+		open.value = comparisonRenderer() !== 'viewer'
+		await nextTick()
+		await compareSelected()
+	}
+}
+function fail(failureMessage) {
+	status.value = 'error'
+	message.value = failureMessage
+}
+async function onOpenUpdate(value) {
+	open.value = value
+	if (value) {
+		return
+	}
+	cleanup()
+	if (isManagedHistoryEntry()) {
+		await new Promise((resolve) => {
+			const remove = router.afterEach(() => (remove(), resolve()))
+			router.back()
+		})
+	} else if (parseRoute(route.query).kind === 'valid') {
+		await removeComparisonRoute()
+	}
+	await nextTick()
+	opener?.focus()
+}
+function optionLabel(option) {
+	if (['missing', 'ambiguous'].includes(option.kind)) {
+		return option.label
+	}
+	const timestamp = t('collectives', '{date} at {time}', { date: moment(option.mtime).format('LL'), time: moment(option.mtime).format('LTS') })
+	if (option.kind === 'current') {
+		return t('collectives', 'Current version — {timestamp}', { timestamp })
+	}
+	return option.label ? t('collectives', '{label} — {timestamp}', { label: option.label, timestamp }) : timestamp
+}
+async function compareSelected() {
+	if (!canCompare.value) {
+		return
+	}
+	let pair = normalizePair(earlier.value, later.value)
+	selection.earlier = pair.earlier.key
+	selection.later = pair.later.key
+	destroyComparison()
+	previews.value = []
+	message.value = ''
+	status.value = 'loading'
+
+	const factory = window.OCA?.Text?.createMarkdownContentComparison
+	const renderer = comparisonRenderer()
+	dialogSize.value = renderer === 'semantic' ? 'full' : 'large'
+	if (renderer === 'unsupported') {
+		status.value = 'unsupported'
+		message.value = isMobile.value
+			? t('collectives', 'Version comparison requires a newer version of the Text app on mobile.')
+			: t('collectives', 'Version comparison is not supported by the installed Text app.')
+		return
+	}
+	const request = requests.begin()
+	let pending = null
+	let expiredSelectionCount = 0
+	try {
+		pair = await preparePair(
+			pair,
+			() => versionsStore.prepareCurrentSnapshot(),
+			(versions) => {
+				const options = createState(props.currentVersion, versions).options
+				const earlier = options.find(({ key }) => key === pair.earlier.key)
+				const later = options.find(({ key }) => key === pair.later.key)
+				expiredSelectionCount = Number(!earlier) + Number(!later)
+				return expiredSelectionCount ? pair : normalizePair(earlier, later)
+			},
+		)
+		if (!requests.isCurrent(request.generation)) {
+			return
+		}
+		if (expiredSelectionCount) {
+			fail(expiredSelectionCount === 2
+				? t('collectives', 'The selected versions have expired or were removed.')
+				: t('collectives', 'One of the selected versions has expired or was removed.'))
+			return
+		}
+		if (renderer === 'viewer') {
+			closeDialog()
+			await nextTick()
+			window.OCA.Viewer.compare({ ...pair.later.fileInfo }, { ...pair.earlier.fileInfo })
+			return
+		}
+		const contents = await loadSnapshots(pair, fetchSnapshot, request.signal)
+		if (!requests.isCurrent(request.generation)) {
+			return
+		}
+		await nextTick()
+		const mount = document.createElement('div')
+		pending = await factory({
+			...contents,
+			el: mount,
+			fileId: props.currentVersion.fileId,
+			filePath: props.filePath,
+			openLinkHandler: window.OCA?.Collectives?.openLink,
+		})
+		if (typeof pending?.destroy !== 'function') {
+			throw new TypeError('Comparison factory returned an invalid instance')
+		}
+		if (!requests.isCurrent(request.generation)) {
+			destroyInstance(pending)
+			pending = null
+			return
+		}
+		host.value.replaceChildren(...mount.childNodes)
+		comparison = pending
+		pending = null
+		status.value = 'ready'
+		try {
+			await routeSuccessfulPair(pair)
+		} catch {
+			shown.value = ''
+			showError(t('collectives', 'Could not update the comparison link.'))
+		}
+	} catch (error) {
+		destroyInstance(pending)
+		if (!requests.isCurrent(request.generation) || isCancellation(error)) {
+			return
+		}
+		open.value = true
+		await nextTick()
+		try {
+			await showComparisonFailure(error, request)
+		} catch (failureError) {
+			if (requests.isCurrent(request.generation) && !isCancellation(failureError)) {
+				throw failureError
+			}
+		}
+	}
+}
+function comparisonRenderer() {
+	return selectRenderer({ comparisonFactory: window.OCA?.Text?.createMarkdownContentComparison, viewerCompare: window.OCA?.Viewer?.compare, isMobile: isMobile.value })
+}
+function onSelectionChange() {
+	resetResult()
+	void removeComparisonRoute(true)
+}
+function retryComparison() {
+	return routeTask.value && missing.value.length ? emit('retryRoute') : compareSelected()
+}
+async function routeSuccessfulPair(pair) {
+	const from = pair.earlier.routeId
+	const to = pair.later.routeId
+	if ([from, to].some((routeId) => optionState.value.ambiguousRouteIds.includes(routeId))) {
+		shown.value = ''
+		return
+	}
+	const signature = pairKey(from, to)
+	shown.value = signature
+	const parsed = parseRoute(route.query)
+	if (parsed.kind === 'valid' && pairKey(parsed.from, parsed.to) === signature) {
+		return
+	}
+	const location = withRoute(route, from, to)
+	const managed = isManagedHistoryEntry()
+	if (routeTask.value || parsed.kind === 'valid' || managed) {
+		await router.replace({ ...location, state: { [HISTORY]: managed } })
+	} else {
+		await router.push({ ...location, state: { [HISTORY]: true } })
+	}
+}
+async function removeComparisonRoute(preserveManaged = false) {
+	if (!Object.hasOwn(route.query, FROM) && !Object.hasOwn(route.query, TO)) {
+		return
+	}
+	await router.replace({
+		...withoutRoute(route),
+		state: { [HISTORY]: preserveManaged && isManagedHistoryEntry() },
+	})
+}
+function closeFromRoute() {
+	if (shown.value || routeTask.value) {
+		closeDialog()
+	}
+}
+function closeDialog() {
+	open.value = false
+	cleanup()
+}
+function isManagedHistoryEntry() {
+	return window.history.state?.[HISTORY] === true
+}
+function pairKey(from, to) {
+	return `${from}\u0000${to}`
+}
+async function copyComparisonLink() {
+	if (!canCopy.value) {
+		return
+	}
+	const url = new URL(router.resolve(route.fullPath).href, window.location.origin).href
+	try {
+		await navigator.clipboard.writeText(url)
+		showSuccess(t('collectives', 'Comparison link copied'))
+	} catch {
+		showError(t('collectives', 'Could not copy the comparison link.'))
+	}
+}
+function fetchSnapshot(snapshot, signal) {
+	return cache.load(snapshot, (item, itemSignal) => loadBody(item, fetch, itemSignal), signal)
+}
+async function showComparisonFailure(error, request) {
+	const limited = error instanceof LimitError ? error.snapshots : null
+	const failureMessage = limited
+		? t('collectives', 'The selected version is too large for complete comparison. A bounded preview is shown instead.')
+		: error instanceof SnapshotError
+			? snapshotErrorMessage(error)
+			: error instanceof PreparationError
+				? t('collectives', 'Could not save current changes before comparison. Please try again.')
+				: t('collectives', 'Could not initialize version comparison.')
+	const loaded = await Promise.all((limited ?? []).map(async (snapshot) => {
+		try {
+			const { content: preview } = await loadPreview(snapshot, fetch, request.signal)
+			return { ...snapshot, preview, previewError: false }
+		} catch (previewError) {
+			if (isCancellation(previewError)) {
+				throw previewError
+			}
+			return { ...snapshot, preview: '', previewError: true }
+		}
+	}))
+	if (requests.isCurrent(request.generation)) {
+		previews.value = loaded
+		fail(failureMessage)
+	}
+}
+function snapshotErrorMessage(error) {
+	return {
+		'permission-one': t('collectives', 'You do not have permission to load one of the selected versions.'),
+		'permission-two': t('collectives', 'You do not have permission to load the selected versions.'),
+		'expired-one': t('collectives', 'One of the selected versions has expired or was removed.'),
+		'expired-two': t('collectives', 'The selected versions have expired or were removed.'),
+		encoding: t('collectives', 'One of the selected versions contains invalid UTF-8 text.'),
+		network: t('collectives', 'Could not load the selected versions because of a network error.'),
+	}[classifyError(error)]
+}
+function resetResult() {
+	destroyComparison()
+	requests.cancel()
+	previews.value = []
+	message.value = ''
+	missing.value = []
+	routeTask.value = null
+	shown.value = ''
+	status.value = 'idle'
+	dialogSize.value = 'large'
+}
+function destroyComparison() {
+	const instance = comparison
+	comparison = null
+	host.value?.replaceChildren()
+	destroyInstance(instance)
+}
+function destroyInstance(instance) {
+	try {
+		instance?.destroy()
+	} catch {
+		showError(t('collectives', 'Could not clean up version comparison.'))
+	}
+}
+function cleanup() {
+	resetResult()
+	cache.clear()
+}
+defineExpose({ closeDialog, closeFromRoute, openFor, openRoutedPair, openSelector })
+</script>
+
+<style scoped lang="scss">
+$g: var(--default-grid-baseline);
+
+:global(div.dialog__content.version-comparison-dialog) {
+	display: flex;
+	flex-direction: column;
+	max-inline-size: 1600px;
+	block-size: 100%;
+	margin-inline: auto;
+	overflow: hidden;
+}
+
+.version-comparison-dialog {
+	&__selectors {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
+		align-items: end;
+		flex: none;
+		gap: calc(3 * $g);
+		inline-size: min(100%, 1040px);
+		margin-inline: auto;
+		padding: 0 calc(3 * $g) calc(2 * $g);
+		select {
+			display: block;
+			box-sizing: border-box;
+			inline-size: 100%;
+			block-size: var(--default-clickable-area);
+			margin: 0;
+		}
+	}
+	.field-label {
+		display: flex;
+		align-items: center;
+		gap: calc(2 * $g);
+		margin-block-end: $g;
+		font-weight: var(--font-weight-element);
+	}
+	.indicator {
+		inline-size: calc(2 * $g);
+		block-size: calc(2 * $g);
+		border-radius: 50%;
+		background: var(--color-text-maxcontrast);
+	}
+	.field--later .indicator {
+		background: var(--color-primary-element);
+	}
+	.copy {
+		align-self: end;
+		justify-self: end;
+		white-space: nowrap;
+	}
+	.message {
+		margin-block: calc(3 * $g);
+	}
+	&__loading {
+		display: grid;
+		flex: 1;
+		min-block-size: 160px;
+		place-content: center;
+	}
+	.previews {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+		gap: calc(2 * $g);
+		min-block-size: 0;
+		overflow: auto;
+	}
+	&__preview {
+		min-inline-size: 0;
+		pre {
+			max-block-size: 16rem;
+			overflow: auto;
+			white-space: pre-wrap;
+		}
+	}
+	&__comparison {
+		display: flex;
+		flex: 1;
+		min-inline-size: 0;
+		min-block-size: 0;
+		overflow: hidden;
+		&:not(:empty) {
+			border-block-start: 1px solid var(--color-border);
+		}
+	}
+}
+@media (max-width: 900px) {
+	.version-comparison-dialog__selectors {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+	.copy {
+		grid-column: 1 / -1;
+	}
+}
+@media (max-width: 600px) {
+	.version-comparison-dialog__selectors {
+		grid-template-columns: 1fr;
+	}
+	.copy {
+		grid-column: auto;
+	}
+}
+</style>

--- a/src/components/PageSidebar/VersionEntry.vue
+++ b/src/components/PageSidebar/VersionEntry.vue
@@ -7,6 +7,7 @@
 	<NcListItem
 		:name="version.basename"
 		class="version"
+		:data-version-id="version.fileVersion"
 		:class="{ active: isSelected }"
 		:active="isSelected"
 		forceDisplayActions
@@ -67,6 +68,7 @@
 		<!-- Actions -->
 		<template #actions>
 			<NcActionButton
+				v-if="canEdit"
 				closeAfterClick
 				@click="$emit('startLabelUpdate')">
 				<template #icon>
@@ -77,11 +79,11 @@
 			<NcActionButton
 				v-if="!isCurrent"
 				closeAfterClick
-				@click="$emit('compare')">
+				@click="$emit('compare', $event)">
 				<template #icon>
 					<FileCompareIcon :size="22" />
 				</template>
-				{{ t('collectives', 'Compare to current version') }}
+				{{ t('collectives', 'Compare with current version') }}
 			</NcActionButton>
 			<NcActionButton
 				v-if="!isCurrent && canEdit"

--- a/src/stores/versions.js
+++ b/src/stores/versions.js
@@ -13,15 +13,17 @@ import * as davApi from '../apis/dav/index.js'
 import { useCollectivesStore } from './collectives.js'
 import { usePagesStore } from './pages.js'
 
+const preparers = new WeakMap()
+const requests = new WeakMap()
+
 export const useVersionsStore = defineStore('versions', {
 	state: () => ({
+		loadedPageId: null,
 		selectedVersion: null,
 		versions: [],
 	}),
 
 	getters: {
-		hasVersionsLoaded: (state) => !!state.versions.length,
-
 		currentVersion: () => {
 			const collectivesStore = useCollectivesStore()
 			const pagesStore = usePagesStore()
@@ -46,16 +48,42 @@ export const useVersionsStore = defineStore('versions', {
 	},
 
 	actions: {
+		registerCurrentSnapshotPreparer(preparer) {
+			preparers.set(this, preparer)
+			return () => {
+				if (preparers.get(this) === preparer) {
+					preparers.delete(this)
+				}
+			}
+		},
+
+		async prepareCurrentSnapshot() {
+			return preparers.get(this)?.()
+		},
+
 		selectVersion(version) {
 			this.selectedVersion = version
 		},
 
-		async getVersions(pageId) {
-			const response = await davApi.getVersions(pageId)
-			this.versions = response.data
-				// filter out root
-				.filter(({ mime }) => mime !== '')
-				.map((version) => this.formatVersion(version, pageId))
+		getVersions(pageId) {
+			const task = Promise.resolve()
+				.then(() => davApi.getVersions(pageId))
+				.then((response) => {
+					const versions = response.data
+						.filter(({ mime }) => mime !== '')
+						.map((version) => this.formatVersion(version, pageId))
+					const currentSnapshot = versions.reduce((latest, version) => !latest || version.mtime > latest.mtime ? version : latest, null)
+					if (currentSnapshot) {
+						currentSnapshot.isCurrentSnapshot = true
+					}
+					if (requests.get(this) === task) {
+						this.versions = versions
+						this.loadedPageId = pageId
+					}
+					return versions
+				})
+			requests.set(this, task)
+			return task
 		},
 
 		formatVersion(version, pageId) {
@@ -93,7 +121,8 @@ export const useVersionsStore = defineStore('versions', {
 			}
 
 			this.selectVersion(null)
-			this.getVersions(pagesStore.currentPage.id)
+			await this.getVersions(pagesStore.currentPage.id)
+				.catch((error) => console.error('Failed to refresh page versions', error))
 			showSuccess(t('collectives', 'Restored {basename} version of {page}.', {
 				basename: version.basename,
 				page: pagesStore.currentPage.title,
@@ -133,7 +162,8 @@ export const useVersionsStore = defineStore('versions', {
 			if (version.basename === this.selectedVersion?.basename) {
 				this.selectVersion(null)
 			}
-			this.getVersions(pagesStore.currentPage.id)
+			await this.getVersions(pagesStore.currentPage.id)
+				.catch((error) => console.error('Failed to refresh page versions', error))
 			showSuccess(t('collectives', 'Deleted {basename} version of {page}.', {
 				basename: version.basename,
 				page: pagesStore.currentPage.title,

--- a/src/tests/util/boundedSnapshotBody.spec.js
+++ b/src/tests/util/boundedSnapshotBody.spec.js
@@ -1,0 +1,152 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+	ComparisonSnapshotEncodingError,
+	ComparisonSnapshotLimitError,
+	loadBoundedSnapshotBody,
+	loadBoundedSnapshotPreview,
+	loadVersionComparisonSnapshots,
+	VERSION_COMPARISON_LIMITS,
+} from '../../util/versionComparison.js'
+
+afterEach(() => vi.unstubAllGlobals())
+
+function responseWithChunks(chunks, { status = 200 } = {}) {
+	const cancel = vi.fn()
+	let index = 0
+	return {
+		cancel,
+		response: {
+			ok: status >= 200 && status < 300,
+			status,
+			body: {
+				getReader: () => ({
+					cancel,
+					read: vi.fn(async () => index < chunks.length
+						? { done: false, value: chunks[index++] }
+						: { done: true }),
+				}),
+			},
+		},
+	}
+}
+
+describe('bounded snapshot body acquisition', () => {
+	it.each([
+		['complete body', loadBoundedSnapshotBody],
+		['bounded preview', loadBoundedSnapshotPreview],
+	])('cache-busts the current %s but keeps historical snapshots cacheable', async (_name, load) => {
+		vi.stubGlobal('window', { location: { href: 'https://nextcloud.local/apps/collectives/Atlas/Page' } })
+		const currentResponse = responseWithChunks([new TextEncoder().encode('fresh')]).response
+		const historicalResponse = responseWithChunks([new TextEncoder().encode('old')]).response
+		const fetchCurrent = vi.fn().mockResolvedValue(currentResponse)
+		const fetchHistorical = vi.fn().mockResolvedValue(historicalResponse)
+
+		await load({ kind: 'current', size: 5, url: '/current?file=7' }, fetchCurrent)
+		await load({ kind: 'historical', size: 3, url: '/historical?file=7' }, fetchHistorical)
+
+		const currentUrl = new URL(fetchCurrent.mock.calls[0][0])
+		expect(currentUrl.pathname).toBe('/current')
+		expect(currentUrl.searchParams.get('file')).toBe('7')
+		expect(currentUrl.searchParams.get('timestamp')).toMatch(/^\d{13}$/)
+		expect(fetchHistorical.mock.calls[0][0]).toBe('/historical?file=7')
+	})
+
+	it('AUD-08 cancels an incorrectly advertised body at the byte ceiling', async () => {
+		const first = new Uint8Array(VERSION_COMPARISON_LIMITS.maximumSnapshotBytes)
+		const overflow = new Uint8Array([0x41])
+		const { response, cancel } = responseWithChunks([first, overflow])
+		const fetchSnapshot = vi.fn().mockResolvedValue(response)
+		const snapshot = { kind: 'historical', size: 1, url: '/snapshot' }
+
+		await expect(loadBoundedSnapshotBody(snapshot, fetchSnapshot))
+			.rejects.toEqual(expect.objectContaining({
+				name: 'ComparisonSnapshotLimitError',
+				snapshots: [snapshot],
+			}))
+		expect(cancel).toHaveBeenCalledOnce()
+		expect(fetchSnapshot).toHaveBeenCalledWith('/snapshot', expect.objectContaining({
+			credentials: 'same-origin',
+		}))
+	})
+
+	it('accepts a streamed body exactly at the byte ceiling', async () => {
+		const bytes = new TextEncoder().encode('bounded')
+		const { response, cancel } = responseWithChunks([bytes])
+
+		await expect(loadBoundedSnapshotBody(
+			{ kind: 'historical', size: bytes.byteLength, url: '/snapshot' },
+			vi.fn().mockResolvedValue(response),
+		)).resolves.toEqual({
+			byteLength: bytes.byteLength,
+			content: 'bounded',
+		})
+		expect(cancel).not.toHaveBeenCalled()
+	})
+
+	it('fails closed when a complete snapshot contains malformed UTF-8', async () => {
+		const { response, cancel } = responseWithChunks([new Uint8Array([0x66, 0x80, 0x6f])])
+
+		await expect(loadBoundedSnapshotBody(
+			{ kind: 'historical', size: 3, url: '/snapshot' },
+			vi.fn().mockResolvedValue(response),
+		)).rejects.toBeInstanceOf(ComparisonSnapshotEncodingError)
+		expect(cancel).toHaveBeenCalledOnce()
+	})
+
+	it('preserves an HTTP status for existing permission and expiry classification', async () => {
+		const { response } = responseWithChunks([], { status: 403 })
+
+		await expect(loadBoundedSnapshotBody(
+			{ kind: 'historical', size: 1, url: '/snapshot' },
+			vi.fn().mockResolvedValue(response),
+		)).rejects.toEqual(expect.objectContaining({ response: { status: 403 } }))
+	})
+
+	it('uses the caller cancellation signal', async () => {
+		const controller = new AbortController()
+		const { response } = responseWithChunks([new Uint8Array()])
+		const fetchSnapshot = vi.fn().mockResolvedValue(response)
+
+		await loadBoundedSnapshotBody(
+			{ kind: 'historical', size: 0, url: '/snapshot' },
+			fetchSnapshot,
+			controller.signal,
+		)
+		expect(fetchSnapshot).toHaveBeenCalledWith('/snapshot', expect.objectContaining({
+			signal: controller.signal,
+		}))
+	})
+
+	it('unwraps measured bodies through atomic pair loading', async () => {
+		const earlier = { kind: 'historical', size: 1, url: '/earlier' }
+		const later = { kind: 'current', size: 1, url: '/later' }
+
+		await expect(loadVersionComparisonSnapshots(
+			{ earlier, later },
+			async ({ url }) => ({ byteLength: 1, content: url }),
+		)).resolves.toEqual({
+			afterContent: '/later',
+			beforeContent: '/earlier',
+		})
+	})
+
+	it('preserves a streamed size-limit failure through atomic pair loading', async () => {
+		const limited = { kind: 'historical', size: 1, url: '/limited' }
+		const current = { kind: 'current', size: 1, url: '/current' }
+
+		await expect(loadVersionComparisonSnapshots(
+			{ earlier: limited, later: current },
+			(snapshot) => snapshot === limited
+				? Promise.reject(new ComparisonSnapshotLimitError([snapshot]))
+				: Promise.resolve('current'),
+		)).rejects.toEqual(expect.objectContaining({
+			name: 'ComparisonSnapshotLimitError',
+			snapshots: [limited],
+		}))
+	})
+})

--- a/src/tests/util/versionComparison.spec.js
+++ b/src/tests/util/versionComparison.spec.js
@@ -1,0 +1,509 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+	classifyComparisonSnapshotError,
+	ComparisonSnapshotEncodingError,
+	ComparisonSnapshotError,
+	ComparisonSnapshotLimitError,
+	createComparisonRequestManager,
+	createVersionComparisonState,
+	CurrentSnapshotPreparationError,
+	isVersionComparisonCancellation,
+	loadBoundedSnapshotPreview,
+	loadVersionComparisonSnapshots,
+	normalizeVersionComparisonPair,
+	prepareVersionComparisonPair,
+	selectVersionComparisonRenderer,
+	VERSION_COMPARISON_LIMITS,
+	VersionComparisonSnapshotCache,
+} from '../../util/versionComparison.js'
+
+const current = { fileId: 7, label: '', mtime: 3000, size: 10, source: '/current', url: '/current' }
+const old = { fileVersion: '1', label: 'Old', mtime: 1000, size: 10, source: '/old', url: '/old' }
+const middle = { fileVersion: '2', label: 'Middle', mtime: 2000, size: 10, source: '/middle', url: '/middle' }
+
+function measured(content, byteLength = new TextEncoder().encode(content).byteLength) {
+	return { byteLength, content }
+}
+
+function state(versions = [old, middle]) {
+	return createVersionComparisonState(current, versions)
+}
+
+function pair(first, second) {
+	const { options } = state()
+	const option = (version) => options.find(({ fileInfo }) => fileInfo === version)
+	return normalizeVersionComparisonPair(option(first), option(second))
+}
+
+describe('version comparison pair model', () => {
+	it.each([
+		[false, vi.fn(), vi.fn(), 'semantic'],
+		[true, vi.fn(), vi.fn(), 'semantic'],
+		[false, undefined, vi.fn(), 'viewer'],
+		[true, undefined, vi.fn(), 'unsupported'],
+		[false, undefined, undefined, 'unsupported'],
+	])('selects supported renderers without breaking the desktop Viewer fallback', (isMobile, comparisonFactory, viewerCompare, expected) => {
+		expect(selectVersionComparisonRenderer({ comparisonFactory, viewerCompare, isMobile })).toBe(expected)
+	})
+
+	it('creates stable current and historical identities in newest-first selector order', () => {
+		expect(state().options.map(({ key }) => key)).toEqual(['current', 'version:2', 'version:1'])
+	})
+
+	it('quarantines invalid and duplicate historical identities', () => {
+		const result = state([
+			{ ...old, fileVersion: '' },
+			{ ...old, fileVersion: 'same' },
+			{ ...middle, fileVersion: 'same' },
+			middle,
+		])
+		expect(result.options.map(({ key }) => key)).toEqual(['current', 'version:2'])
+		expect(result.quarantinedCount).toBe(3)
+		const usableRouteIds = result.options.flatMap(({ routeId, routeAliases = [] }) => [routeId, ...routeAliases])
+		expect(result.ambiguousRouteIds.some((routeId) => usableRouteIds.includes(routeId))).toBe(false)
+	})
+
+	it('quarantines a historical identity that matches the current snapshot', () => {
+		const currentSnapshot = {
+			...current,
+			fileVersion: 'same',
+			isCurrentSnapshot: true,
+		}
+		const result = state([
+			{ ...old, fileVersion: 'same' },
+			currentSnapshot,
+		])
+
+		expect(result.options.map(({ key }) => key)).toEqual(['current'])
+		expect(result.options[0].routeId).toBe('current:same')
+		expect(result.quarantinedCount).toBe(1)
+		expect(result.ambiguousRouteIds).toEqual(['version:same'])
+	})
+
+	it('C01 normalizes current and historical snapshots by chronology and identity', () => {
+		expect(pair(current, old)).toMatchObject({
+			earlier: { key: 'version:1', kind: 'historical', label: 'Old', mtime: 1000 },
+			later: { key: 'current', kind: 'current', mtime: 3000 },
+		})
+	})
+
+	it('C02 loads both immutable historical snapshots in chronological order', async () => {
+		const comparisonPair = pair(middle, old)
+		const fetchSnapshot = vi.fn(async ({ url }) => measured(`body:${url}`))
+
+		await expect(loadVersionComparisonSnapshots(comparisonPair, fetchSnapshot)).resolves.toEqual({
+			afterContent: 'body:/middle',
+			beforeContent: 'body:/old',
+		})
+		expect(fetchSnapshot.mock.calls.map(([snapshot]) => snapshot.key))
+			.toEqual(['version:1', 'version:2'])
+	})
+
+	it('C03 normalizes reversed selectors without swapping visible labels', () => {
+		expect(pair(middle, old)).toMatchObject({
+			earlier: { key: 'version:1', label: 'Old', mtime: 1000 },
+			later: { key: 'version:2', label: 'Middle', mtime: 2000 },
+		})
+	})
+
+	it('C04 rejects an identical pair before comparison starts', () => {
+		const option = state().options[0]
+		expect(() => normalizeVersionComparisonPair(option, option)).toThrow('distinct')
+	})
+})
+
+describe('atomic current snapshot freshness', () => {
+	it('AUD-03 binds current bytes to the committed DAV snapshot resource', () => {
+		const committed = {
+			...middle,
+			etag: '"committed"',
+			fileVersion: '4',
+			isCurrentSnapshot: true,
+			mtime: 4000,
+			source: '/versions/4',
+		}
+		const [currentOption] = createVersionComparisonState(
+			{ ...current, mtime: 4000, source: '/mutable-live' },
+			[old, committed],
+		).options
+
+		expect(currentOption).toMatchObject({
+			etag: '"committed"',
+			routeId: 'current:4',
+			url: '/versions/4',
+		})
+	})
+
+	it('AUD-03 does not pair a committed identity with the mutable live URL', () => {
+		const committedWithoutSource = {
+			...middle,
+			fileVersion: '4',
+			isCurrentSnapshot: true,
+			mtime: 4000,
+			source: undefined,
+			url: undefined,
+		}
+		const [currentOption] = createVersionComparisonState(
+			{ ...current, etag: '"mutable"', mtime: 4000, size: 99, source: '/mutable-live', url: '/mutable-live' },
+			[old, committedWithoutSource],
+		).options
+
+		expect(currentOption).toMatchObject({
+			routeId: 'current:4',
+			size: committedWithoutSource.size,
+		})
+		expect(currentOption.etag).toBeUndefined()
+		expect(currentOption.url).toBeUndefined()
+	})
+
+	it('AUD-03 resolves identity and bytes from the committed preparation result', async () => {
+		const stalePair = pair(current, old)
+		const committedPair = {
+			earlier: stalePair.earlier,
+			later: { ...stalePair.later, mtime: 4000, routeId: 'current:4', url: '/current-4' },
+		}
+		const prepare = vi.fn().mockResolvedValue(committedPair)
+		const resolvePair = vi.fn((prepared) => prepared ?? stalePair)
+
+		await expect(prepareVersionComparisonPair(stalePair, prepare, resolvePair))
+			.resolves.toBe(committedPair)
+		expect(resolvePair).toHaveBeenCalledWith(committedPair)
+	})
+
+	it('AUD-03 keeps committed route and bytes stable across a later save race', async () => {
+		const stalePair = pair(current, old)
+		const liveCurrent = { ...current, mtime: 4000, source: '/mutable-live-4' }
+		const committed = {
+			...middle,
+			fileVersion: '4',
+			isCurrentSnapshot: true,
+			mtime: 4000,
+			source: '/versions/4',
+		}
+		const committedPair = await prepareVersionComparisonPair(
+			stalePair,
+			vi.fn().mockResolvedValue([old, committed]),
+			(versions) => {
+				const options = createVersionComparisonState(liveCurrent, versions).options
+				return normalizeVersionComparisonPair(
+					options.find(({ key }) => key === stalePair.earlier.key),
+					options.find(({ key }) => key === stalePair.later.key),
+				)
+			},
+		)
+
+		liveCurrent.mtime = 5000
+		liveCurrent.source = '/mutable-live-5'
+		committed.source = '/versions/5'
+		const contents = await loadVersionComparisonSnapshots(
+			committedPair,
+			async ({ url }) => measured(`bytes:${url}`),
+		)
+
+		expect(committedPair.later).toMatchObject({
+			routeId: 'current:4',
+			url: '/versions/4',
+		})
+		expect(contents.afterContent).toBe('bytes:/versions/4')
+	})
+
+	it('C08 rejects failed current preparation before resolving a stale pair', async () => {
+		const stalePair = pair(current, old)
+		const failure = new Error('save failed')
+		const prepare = vi.fn().mockRejectedValue(failure)
+		const resolvePair = vi.fn()
+
+		await expect(prepareVersionComparisonPair(stalePair, prepare, resolvePair))
+			.rejects.toMatchObject({ cause: failure })
+		expect(resolvePair).not.toHaveBeenCalled()
+	})
+
+	it('reports a missing current preparer as a typed preparation failure', async () => {
+		const stalePair = pair(current, old)
+		const resolvePair = vi.fn()
+
+		await expect(prepareVersionComparisonPair(
+			stalePair,
+			vi.fn().mockResolvedValue(undefined),
+			resolvePair,
+		)).rejects.toBeInstanceOf(CurrentSnapshotPreparationError)
+		expect(resolvePair).not.toHaveBeenCalled()
+	})
+
+	it('rebinds the current route identity after preparation refreshes versions', async () => {
+		const stalePair = pair(current, old)
+		const freshCurrent = { ...current, mtime: 4000 }
+		const freshVersions = [{ ...old }, { ...middle, fileVersion: '4', mtime: 4000, isCurrentSnapshot: true }]
+		const prepare = vi.fn().mockResolvedValue(freshVersions)
+		const resolvePair = vi.fn((versions) => {
+			const options = createVersionComparisonState(freshCurrent, versions).options
+			return normalizeVersionComparisonPair(
+				options.find(({ key }) => key === stalePair.earlier.key),
+				options.find(({ key }) => key === stalePair.later.key),
+			)
+		})
+
+		const refreshedPair = await prepareVersionComparisonPair(stalePair, prepare, resolvePair)
+
+		expect(prepare).toHaveBeenCalledOnce()
+		expect(resolvePair).toHaveBeenCalledOnce()
+		expect(refreshedPair.later.routeId).toBe('current:4')
+	})
+})
+
+describe('atomic loading, cancellation, and cache', () => {
+	it.each([
+		['unknown', undefined],
+		['negative', -1],
+		['over the ceiling', VERSION_COMPARISON_LIMITS.maximumSnapshotBytes + 1],
+	])('AUD-08 rejects %s snapshot size before either body request', async (_name, size) => {
+		const comparisonPair = pair(old, middle)
+		comparisonPair.earlier = { ...comparisonPair.earlier, size }
+		const fetchSnapshot = vi.fn()
+
+		await expect(loadVersionComparisonSnapshots(comparisonPair, fetchSnapshot))
+			.rejects.toBeInstanceOf(ComparisonSnapshotLimitError)
+		expect(fetchSnapshot).not.toHaveBeenCalled()
+	})
+
+	it.each([
+		VERSION_COMPARISON_LIMITS.maximumSnapshotBytes - 1,
+		VERSION_COMPARISON_LIMITS.maximumSnapshotBytes,
+	])('AUD-08 accepts trusted metadata at %i bytes', async (size) => {
+		const comparisonPair = pair(old, middle)
+		comparisonPair.earlier = { ...comparisonPair.earlier, size }
+		comparisonPair.later = { ...comparisonPair.later, size }
+		const fetchSnapshot = vi.fn().mockResolvedValue(measured('bounded'))
+
+		await expect(loadVersionComparisonSnapshots(comparisonPair, fetchSnapshot)).resolves.toBeDefined()
+		expect(fetchSnapshot).toHaveBeenCalledTimes(2)
+	})
+
+	it('AUD-08 bounds a preview when the server ignores Range', async () => {
+		const cancel = vi.fn()
+		const fetchPreview = vi.fn().mockResolvedValue({
+			body: {
+				getReader: () => ({
+					cancel,
+					read: vi.fn()
+						.mockResolvedValueOnce({ done: false, value: new TextEncoder().encode('x'.repeat(VERSION_COMPARISON_LIMITS.maximumPreviewBytes + 100)) })
+						.mockResolvedValueOnce({ done: true }),
+				}),
+			},
+			ok: true,
+		})
+
+		const preview = await loadBoundedSnapshotPreview(state().options[1], fetchPreview)
+
+		expect(new TextEncoder().encode(preview.content).byteLength).toBeLessThanOrEqual(VERSION_COMPARISON_LIMITS.maximumPreviewBytes)
+		expect([...preview.content]).toHaveLength(VERSION_COMPARISON_LIMITS.maximumPreviewCharacters)
+		expect(preview.truncated).toBe(true)
+		expect(cancel).toHaveBeenCalledOnce()
+		expect(fetchPreview.mock.calls[0][1].headers.Range).toBe(`bytes=0-${VERSION_COMPARISON_LIMITS.maximumPreviewBytes - 1}`)
+	})
+
+	it('AUD-08 keeps UTF-8 preview text and DOM characters bounded', async () => {
+		const bytes = new TextEncoder().encode('é'.repeat(VERSION_COMPARISON_LIMITS.maximumPreviewCharacters + 10))
+		const fetchPreview = vi.fn().mockResolvedValue(new Response(bytes))
+
+		const preview = await loadBoundedSnapshotPreview(state().options[1], fetchPreview)
+
+		expect(preview.content).not.toContain('\uFFFD')
+		expect([...preview.content]).toHaveLength(VERSION_COMPARISON_LIMITS.maximumPreviewCharacters)
+		expect(preview.truncated).toBe(true)
+	})
+
+	it('AUD-08 rejects interior malformed UTF-8 without consuming the remaining preview', async () => {
+		const cancel = vi.fn()
+		const read = vi.fn()
+			.mockResolvedValueOnce({ done: false, value: Uint8Array.from([0x61]) })
+			.mockResolvedValueOnce({ done: false, value: Uint8Array.from([0x80]) })
+			.mockResolvedValueOnce({ done: false, value: Uint8Array.from([0x62]) })
+		const fetchPreview = vi.fn().mockResolvedValue({
+			body: { getReader: () => ({ cancel, read }) },
+			ok: true,
+		})
+
+		await expect(loadBoundedSnapshotPreview(state().options[1], fetchPreview))
+			.rejects.toThrow()
+		expect(cancel).toHaveBeenCalledOnce()
+		expect(read).toHaveBeenCalledTimes(2)
+	})
+
+	it.each([
+		[1, [0xf0]],
+		[2, [0xf0, 0x9f]],
+		[3, [0xf0, 0x9f, 0x98]],
+	])('AUD-08 drops only an incomplete trailing UTF-8 sequence split after %i bytes', async (_length, suffix) => {
+		const bytes = Uint8Array.from([0x6f, 0x6b, ...suffix])
+		const fetchPreview = vi.fn().mockResolvedValue(new Response(bytes))
+
+		await expect(loadBoundedSnapshotPreview(state().options[1], fetchPreview)).resolves.toEqual({
+			content: 'ok',
+			truncated: true,
+		})
+	})
+
+	it.each([
+		[[{ response: { status: 403 } }], 'permission-one'],
+		[[{ response: { status: 403 } }, { response: { status: 403 } }], 'permission-two'],
+		[[{ response: { status: 404 } }], 'expired-one'],
+		[[{ response: { status: 410 } }, { response: { status: 404 } }], 'expired-two'],
+		[[{ response: { status: 403 } }, { response: { status: 404 } }], 'network'],
+		[[{ response: { status: 404 } }, new Error('offline')], 'network'],
+		[[new ComparisonSnapshotEncodingError()], 'encoding'],
+		[[new Error('offline')], 'network'],
+	])('classifies snapshot failures for actionable messages', (reasons, expected) => {
+		const error = { reasons }
+		expect(classifyComparisonSnapshotError(error)).toBe(expected)
+	})
+
+	it('distinguishes cancellation from a network failure', () => {
+		expect(isVersionComparisonCancellation({ name: 'AbortError' })).toBe(true)
+		expect(isVersionComparisonCancellation({ name: 'CanceledError' })).toBe(true)
+		expect(isVersionComparisonCancellation(new Error('offline'))).toBe(false)
+		expect(isVersionComparisonCancellation({ __CANCEL__: true })).toBe(true)
+	})
+
+	it('loads both immutable snapshots and publishes neither when one or both fail', async () => {
+		const comparisonPair = pair(old, middle)
+		const fetchSnapshot = vi.fn(async ({ url }) => {
+			if (url === '/old') {
+				throw new Error('expired')
+			}
+			return measured(url)
+		})
+		const error = await loadVersionComparisonSnapshots(comparisonPair, fetchSnapshot).catch((reason) => reason)
+		expect(error).toBeInstanceOf(ComparisonSnapshotError)
+		expect(error.reasons).toHaveLength(1)
+		expect(fetchSnapshot).toHaveBeenCalledTimes(2)
+	})
+
+	it('C05 reuses a successful historical body without another DAV load', async () => {
+		const cache = new VersionComparisonSnapshotCache()
+		const historical = state().options[1]
+		const fetchSnapshot = vi.fn(async ({ kind }) => measured(`${kind}-${fetchSnapshot.mock.calls.length}`))
+
+		expect(await cache.load(historical, fetchSnapshot)).toBe(await cache.load(historical, fetchSnapshot))
+		expect(fetchSnapshot).toHaveBeenCalledOnce()
+	})
+
+	it('C06 reloads the current snapshot instead of serving a stale cache entry', async () => {
+		const cache = new VersionComparisonSnapshotCache()
+		const currentSnapshot = state().options[0]
+		const fetchSnapshot = vi.fn(async () => measured(`current-${fetchSnapshot.mock.calls.length}`))
+
+		await cache.load(currentSnapshot, fetchSnapshot)
+		await cache.load(currentSnapshot, fetchSnapshot)
+		expect(fetchSnapshot).toHaveBeenCalledTimes(2)
+	})
+
+	it('C11 does not cache a failed or aborted historical completion before retry', async () => {
+		const cache = new VersionComparisonSnapshotCache()
+		const historical = state().options[1]
+		const failed = vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce(measured('ok'))
+		await expect(cache.load(historical, failed)).rejects.toThrow('offline')
+		await expect(cache.load(historical, failed)).resolves.toEqual(measured('ok'))
+		cache.clear()
+		const controller = new AbortController()
+		const aborted = vi.fn(async () => {
+			controller.abort()
+			return measured('stale')
+		})
+		await cache.load(historical, aborted, controller.signal)
+		await cache.load(historical, aborted)
+		expect(aborted).toHaveBeenCalledTimes(2)
+	})
+
+	it('AUD-15 enforces entry, UTF-8 byte, identity, recency, and clear boundaries', async () => {
+		const cache = new VersionComparisonSnapshotCache({ maximumBytes: 8, maximumEntries: 2 })
+		const snapshots = [
+			{ ...state().options[1], fileVersion: 'a', url: '/a' },
+			{ ...state().options[1], fileVersion: 'b', url: '/b' },
+			{ ...state().options[1], fileVersion: 'c', url: '/c' },
+		]
+		const fetchSnapshot = vi.fn(async ({ fileVersion }) => measured(({ a: 'éé', b: 'bbbb', c: 'cccc' })[fileVersion]))
+
+		await cache.load(snapshots[0], fetchSnapshot)
+		await cache.load(snapshots[1], fetchSnapshot)
+		await cache.load(snapshots[0], fetchSnapshot)
+		await cache.load(snapshots[2], fetchSnapshot)
+		await cache.load(snapshots[1], fetchSnapshot)
+		expect(fetchSnapshot).toHaveBeenCalledTimes(4)
+
+		const sameVersionDifferentUrl = { ...snapshots[0], url: '/different' }
+		await cache.load(sameVersionDifferentUrl, fetchSnapshot)
+		expect(fetchSnapshot).toHaveBeenCalledTimes(5)
+
+		cache.clear()
+		await cache.load(sameVersionDifferentUrl, fetchSnapshot)
+		expect(fetchSnapshot).toHaveBeenCalledTimes(6)
+	})
+
+	it('AUD-15 reuses the bounded loader byte measurement when caching', async () => {
+		const cache = new VersionComparisonSnapshotCache({ maximumBytes: 4, maximumEntries: 1 })
+		const historical = state().options[1]
+		const fetchSnapshot = vi.fn().mockResolvedValue({
+			byteLength: 5,
+			content: 'x',
+		})
+
+		await expect(cache.load(historical, fetchSnapshot)).resolves.toEqual({ byteLength: 5, content: 'x' })
+		await cache.load(historical, fetchSnapshot)
+
+		expect(fetchSnapshot).toHaveBeenCalledTimes(2)
+	})
+
+	it.each([
+		['two-byte characters', 'éé', 3],
+		['an astral character', '😀', 3],
+		['an unpaired surrogate', '\ud800', 2],
+	])('AUD-15 does not cache %s above the UTF-8 byte budget', async (_name, content, maximumBytes) => {
+		const cache = new VersionComparisonSnapshotCache({ maximumBytes, maximumEntries: 2 })
+		const historical = state().options[1]
+		const fetchSnapshot = vi.fn().mockResolvedValue(measured(content))
+
+		await cache.load(historical, fetchSnapshot)
+		await cache.load(historical, fetchSnapshot)
+		expect(fetchSnapshot).toHaveBeenCalledTimes(2)
+	})
+
+	it('C09 aborts a superseded request and prevents its generation from publishing', () => {
+		const manager = createComparisonRequestManager()
+		const first = manager.begin()
+		const second = manager.begin()
+		expect(first.signal.aborted).toBe(true)
+		expect(manager.isCurrent(first.generation)).toBe(false)
+		expect(manager.isCurrent(second.generation)).toBe(true)
+	})
+
+	it('C10 allows only the latest rapid pair generation to publish', () => {
+		const manager = createComparisonRequestManager()
+		const first = manager.begin()
+		const second = manager.begin()
+		const published = []
+
+		if (manager.isCurrent(first.generation)) {
+			published.push('stale')
+		}
+		if (manager.isCurrent(second.generation)) {
+			published.push('latest')
+		}
+
+		expect(published).toEqual(['latest'])
+	})
+
+	it('cancels the active comparison request', () => {
+		const manager = createComparisonRequestManager()
+		const active = manager.begin()
+
+		manager.cancel()
+		expect(active.signal.aborted).toBe(true)
+		expect(manager.isCurrent(active.generation)).toBe(false)
+	})
+})

--- a/src/tests/util/versionComparisonRoute.spec.js
+++ b/src/tests/util/versionComparisonRoute.spec.js
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+	canonicalPathRoute,
+	MAX_COMPARISON_ID_LENGTH,
+	parseVersionComparisonRoute,
+	resolveVersionComparisonRoute,
+	withoutVersionComparisonRoute,
+	withVersionComparisonRoute,
+} from '../../util/versionComparisonRoute.js'
+
+const route = {
+	path: '/Atlas/Page',
+	query: { fileId: '42', view: 'grid' },
+	hash: '#rollout',
+}
+
+describe('canonical version comparison routes', () => {
+	it('R01 round-trips an exact ordered current/historical or historical/historical pair', () => {
+		for (const [from, to] of [
+			['version:1', 'current:2'],
+			['version:1', 'version:2'],
+		]) {
+			const location = withVersionComparisonRoute(route, from, to)
+			expect(parseVersionComparisonRoute(location.query)).toEqual({ kind: 'valid', from, to })
+		}
+	})
+
+	it.each([
+		['one value', { compareFrom: '1' }],
+		['empty value', { compareFrom: '', compareTo: 'current' }],
+		['identical value', { compareFrom: '1', compareTo: '1' }],
+		['duplicate array', { compareFrom: ['1', '2'], compareTo: 'current' }],
+		['slash', { compareFrom: 'versions/1', compareTo: 'current' }],
+		['backslash', { compareFrom: 'versions\\1', compareTo: 'current' }],
+		['control character', { compareFrom: 'version\n1', compareTo: 'current' }],
+		['overlong identity', { compareFrom: 'x'.repeat(MAX_COMPARISON_ID_LENGTH + 1), compareTo: 'current' }],
+	])('fails closed for %s without accepting an ambiguous route', (_name, query) => {
+		expect(parseVersionComparisonRoute(query)).toEqual({ kind: 'invalid' })
+	})
+
+	it('distinguishes an absent route', () => {
+		expect(parseVersionComparisonRoute(route.query)).toEqual({ kind: 'absent' })
+	})
+
+	it('R10 preserves unrelated query, hash, and path while closing a managed route', () => {
+		const compared = withVersionComparisonRoute(route, 'version:1', 'current:2')
+		expect(withoutVersionComparisonRoute(compared)).toEqual(route)
+	})
+
+	it('preserves the exact query pair while a renamed page path is canonicalized', () => {
+		const compared = withVersionComparisonRoute(route, 'version:1', 'current:2')
+		expect(canonicalPathRoute(compared, '/Atlas/Page-renamed')).toEqual({
+			path: '/Atlas/Page-renamed',
+			query: compared.query,
+			hash: route.hash,
+		})
+	})
+
+	it('R07 reports one missing version without substitution', () => {
+		const options = [
+			{ routeId: 'current:2', routeAliases: ['current'] },
+			{ routeId: 'version:1' },
+		]
+		expect(resolveVersionComparisonRoute(options, { from: 'missing', to: 'current' }).missing)
+			.toEqual(['missing'])
+	})
+
+	it('R08 reports two missing versions without substitution', () => {
+		const options = [
+			{ routeId: 'current:2', routeAliases: ['current'] },
+			{ routeId: 'version:1' },
+		]
+		expect(resolveVersionComparisonRoute(options, { from: 'missing-1', to: 'missing-2' }).missing)
+			.toEqual(['missing-1', 'missing-2'])
+	})
+
+	it('R09 resolves an unavailable ambiguous identity to a fail-closed missing result', () => {
+		const current = { routeId: 'current:2', routeAliases: ['current'] }
+		const resolved = resolveVersionComparisonRoute(
+			[current, { routeId: 'version:1' }],
+			{ from: 'current:2', to: 'current' },
+			['current:2'],
+		)
+		expect(resolved).toEqual({ first: null, second: current, missing: ['current:2'] })
+	})
+
+	it.each([
+		['canonical ID then alias', 'current:2', 'current'],
+		['alias then canonical ID', 'current', 'current:2'],
+	])('AUD-20 rejects %s resolving to the same semantic snapshot', (_name, from, to) => {
+		const current = { key: 'current', routeId: 'current:2', routeAliases: ['current'] }
+		const resolved = resolveVersionComparisonRoute(
+			[current, { key: 'version:1', routeId: 'version:1' }],
+			{ from, to },
+		)
+
+		expect(resolved).toEqual({
+			first: current,
+			second: current,
+			missing: [],
+			invalid: 'self-pair',
+		})
+	})
+
+	it('rejects rebuilt options with the same semantic key', () => {
+		const canonical = { key: 'current', routeId: 'current:2' }
+		const alias = { key: 'current', routeId: 'current' }
+
+		expect(resolveVersionComparisonRoute(
+			[canonical, alias],
+			{ from: 'current:2', to: 'current' },
+		)).toEqual({
+			first: canonical,
+			second: alias,
+			missing: [],
+			invalid: 'self-pair',
+		})
+	})
+})

--- a/src/tests/util/versionsStore.spec.js
+++ b/src/tests/util/versionsStore.spec.js
@@ -1,0 +1,136 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as davApi from '../../apis/dav/index.js'
+import { useVersionsStore } from '../../stores/versions.js'
+
+vi.mock('../../apis/dav/index.js', () => ({
+	deleteVersion: vi.fn(),
+	getVersions: vi.fn(),
+	restoreVersion: vi.fn(),
+}))
+vi.mock('@nextcloud/dialogs', () => ({ showError: vi.fn(), showSuccess: vi.fn() }))
+vi.mock('@nextcloud/l10n', () => ({ t: (_app, message) => message }))
+vi.mock('@nextcloud/moment', () => ({
+	default: (value) => ({
+		format: () => String(value),
+		unix: () => Math.floor(new Date(value).getTime() / 1000),
+	}),
+}))
+vi.mock('@nextcloud/paths', () => ({ encodePath: (value) => value, join: (...parts) => parts.join('') }))
+vi.mock('@nextcloud/router', () => ({ generateRemoteUrl: () => '/remote.php/dav' }))
+vi.mock('../../stores/collectives.js', () => ({ useCollectivesStore: () => ({ currentCollectiveCanEdit: true }) }))
+vi.mock('../../stores/pages.js', () => ({
+	usePagesStore: () => ({
+		currentPage: { id: 7, title: 'Page' },
+		pageDavPath: () => '',
+	}),
+}))
+
+function deferred() {
+	let reject
+	let resolve
+	const promise = new Promise((resolvePromise, rejectPromise) => {
+		reject = rejectPromise
+		resolve = resolvePromise
+	})
+	return { promise, reject, resolve }
+}
+
+function response(fileVersion, lastmod) {
+	return {
+		data: [{
+			basename: fileVersion,
+			filename: `/versions/7/${fileVersion}`,
+			lastmod,
+			mime: 'text/markdown',
+			props: { getetag: `"${fileVersion}"`, 'version-author': 'user', 'version-label': '' },
+			size: 10,
+			type: 'file',
+		}],
+	}
+}
+
+describe('versions metadata generations', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		vi.restoreAllMocks()
+	})
+
+	it('publishes only the latest A to B to A request without redirecting stale results', async () => {
+		const firstA = deferred()
+		const b = deferred()
+		const latestA = deferred()
+		vi.mocked(davApi.getVersions)
+			.mockReturnValueOnce(firstA.promise)
+			.mockReturnValueOnce(b.promise)
+			.mockReturnValueOnce(latestA.promise)
+		const store = useVersionsStore()
+
+		const firstRequest = store.getVersions(7)
+		const secondRequest = store.getVersions(8)
+		const latestRequest = store.getVersions(7)
+		firstA.resolve(response('100', '2026-08-29T10:00:00Z'))
+		b.resolve(response('200', '2026-08-29T10:01:00Z'))
+
+		await expect(firstRequest).resolves.toEqual([expect.objectContaining({ fileVersion: '100' })])
+		await expect(secondRequest).resolves.toEqual([expect.objectContaining({ fileVersion: '200' })])
+		expect(store.versions).toEqual([])
+		latestA.resolve(response('300', '2026-08-29T10:02:00Z'))
+
+		const latestResult = await latestRequest
+		expect(latestResult).toEqual(store.versions)
+		expect(store.versions.map(({ fileVersion }) => fileVersion)).toEqual(['300'])
+		expect(store.loadedPageId).toBe(7)
+	})
+
+	it('returns the stale transport failure instead of a synthetic superseded error', async () => {
+		const stale = deferred()
+		const current = deferred()
+		vi.mocked(davApi.getVersions)
+			.mockReturnValueOnce(stale.promise)
+			.mockReturnValueOnce(current.promise)
+		const store = useVersionsStore()
+
+		const staleRequest = store.getVersions(7)
+		const currentRequest = store.getVersions(8)
+		stale.reject(new Error('stale transport failed'))
+		current.resolve(response('200', '2026-08-29T10:01:00Z'))
+
+		await expect(staleRequest).rejects.toThrow('stale transport failed')
+		await currentRequest
+		expect(store.loadedPageId).toBe(8)
+	})
+
+	it('keeps the current snapshot preparer outside reactive Pinia state', async () => {
+		const store = useVersionsStore()
+		const prepare = vi.fn().mockResolvedValue('prepared')
+		const unregister = store.registerCurrentSnapshotPreparer(prepare)
+
+		expect(Object.hasOwn(store.$state, 'currentSnapshotPreparer')).toBe(false)
+		await expect(store.prepareCurrentSnapshot()).resolves.toBe('prepared')
+		unregister()
+		await expect(store.prepareCurrentSnapshot()).resolves.toBeUndefined()
+	})
+
+	it.each([
+		['restore', 'restoreVersion'],
+		['delete', 'deleteVersion'],
+	])('handles a metadata refresh failure after %s', async (_operation, action) => {
+		vi.mocked(davApi[action]).mockResolvedValue()
+		const store = useVersionsStore()
+		vi.spyOn(store, 'getVersions').mockRejectedValue(new Error('refresh failed'))
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+		const version = { basename: 'Initial version', fileId: 7, fileVersion: '100' }
+
+		await expect(store[action](version)).resolves.toBeUndefined()
+
+		expect(davApi[action]).toHaveBeenCalledWith(7, '100')
+		expect(store.getVersions).toHaveBeenCalledWith(7)
+		expect(consoleError).toHaveBeenCalledWith('Failed to refresh page versions', expect.any(Error))
+	})
+})

--- a/src/util/versionComparison.js
+++ b/src/util/versionComparison.js
@@ -1,0 +1,351 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { isValidComparisonId } from './versionComparisonRoute.js'
+
+/* eslint-disable jsdoc/require-jsdoc */
+
+export const CURRENT_VERSION_KEY = 'current'
+
+export const VERSION_COMPARISON_LIMITS = Object.freeze({
+	maximumCachedBytes: 4_000_000,
+	maximumCachedEntries: 2,
+	maximumPreviewBytes: 16_384,
+	maximumPreviewCharacters: 4_096,
+	maximumSnapshotBytes: 2_000_000,
+})
+const LIMITS = VERSION_COMPARISON_LIMITS
+
+const CURRENT_KIND = 'current'
+const CURRENT_ROUTE_NAMESPACE = 'current'
+const HISTORICAL_KIND = 'historical'
+const HISTORICAL_ROUTE_NAMESPACE = 'version'
+
+export function selectVersionComparisonRenderer({ comparisonFactory, viewerCompare, isMobile }) {
+	return typeof comparisonFactory === 'function'
+		? 'semantic'
+		: !isMobile && typeof viewerCompare === 'function' ? 'viewer' : 'unsupported'
+}
+
+export function createVersionComparisonState(currentVersion, versions) {
+	const currentSnapshot = versions.find(({ isCurrentSnapshot }) => isCurrentSnapshot)
+		?? versions.find(({ mtime }) => mtime === currentVersion.mtime)
+	const currentMtime = currentSnapshot?.mtime ?? currentVersion.mtime
+	const currentSnapshotId = validIdentity(currentSnapshot?.fileVersion) ? currentSnapshot.fileVersion : String(Math.floor(currentMtime / 1000))
+	const currentRouteId = routeId(CURRENT_ROUTE_NAMESPACE, currentSnapshotId)
+	const current = {
+		etag: currentSnapshot ? currentSnapshot.etag : currentVersion.etag,
+		fileInfo: currentVersion,
+		key: CURRENT_VERSION_KEY,
+		kind: CURRENT_KIND,
+		mtime: currentMtime,
+		routeAliases: [CURRENT_VERSION_KEY],
+		routeId: currentRouteId,
+		size: currentSnapshot ? currentSnapshot.size : currentVersion.size,
+		url: currentSnapshot ? currentSnapshot.source ?? currentSnapshot.url : currentVersion.source ?? currentVersion.url,
+	}
+	const candidates = versions.filter((version) => version !== currentSnapshot)
+	const identityCounts = new Map()
+	for (const { fileVersion } of versions) {
+		if (validIdentity(fileVersion)) {
+			identityCounts.set(fileVersion, (identityCounts.get(fileVersion) ?? 0) + 1)
+		}
+	}
+	const duplicateIdentities = new Set([...identityCounts].filter(([, count]) => count > 1).map(([fileVersion]) => fileVersion))
+	let quarantinedCount = 0
+	const historical = candidates
+		.flatMap((version) => {
+			const fileVersion = version.fileVersion
+			if (!validIdentity(fileVersion) || duplicateIdentities.has(fileVersion)) {
+				quarantinedCount++
+				return []
+			}
+			const route = routeId(HISTORICAL_ROUTE_NAMESPACE, fileVersion)
+			const previousCurrentRouteId = routeId(CURRENT_ROUTE_NAMESPACE, fileVersion)
+			return [{
+				fileInfo: version,
+				fileVersion,
+				key: route,
+				kind: HISTORICAL_KIND,
+				label: version.label,
+				mtime: version.mtime,
+				routeAliases: previousCurrentRouteId === currentRouteId ? [] : [previousCurrentRouteId],
+				routeId: route,
+				size: version.size,
+				url: version.source ?? version.url,
+			}]
+		})
+		.toSorted(compare)
+
+	return {
+		ambiguousRouteIds: [...duplicateIdentities]
+			.flatMap((fileVersion) => [routeId(HISTORICAL_ROUTE_NAMESPACE, fileVersion), routeId(CURRENT_ROUTE_NAMESPACE, fileVersion)])
+			.filter((routeId) => routeId !== currentRouteId),
+		options: [current, ...historical.reverse()],
+		quarantinedCount,
+	}
+}
+
+function routeId(namespace, identity) {
+	return `${namespace}:${identity}`
+}
+
+function validIdentity(fileVersion) {
+	return isValidComparisonId(fileVersion)
+		&& isValidComparisonId(routeId(HISTORICAL_ROUTE_NAMESPACE, fileVersion))
+		&& isValidComparisonId(routeId(CURRENT_ROUTE_NAMESPACE, fileVersion))
+}
+
+export function normalizeVersionComparisonPair(first, second) {
+	if (!first || !second || first.key === second.key) {
+		throw new TypeError('Two distinct versions are required')
+	}
+	return compare(first, second) <= 0 ? { earlier: first, later: second } : { earlier: second, later: first }
+}
+
+function compare(first, second) {
+	if (first.mtime !== second.mtime) {
+		return first.mtime - second.mtime
+	}
+	if (first.kind !== second.kind) {
+		return first.kind === 'current' ? 1 : -1
+	}
+	return first.key < second.key ? -1 : first.key > second.key ? 1 : 0
+}
+
+export class ComparisonSnapshotError extends Error {
+	constructor(before, after) {
+		super('One or more comparison snapshots could not be loaded')
+		this.name = new.target.name
+		this.reasons = [before, after].filter(({ status }) => status === 'rejected').map(({ reason }) => reason)
+	}
+}
+
+export class ComparisonSnapshotEncodingError extends Error {
+	constructor(cause) {
+		super('Comparison snapshot contains invalid UTF-8', { cause })
+		this.name = new.target.name
+	}
+}
+
+export class ComparisonSnapshotLimitError extends Error {
+	constructor(snapshots) {
+		super('One or more comparison snapshots exceed the comparison size limit')
+		this.name = new.target.name
+		this.snapshots = snapshots
+	}
+}
+
+export function classifyComparisonSnapshotError(error) {
+	if (error.reasons.length > 0 && error.reasons.every((reason) => reason instanceof ComparisonSnapshotEncodingError)) {
+		return 'encoding'
+	}
+	const statuses = error.reasons.map((reason) => reason?.response?.status)
+	const count = error.reasons.length === 2 ? 'two' : 'one'
+	if (statuses.every((status) => status === 403)) {
+		return `permission-${count}`
+	}
+	if (statuses.every((status) => status === 404 || status === 410)) {
+		return `expired-${count}`
+	}
+	return 'network'
+}
+
+export function isVersionComparisonCancellation(error) {
+	return error?.name === 'AbortError' || error?.name === 'CanceledError' || error?.__CANCEL__ === true
+}
+
+export class CurrentSnapshotPreparationError extends Error {
+	constructor(cause) {
+		super('Current editor bytes could not be prepared', { cause })
+		this.name = new.target.name
+	}
+}
+
+export async function prepareVersionComparisonPair(pair, prepareCurrentSnapshot, resolvePair) {
+	if (pair.earlier.kind !== 'current' && pair.later.kind !== 'current') {
+		return pair
+	}
+	let prepared
+	try {
+		prepared = await prepareCurrentSnapshot()
+	} catch (error) {
+		throw new CurrentSnapshotPreparationError(error)
+	}
+	if (prepared === undefined) {
+		throw new CurrentSnapshotPreparationError()
+	}
+	return resolvePair(prepared)
+}
+
+export async function loadVersionComparisonSnapshots(pair, fetchSnapshot, signal) {
+	const unboundedSnapshots = [pair.earlier, pair.later].filter(({ size }) => !Number.isSafeInteger(size) || size < 0 || size > LIMITS.maximumSnapshotBytes)
+	if (unboundedSnapshots.length > 0) {
+		throw new ComparisonSnapshotLimitError(unboundedSnapshots)
+	}
+	const load = (snapshot) => Promise.resolve().then(() => fetchSnapshot(snapshot, signal))
+	const [before, after] = await Promise.allSettled([load(pair.earlier), load(pair.later)])
+	const limitedSnapshots = [before, after].filter(({ status, reason }) => status === 'rejected' && reason instanceof ComparisonSnapshotLimitError).flatMap(({ reason }) => reason.snapshots)
+	if (limitedSnapshots.length > 0) {
+		throw new ComparisonSnapshotLimitError(limitedSnapshots)
+	}
+	if (before.status === 'rejected' || after.status === 'rejected') {
+		throw new ComparisonSnapshotError(before, after)
+	}
+	return { afterContent: contentOf(after.value), beforeContent: contentOf(before.value) }
+}
+
+function contentOf(loaded) {
+	if (typeof loaded?.content === 'string' && Number.isSafeInteger(loaded.byteLength) && loaded.byteLength >= 0) {
+		return loaded.content
+	}
+	throw new TypeError('Snapshot loader must return measured content')
+}
+
+export async function loadBoundedSnapshotBody(snapshot, fetchSnapshot = fetch, signal) {
+	return readSnapshot(snapshot, fetchSnapshot, signal, false)
+}
+
+export async function loadBoundedSnapshotPreview(snapshot, fetchPreview = fetch, signal) {
+	return readSnapshot(snapshot, fetchPreview, signal, true)
+}
+
+async function readSnapshot(snapshot, fetchSnapshot, signal, preview) {
+	const limit = preview ? LIMITS.maximumPreviewBytes : LIMITS.maximumSnapshotBytes
+	let url = snapshot.url
+	if (snapshot.kind === CURRENT_KIND) {
+		const currentUrl = new URL(url, window.location.href)
+		currentUrl.searchParams.set('timestamp', Date.now())
+		url = currentUrl.href
+	}
+	const response = await fetchSnapshot(url, { credentials: 'same-origin', ...(preview ? { headers: { Range: `bytes=0-${limit - 1}` } } : {}), signal })
+	if (!response.ok) {
+		const error = new Error(`Snapshot request failed with status ${response.status}`)
+		error.response = { status: response.status }
+		throw error
+	}
+	const length = Number(response.headers?.get?.('content-length'))
+	if (!preview && Number.isFinite(length) && length > limit) {
+		await response.body?.cancel?.()
+		throw new ComparisonSnapshotLimitError([snapshot])
+	}
+	const reader = response.body?.getReader()
+	if (!reader) {
+		throw new Error('Snapshot response is not streamable')
+	}
+
+	const decoder = new TextDecoder('utf-8', { fatal: true })
+	let bytes = 0
+	const chunks = []
+	let truncated = preview && snapshot.size > limit
+	while (bytes < limit) {
+		const { done, value } = await reader.read()
+		if (done) {
+			break
+		}
+		const copied = Math.min(value.byteLength, limit - bytes)
+		if (!preview && copied < value.byteLength) {
+			await reader.cancel()
+			throw new ComparisonSnapshotLimitError([snapshot])
+		}
+		try {
+			chunks.push(decoder.decode(value.subarray(0, copied), { stream: true }))
+		} catch (error) {
+			await reader.cancel()
+			throw preview ? error : new ComparisonSnapshotEncodingError(error)
+		}
+		bytes += copied
+		if (preview && (copied < value.byteLength || bytes === limit)) {
+			truncated = true
+			await reader.cancel()
+			break
+		}
+	}
+	if (!preview && bytes === limit) {
+		const { done } = await reader.read()
+		if (!done) {
+			await reader.cancel()
+			throw new ComparisonSnapshotLimitError([snapshot])
+		}
+	}
+
+	try {
+		chunks.push(decoder.decode())
+	} catch (error) {
+		if (!preview) {
+			throw new ComparisonSnapshotEncodingError(error)
+		}
+		truncated = true
+	}
+	let content = chunks.join('')
+	if (!preview) {
+		return { byteLength: bytes, content }
+	}
+	const chars = Array.from(content)
+	if (chars.length > LIMITS.maximumPreviewCharacters) {
+		content = chars.slice(0, LIMITS.maximumPreviewCharacters).join('')
+		truncated = true
+	}
+	return { content, truncated }
+}
+
+export class VersionComparisonSnapshotCache {
+	constructor({ maximumBytes = LIMITS.maximumCachedBytes, maximumEntries = LIMITS.maximumCachedEntries } = {}) {
+		this.entries = new Map()
+		this.byteLimit = maximumBytes
+		this.entryLimit = maximumEntries
+		this.bytes = 0
+	}
+
+	async load(snapshot, fetchSnapshot, signal) {
+		const key = JSON.stringify([snapshot.fileInfo?.id ?? snapshot.fileInfo?.fileId ?? snapshot.fileId, snapshot.fileVersion, snapshot.fileInfo?.etag ?? snapshot.etag, snapshot.url])
+		if (snapshot.kind === 'historical' && this.entries.has(key)) {
+			const cached = this.entries.get(key)
+			this.entries.delete(key)
+			this.entries.set(key, cached)
+			return cached
+		}
+
+		const loaded = await fetchSnapshot(snapshot, signal)
+		contentOf(loaded)
+		if (snapshot.kind === 'historical' && !signal?.aborted) {
+			const bytes = loaded.byteLength
+			if (bytes <= this.byteLimit && this.entryLimit > 0) {
+				while (this.entries.size >= this.entryLimit || this.bytes + bytes > this.byteLimit) {
+					const oldestKey = this.entries.keys().next().value
+					const oldest = this.entries.get(oldestKey)
+					this.entries.delete(oldestKey)
+					this.bytes -= oldest.byteLength
+				}
+				this.entries.set(key, loaded)
+				this.bytes += bytes
+			}
+		}
+		return loaded
+	}
+
+	clear() {
+		this.entries.clear()
+		this.bytes = 0
+	}
+}
+
+export function createComparisonRequestManager() {
+	let controller = null
+	let generation = 0
+	return {
+		begin() {
+			controller?.abort()
+			controller = new AbortController()
+			return { generation: ++generation, signal: controller.signal }
+		},
+		isCurrent: (candidate) => candidate === generation,
+		cancel() {
+			controller?.abort()
+			controller = null
+			generation++
+		},
+	}
+}

--- a/src/util/versionComparisonRoute.js
+++ b/src/util/versionComparisonRoute.js
@@ -1,0 +1,142 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export const COMPARE_FROM_QUERY = 'compareFrom'
+export const COMPARE_TO_QUERY = 'compareTo'
+export const COMPARISON_HISTORY_STATE = 'collectivesVersionComparison'
+export const MAX_COMPARISON_ID_LENGTH = 255
+
+/**
+ * Replace only a route path during slug canonicalization.
+ *
+ * @param {object} route Current route
+ * @param {string} path Canonical path
+ * @return {object} Vue Router location
+ */
+export function canonicalPathRoute(route, path) {
+	return {
+		path,
+		query: route.query,
+		hash: route.hash,
+	}
+}
+
+/**
+ * Parse the two comparison-only parameters without accepting Vue Router's
+ * array representation for duplicate values.
+ *
+ * @param {object} query Decoded Vue Router query
+ * @return {{kind: 'absent'}|{kind: 'invalid'}|{kind: 'valid', from: string, to: string}}
+ */
+export function parseVersionComparisonRoute(query) {
+	const hasFrom = Object.hasOwn(query, COMPARE_FROM_QUERY)
+	const hasTo = Object.hasOwn(query, COMPARE_TO_QUERY)
+	if (!hasFrom && !hasTo) {
+		return { kind: 'absent' }
+	}
+	if (!hasFrom || !hasTo) {
+		return { kind: 'invalid' }
+	}
+
+	const from = query[COMPARE_FROM_QUERY]
+	const to = query[COMPARE_TO_QUERY]
+	if (!isValidComparisonId(from)
+		|| !isValidComparisonId(to)
+		|| from === to) {
+		return { kind: 'invalid' }
+	}
+
+	return { kind: 'valid', from, to }
+}
+
+/**
+ * Build a route location containing one comparison pair.
+ *
+ * @param {object} route Current route
+ * @param {string} from Earlier/current opaque identity
+ * @param {string} to Later/current opaque identity
+ * @return {object} Vue Router location
+ */
+export function withVersionComparisonRoute(route, from, to) {
+	return {
+		path: route.path,
+		query: {
+			...route.query,
+			[COMPARE_FROM_QUERY]: from,
+			[COMPARE_TO_QUERY]: to,
+		},
+		hash: route.hash,
+	}
+}
+
+/**
+ * Remove only comparison parameters.
+ *
+ * @param {object} route Current route
+ * @return {object} Vue Router location
+ */
+export function withoutVersionComparisonRoute(route) {
+	const query = { ...route.query }
+	delete query[COMPARE_FROM_QUERY]
+	delete query[COMPARE_TO_QUERY]
+	return {
+		path: route.path,
+		query,
+		hash: route.hash,
+	}
+}
+
+/**
+ * Resolve a URL identity against selector options without substituting.
+ *
+ * @param {object[]} options Comparison options
+ * @param {{from: string, to: string}} requested Requested pair
+ * @param {Iterable<string>} unavailableRouteIds Ambiguous identities to reject
+ * @return {{first: object|null, second: object|null, missing: string[], invalid?: 'self-pair'}}
+ */
+export function resolveVersionComparisonRoute(options, requested, unavailableRouteIds = []) {
+	const unavailable = new Set(unavailableRouteIds)
+	const byRouteId = new Map()
+	for (const option of options) {
+		for (const routeId of [option.routeId, ...(option.routeAliases ?? [])]) {
+			if (!unavailable.has(routeId)) {
+				byRouteId.set(routeId, option)
+			}
+		}
+	}
+	const first = byRouteId.get(requested.from) ?? null
+	const second = byRouteId.get(requested.to) ?? null
+	const missing = [
+		...first ? [] : [requested.from],
+		...second ? [] : [requested.to],
+	]
+	return {
+		first,
+		second,
+		missing,
+		...(first && second
+			&& (first === second || (first.key !== undefined && first.key === second.key))
+			? { invalid: 'self-pair' }
+			: {}),
+	}
+}
+
+/**
+ * Test an already-decoded opaque version identity.
+ *
+ * @param {unknown} value Candidate identity
+ * @return {value is string} Whether it is a bounded route identity
+ */
+export function isValidComparisonId(value) {
+	return typeof value === 'string'
+		&& value.length > 0
+		&& value.length <= MAX_COMPARISON_ID_LENGTH
+		&& !value.includes('/')
+		&& !value.includes('\\')
+		&& ![...value].some((character) => {
+			const codePoint = character.codePointAt(0)
+			return codePoint <= 31 || codePoint === 127
+		})
+}


### PR DESCRIPTION
Part 5 of the version-comparison work for nextcloud/collectives#599: page-version comparison inside Collectives, with the stock Viewer kept as the fallback.

- A version-pair dialog that loads both snapshots before mounting either side; pair selection from the versions sidebar
- Runtime capability detection (factory function check, not a version pin); the Viewer fallback is unchanged; explicit refusal on mobile
- A lifecycle fix so an in-flight member request can't create an editor after edit mode ended or write stale content back over a version restore; version freshness moved to the versions tab

Depends on: nextcloud/text#9050 (needs the full Text stack #9047-#9050; base main). Followed by #2700.

Full story, screenshots and the test matrix live in the #599 implementation update: https://github.com/nextcloud/collectives/issues/599#issuecomment-5295582982

AI disclosure: developed with OpenAI Codex (gpt-5.6-sol). Codex generated the implementation and tests under my direction; I reviewed, cleaned and verified the code, ran the full test and CI matrix, and signed the commits personally.
