### PR TITLE
Add shareable comparison links

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -65,8 +65,14 @@ jobs:
         include:
           - server-versions: 'stable32'
             server-major: '32'
+            semantic-e2e: '0'
+            text-app-repository: 'nextcloud/text'
+            text-app-ref: 'stable32'
           - server-versions: 'master'
             server-major: ''
+            semantic-e2e: '1'
+            text-app-repository: 'nextcloud/text'
+            text-app-ref: 'b5ff1b0ce8d38b8a8dfdd6acf7b3f36c3fa2e272'
 
     env:
       PUPPETEER_SKIP_DOWNLOAD: true
@@ -112,18 +118,13 @@ jobs:
           path: apps/password_policy
           ref: ${{ matrix.server-versions }}
 
-      - name: Register text Git reference
-        run: |
-          text_app_ref="$(if [ "${{ matrix.server-versions }}" = "master" ]; then echo -n "main"; else echo -n "${{ matrix.server-versions }}"; fi)"
-          echo "text_app_ref=$text_app_ref" >> $GITHUB_ENV
-
       - name: Checkout text app
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          repository: nextcloud/text
+          repository: ${{ matrix.text-app-repository }}
           path: apps/text
-          ref: ${{ env.text_app_ref }}
+          ref: ${{ matrix.text-app-ref }}
 
       - name: Checkout viewer app
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -164,6 +165,13 @@ jobs:
       - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
         run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
 
+      - name: Build compatible Text semantic API
+        if: matrix.semantic-e2e == '1'
+        working-directory: apps/text
+        run: |
+          npm ci
+          npm run build
+
       - name: Install node dependencies & build app
         working-directory: apps/${{ env.APP_NAME }}
         run: |
@@ -189,6 +197,11 @@ jobs:
         php-versions: ['8.1', '8.4']
         databases: ['sqlite']
         server-versions: ['stable32', 'master']
+        include:
+          - server-versions: 'stable32'
+            semantic-e2e: '0'
+          - server-versions: 'master'
+            semantic-e2e: '1'
         exclude:
           - php-versions: '8.1'
             server-versions: 'stable32'
@@ -276,6 +289,7 @@ jobs:
           npx cypress run --record false --config defaultCommandTimeout=20000,video=false
         env:
           CYPRESS_ncVersion: ${{ matrix.server-versions }}
+          CYPRESS_semanticE2E: ${{ matrix.semantic-e2e }}
           # `SPLIT` needs to match count of `containers` in the matrix above
           SPLIT: 4
           SPLIT_INDEX: ${{ env.container_index }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,6 +20,17 @@ jobs:
             server-branch: ['stable32', 'master']
             shardIndex: [1, 2, 3, 4]
             shardTotal: [4]
+            include:
+              - server-branch: 'stable32'
+                project-args: '--project=chromium --project=comparison-viewer-chromium'
+                semantic-e2e: '0'
+                text-repository: 'nextcloud/text'
+                text-ref: 'stable32'
+              - server-branch: 'master'
+                project-args: '--project=chromium --project=comparison-chromium'
+                semantic-e2e: '1'
+                text-repository: 'nextcloud/text'
+                text-ref: 'b5ff1b0ce8d38b8a8dfdd6acf7b3f36c3fa2e272'
     steps:
       - name: Checkout app
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -56,19 +67,24 @@ jobs:
           npm run build --if-present
 
       - name: Install Playwright Browsers
-        run: npx playwright install chromium --only-shell
+        run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        run: npx playwright test ${{ matrix.project-args }} --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
+          COLLECTIVES_SEMANTIC_E2E: ${{ matrix.semantic-e2e }}
           PLAYWRIGHT_NC_SERVER_BRANCH: ${{ matrix.server-branch }}
+          PLAYWRIGHT_TEXT_REPOSITORY: ${{ matrix.text-repository }}
+          PLAYWRIGHT_TEXT_REF: ${{ matrix.text-ref }}
 
       - name: Upload results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: playwright-report_${{ matrix.server-branch }}_shard${{ matrix.shardIndex }}
-          path: test-results/
+          path: |
+            test-results/
+            blob-report/
           retention-days: 7
 
   summary:

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ css/*
 
 # Cypress test artifacts
 cypress/downloads/
+cypress/results/
 cypress/screenshots/
 cypress/videos/
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,6 +8,8 @@ import { defineConfig } from 'cypress'
 import cypressSplit from 'cypress-split'
 import vitePreprocessor from 'cypress-vite'
 
+const SEMANTIC_E2E = process.env.CYPRESS_semanticE2E === '1'
+
 export default defineConfig({
 	viewportWidth: 1280,
 	viewportHeight: 900,
@@ -20,6 +22,9 @@ export default defineConfig({
 
 		baseUrl: 'http://localhost:8081/index.php/',
 		specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
+	},
+	expose: {
+		semanticE2E: SEMANTIC_E2E,
 	},
 	defaultCommandTimeout: 7000,
 	retries: {

--- a/cypress/e2e/page-versions-components.cy.js
+++ b/cypress/e2e/page-versions-components.cy.js
@@ -6,6 +6,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { createApp, h, nextTick, ref } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
+import PageSidebar from '../../src/components/PageSidebar.vue'
 import SidebarTabVersions from '../../src/components/PageSidebar/SidebarTabVersions.vue'
 import VersionComparisonDialog from '../../src/components/PageSidebar/VersionComparisonDialog.vue'
 import { useCollectivesStore } from '../../src/stores/collectives.js'
@@ -13,6 +14,19 @@ import { usePagesStore } from '../../src/stores/pages.js'
 import { useRootStore } from '../../src/stores/root.js'
 import { useVersionsStore } from '../../src/stores/versions.js'
 import { VERSION_COMPARISON_LIMITS } from '../../src/util/versionComparison.js'
+import {
+	COMPARISON_WARNING_STATE,
+	rejectedVersionComparisonRoute,
+} from '../../src/util/versionComparisonRoute.js'
+
+function nextNavigation(router) {
+	return new Promise((resolve) => {
+		const remove = router.afterEach(() => {
+			remove()
+			resolve()
+		})
+	})
+}
 
 async function waitFor(condition, message = 'Expected component state was not reached') {
 	for (let attempt = 0; attempt < 100; attempt++) {
@@ -22,6 +36,34 @@ async function waitFor(condition, message = 'Expected component state was not re
 		await new Promise((resolve) => setTimeout(resolve))
 	}
 	throw new Error(typeof message === 'function' ? message() : message)
+}
+
+async function mountPageSidebar() {
+	const pinia = createPinia()
+	setActivePinia(pinia)
+	const rootStore = useRootStore()
+	const collectivesStore = useCollectivesStore()
+	const pagesStore = usePagesStore()
+	rootStore.$patch({ collectiveId: 1, pageId: 7, showingSidebar: false })
+	collectivesStore.collectivesState = [{ id: 1, name: 'Atlas', canEdit: true, canShare: true, isPageShare: false }]
+	pagesStore.allPages = {
+		1: [{ id: 7, parentId: 0, title: 'Page', fileName: 'Readme.md', timestamp: 1 }],
+	}
+
+	window.history.replaceState({}, '', '/Atlas/Page?fileId=42&view=grid#rollout')
+	const router = createRouter({
+		history: createWebHistory(),
+		routes: [{ path: '/:pathMatch(.*)*', component: { render: () => null } }],
+	})
+	const element = document.createElement('div')
+	document.body.append(element)
+	const app = createApp({ render: () => h(PageSidebar) })
+	app.use(pinia)
+	app.use(router)
+	app.mount(element)
+	await router.isReady()
+	await nextTick()
+	return { app, element, router }
 }
 
 function deferred() {
@@ -113,6 +155,46 @@ function comparisonFixture(size = 10) {
 }
 
 describe('Mounted page version components', () => {
+	it('rejects an invalid comparison without corrupting real router history', () => {
+		cy.then(async () => {
+			const { app, element, router } = await mountPageSidebar()
+			const invalid = {
+				path: '/Atlas/Page',
+				query: { fileId: '42', view: 'grid', compareFrom: 'broken' },
+				hash: '#rollout',
+			}
+			const rejected = rejectedVersionComparisonRoute(invalid, {
+				back: '/stale-back',
+				current: '/Atlas/Page?fileId=42&view=grid&compareFrom=broken#rollout',
+				forward: '/stale-forward',
+				position: 99,
+			})
+			expect(rejected.state).to.deep.equal({
+				[COMPARISON_WARNING_STATE]: JSON.stringify(['broken', undefined]),
+			})
+
+			await router.push(invalid)
+			await waitFor(() => router.currentRoute.value.query.compareFrom === undefined)
+			expect(router.currentRoute.value.fullPath).to.equal('/Atlas/Page?fileId=42&view=grid#rollout')
+			expect(window.history.state[COMPARISON_WARNING_STATE]).to.equal(JSON.stringify(['broken', undefined]))
+
+			await router.push('/Atlas/Next?step=1#next')
+			const back = nextNavigation(router)
+			router.back()
+			await back
+			expect(router.currentRoute.value.fullPath).to.equal('/Atlas/Page?fileId=42&view=grid#rollout')
+
+			const forward = nextNavigation(router)
+			router.forward()
+			await forward
+			expect(router.currentRoute.value.fullPath).to.equal('/Atlas/Next?step=1#next')
+			expect(window.history.state).to.include.keys('back', 'current', 'forward', 'position')
+
+			app.unmount()
+			element.remove()
+		})
+	})
+
 	it('keeps the active page loading while a stale page request completes', () => {
 		cy.then(async () => {
 			const consoleError = Cypress.sinon.spy(console, 'error')
@@ -175,6 +257,28 @@ describe('Mounted page version components', () => {
 				mounted.element.remove()
 				fetchSnapshot.restore()
 			}
+		})
+	})
+
+	it('shows routed Viewer preparation failure before any snapshot read', () => {
+		cy.then(async () => {
+			const fixture = comparisonFixture()
+			window.OCA ??= {}
+			window.OCA.Text = {}
+			window.OCA.Viewer = { compare: Cypress.sinon.stub() }
+			const fetchSnapshot = Cypress.sinon.stub(window, 'fetch')
+			const mounted = await mountVersionComparisonDialog(fixture.currentVersion, fixture.versions)
+
+			await mounted.component.value.openRoutedPair({ from: 'version:1', to: 'current:3' })
+			await waitFor(() => document.querySelector('.version-comparison-dialog [role="alert"]'))
+			expect(document.querySelector('.version-comparison-dialog [role="alert"]').textContent)
+				.to.contain('Could not save current changes before comparison. Please try again.')
+			expect(fetchSnapshot).not.to.have.been.called
+			expect(window.OCA.Viewer.compare).not.to.have.been.called
+
+			mounted.app.unmount()
+			mounted.element.remove()
+			fetchSnapshot.restore()
 		})
 	})
 
@@ -267,6 +371,27 @@ describe('Mounted page version components', () => {
 				mounted.app.unmount()
 				mounted.element.remove()
 				fetchSnapshot.restore()
+			}
+		})
+	})
+
+	it('shows one informational message for current snapshot aliases', () => {
+		cy.then(async () => {
+			const fixture = comparisonFixture()
+			window.OCA ??= {}
+			window.OCA.Text = {}
+			const mounted = await mountVersionComparisonDialog(fixture.currentVersion, fixture.versions)
+
+			try {
+				await mounted.component.value.openRoutedPair({ from: 'current:3', to: 'current' })
+				await waitFor(() => document.querySelector('.modal-wrapper [role="status"]'))
+				expect(document.querySelectorAll('.modal-wrapper [role="status"]')).to.have.length(1)
+				expect(document.querySelector('.modal-wrapper [role="status"]').textContent).to.contain('Select two different versions.')
+				expect(document.querySelectorAll('.modal-wrapper [role="alert"]')).to.have.length(0)
+				expect([...document.querySelectorAll('.modal-wrapper button')].some(({ textContent }) => textContent.includes('Retry'))).to.equal(false)
+			} finally {
+				mounted.app.unmount()
+				mounted.element.remove()
 			}
 		})
 	})

--- a/cypress/e2e/page-versions.spec.js
+++ b/cypress/e2e/page-versions.spec.js
@@ -3,36 +3,567 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-describe('Page versions', function() {
+import { createVersionComparisonAccount } from '../../playwright/support/helpers/versionComparisonFixtures.ts'
+import { createCollectiveShare, deleteShare } from '../../src/apis/collectives/shares.js'
+import { listVersions } from '../../src/apis/dav/davRequests.js'
+
+const HISTORICAL_SNAPSHOT_URL = /\/remote\.php\/dav\/versions\/(?!.*[?&]timestamp=\d{13}(?:&|$))/
+const CURRENT_SNAPSHOT_URL = /\/remote\.php\/dav\/versions\/.*[?&]timestamp=\d{13}(?:&|$)/
+const SEMANTIC_E2E = Cypress.expose('semanticE2E') === true || Cypress.expose('semanticE2E') === '1'
+const describeSemantic = SEMANTIC_E2E ? describe : () => {}
+const RUN_NAMESPACE = crypto.randomUUID().slice(0, 8)
+const fixtureName = (name) => `c599-e2e-${RUN_NAMESPACE}-${name}`
+const COLLECTIVE_NAME = fixtureName('versions')
+const PAGE_NAME = fixtureName('page')
+const FRESH_PAGE_NAME = fixtureName('fresh-page')
+const STABLE_PAGE_NAME = fixtureName('stable-link-page')
+const REMOVED_VERSION_PAGE_NAME = fixtureName('removed-version-page')
+const SINGLE_REMOVED_VERSION_PAGE_NAME = fixtureName('single-removed-version-page')
+const VIEWER_FALLBACK_PAGE_NAME = fixtureName('viewer-fallback-page')
+const RAPID_COMPARE_PAGE_NAME = fixtureName('rapid-compare-page')
+const RAPID_GENERATION_PAGE_NAME = fixtureName('rapid-generation-page')
+const RESTORE_AUTH_PAGE_NAME = fixtureName('restore-auth-page')
+const OWNER = createVersionComparisonAccount('owner', `cypress-${RUN_NAMESPACE}`, () => crypto.randomUUID())
+const READER = createVersionComparisonAccount('reader', `cypress-${RUN_NAMESPACE}`, () => crypto.randomUUID())
+const READER_USER = READER.userId
+const OCS_HEADERS = { 'OCS-APIRequest': 'true' }
+
+function provisioningApiUrl(userId = '') {
+	const baseUrl = Cypress.config('baseUrl').replace(/\/index\.php\/?$/, '')
+	const userPath = userId ? `/${encodeURIComponent(userId)}` : ''
+	return `${baseUrl}/ocs/v2.php/cloud/users${userPath}`
+}
+
+function provisionTestUser(user) {
+	return deleteTestUser(user, false).then(() => cy.request({
+		method: 'POST',
+		url: provisioningApiUrl(),
+		auth: { username: 'admin', password: 'admin' },
+		headers: OCS_HEADERS,
+		body: {
+			userid: user.userId,
+			password: user.password,
+			language: user.language,
+		},
+		form: true,
+		log: false,
+	}))
+}
+
+function deleteTestUser(user, failOnStatusCode = true) {
+	return cy.clearCookies({ log: false }).then(() => cy.request({
+		method: 'DELETE',
+		url: provisioningApiUrl(user.userId),
+		auth: { username: 'admin', password: 'admin' },
+		headers: OCS_HEADERS,
+		failOnStatusCode,
+		log: false,
+	}))
+}
+
+function logoutAndClearSession() {
+	cy.logout()
+	return cy.then(() => Cypress.session.clearAllSavedSessions())
+}
+
+function authenticatedDavRequest(user, options) {
+	return cy.clearCookies({ log: false }).then(() => cy.request({
+		...options,
+		auth: { username: user.userId, password: user.password },
+		log: false,
+	}))
+}
+
+function versionEntries(body) {
+	return (body.match(/<d:response>[\s\S]*?<\/d:response>/g) ?? [])
+		.filter((entry) => entry.includes('<d:getcontenttype>text/markdown</d:getcontenttype>'))
+		.map((entry) => ({
+			href: entry.match(/<d:href>([^<]+)<\/d:href>/)?.[1],
+			lastModified: Date.parse(entry.match(/<d:getlastmodified>([^<]+)<\/d:getlastmodified>/)?.[1]),
+		}))
+		.filter(({ href, lastModified }) => href && Number.isFinite(lastModified))
+		.toSorted((first, second) => first.lastModified - second.lastModified)
+}
+
+function listDavVersions(user, url) {
+	return authenticatedDavRequest(user, {
+		method: 'PROPFIND',
+		url,
+		headers: { Depth: '1', 'Content-Type': 'application/xml' },
+		body: listVersions(),
+	})
+}
+
+function selectVersionAt(selectorIndex, optionIndex, options = {}) {
+	cy.get('.version-comparison-dialog select').eq(selectorIndex).then(($select) => {
+		cy.wrap($select).select($select.find('option').eq(optionIndex).val(), options)
+	})
+}
+
+function selectVersionFromEnd(selectorIndex, offset, options = {}) {
+	cy.get('.version-comparison-dialog select').eq(selectorIndex).then(($select) => {
+		const optionIndex = $select.find('option').length - offset
+		cy.wrap($select).select($select.find('option').eq(optionIndex).val(), options)
+	})
+}
+
+function getVersionComparisonModal() {
+	return cy.get('.modal-container').filter(':has(.version-comparison-dialog)')
+}
+
+function appendQuarantinedVersionEntries(body) {
+	const entries = body.match(/<d:response>[\s\S]*?<\/d:response>/g) ?? []
+	const historicalEntries = entries
+		.filter((entry) => entry.includes('<d:getcontenttype>text/markdown</d:getcontenttype>'))
+		.map((entry) => ({
+			entry,
+			href: entry.match(/<d:href>([^<]+)<\/d:href>/)?.[1],
+			lastModified: Date.parse(entry.match(/<d:getlastmodified>([^<]+)<\/d:getlastmodified>/)?.[1]),
+		}))
+		.filter(({ href, lastModified }) => href && Number.isFinite(lastModified))
+		.toSorted((first, second) => first.lastModified - second.lastModified)
+	const { entry: duplicatedEntry, href } = historicalEntries[0] ?? {}
+	if (!duplicatedEntry || !href) {
+		throw new Error('Could not find a historical DAV version to duplicate')
+	}
+	const rawVersionId = href.split('/').at(-1)
+	const duplicateVersionId = decodeURIComponent(rawVersionId)
+	const encodedFirstCharacter = `%${rawVersionId.charCodeAt(0).toString(16).toUpperCase()}`
+	const duplicateEntry = duplicatedEntry.replace(
+		href,
+		`${href.slice(0, -rawVersionId.length)}${encodedFirstCharacter}${rawVersionId.slice(1)}`,
+	)
+	const reservedEntry = duplicatedEntry.replace(
+		/(<d:href>[^<]*\/)[^/<]+(<\/d:href>)/,
+		'$1current$2',
+	)
+	const mutatedBody = body.replace(
+		/(<\/(?:d:)?multistatus>)/i,
+		`${duplicateEntry}${reservedEntry}$1`,
+	)
+	if (mutatedBody === body) {
+		throw new Error('Could not append quarantined DAV versions')
+	}
+	return {
+		body: mutatedBody,
+		duplicateVersionId,
+	}
+}
+
+function closeSemanticComparison() {
+	getVersionComparisonModal()
+		.parents('.modal-mask')
+		.should('have.css', 'opacity', '1')
+	getVersionComparisonModal().find('button.modal-container__close').click()
+	cy.get('.version-comparison-dialog').should('not.exist')
+}
+
+function openVersionsSidebar() {
+	cy.get('body').should(($body) => {
+		expect(
+			$body.find('#tab-button-versions:visible, button.page-sidebar-button:visible').length,
+			'visible Versions tab or sidebar button',
+		).to.be.greaterThan(0)
+	}).then(($body) => {
+		if (!$body.find('#tab-button-versions:visible').length) {
+			cy.get('button.page-sidebar-button:visible').click()
+		}
+	})
+	cy.get('#tab-button-versions').should('be.visible').click()
+}
+
+function openInitialCurrentSemanticComparison() {
+	cy.get('.app-sidebar-tabs__content .version-list .list-item')
+		.eq(3)
+		.find('.list-item-content__actions')
+		.click()
+	cy.clickMenuButton('Compare with current version')
+	cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+}
+
+function insertEditorContent(content, appendParagraph = false) {
+	cy.getEditorContent(true).should('be.visible')
+	cy.window({ log: false }).then((window) => {
+		const components = window.OCA?.Text?.editorComponents
+		if (!components) {
+			throw new Error('Text editor components are unavailable')
+		}
+		const component = Array.from(components)
+			.find((candidate) => candidate.active)
+		if (!component) {
+			throw new Error('No active Text editor component is available')
+		}
+		cy.wrap(component.whenSynced, { log: false }).then(() => {
+			const command = appendParagraph
+				? component.editor.chain().focus('end').insertContent({
+						type: 'paragraph',
+						content: [{ type: 'text', text: content }],
+					}).run()
+				: component.editor.commands.insertContent(content)
+			expect(command, 'editor content command').to.equal(true)
+		})
+	})
+}
+
+function assertMeasuredComparisonLayout(expectedMode) {
+	cy.get('.version-comparison-dialog .text-comparison').should(($comparison) => {
+		const width = $comparison[0].getBoundingClientRect().width
+		const measuredMode = width >= 760 ? 'paired' : 'single'
+		expect(width, 'measured comparison container width').to.be.greaterThan(0)
+		expect($comparison[0].scrollWidth, 'comparison horizontal overflow')
+			.to.be.at.most($comparison[0].clientWidth + 1)
+		expect($comparison.hasClass(`text-comparison--${measuredMode}`), `layout for ${width}px container`).to.equal(true)
+		expect(measuredMode, `expected mode for ${width}px container`).to.equal(expectedMode)
+	})
+}
+
+let publicSharePath = ''
+let publicShare = null
+
+function closeViewerComparison() {
+	cy.window().then((window) => window.OCA.Viewer.close())
+	cy.get('#viewer').should('not.exist')
+}
+
+const ROLLBACK_SECTION = `## Rollback ownership
+
+Maya owns rollback approval.
+
+Escalate checkout regressions to the release commander.`
+
+const EVIDENCE_SECTION = `## Audit archive
+
+Each decision receives a durable timestamp.
+
+Signed records remain with the project history.`
+
+const READINESS_SECTION = `## Regional readiness
+
+All checkout regions use the same health gate.
+
+Regional owners confirm capacity before launch.`
+
+const INITIAL_CONTENT = `---
+release: atlas-2.4
+status: draft
+owner: Maya Chen
+---
+
+# Atlas 2.4 release plan
+
+> Draft rollout window: Thursday, 18 July.
+
+## Objective
+
+Ship **Atlas 2.4** to a 10% pilot cohort while protecting checkout availability.
+
+Release owner: Maya Chen.
+
+Status cadence: every 15 minutes.
+
+All named owners have acknowledged the window.
+
+Status dashboard is available to the release team.
+
+The dashboard is reviewed before each traffic increase.
+
+Keep the [incident channel](https://chat.example.test/atlas) staffed during rollout.
+
+The incident commander acknowledges every escalation.
+
+Follow the [operator runbook](https://docs.example.test/atlas/draft).
+
+The release commander validates every operator handoff.
+
+Customer update is ready for review.
+
+Checkout remains available throughout the launch.
+
+${ROLLBACK_SECTION}
+
+${EVIDENCE_SECTION}
+
+${READINESS_SECTION}
+
+## Decision protocol
+
+The release commander records every traffic decision.
+
+## Rollout checklist
+
+- [x] Freeze schema changes
+- [ ] Confirm support coverage
+- [ ] Enable the pilot cohort
+
+## Schedule
+
+| Stage | Owner | Traffic |
+| --- | --- | --- |
+| Pilot | Maya | 10% |
+| General availability | Lee | Pending |
+
+Checkout remains available throughout the launch.
+
+::: info
+The checkout health gate must remain green for fifteen minutes.
+:::
+
+Health checks are sampled from every checkout region.
+
+<details>
+<summary>Escalation contacts</summary>
+Maya leads release decisions; Noor leads rollback execution.
+</details>
+
+## Guardrail
+
+\`\`\`js
+const rolloutPercent = 10
+const rollbackThreshold = 0.02
+\`\`\`
+
+Rollback if error rate exceeds \`2%\`.
+
+The rollout decision is recorded in the release evidence.[^atlas-draft]
+
+Visual evidence follows the signed release decision.
+
+![Atlas rollout dashboard](/core/img/logo/logo.svg)
+
+The image checksum is recorded separately.
+
+[^atlas-draft]: Draft approval requires checkout error rate below two percent.
+`
+
+const SECOND_CONTENT = INITIAL_CONTENT
+	.replace('# Atlas 2.4 release plan', '# Atlas 2.4 release plan #')
+	.replace('Status dashboard is available to the release team.', 'Status dashboard is available to the release team. ')
+	.replaceAll('\n', '\r\n')
+	.replace(/\r\n$/, '')
+
+const REVIEWED_CONTENT = INITIAL_CONTENT
+	.replace('status: draft', 'status: reviewed')
+	.replace('Draft rollout window', 'Reviewed rollout window')
+	.replace('10% pilot cohort', '15% reviewed cohort')
+	.replace('- [ ] Confirm support coverage', '- [x] Confirm support coverage')
+	.replace('| Pilot | Maya | 10% |', '| Pilot | Maya | 15% |')
+	.replace('const rolloutPercent = 10', 'const rolloutPercent = 15')
+
+const CURRENT_CONTENT = `---
+release: atlas-2.4
+status: launch-ready
+owner: Maya Chen and Noor Patel
+---
+
+# Atlas 2.4 launch plan
+
+> Approved rollout window: Friday, 19 July.
+
+## Objective
+
+Ship **Atlas 2.4** through a 25% progressive rollout while protecting checkout availability.
+
+Release owner: **Maya Chen**.
+
+Status cadence: *every 15 minutes*.
+
+All named owners have acknowledged the window.
+
+[Status dashboard](https://status.example.test/atlas) is available to the release team.
+
+The dashboard is reviewed before each traffic increase.
+
+Keep the incident channel staffed during rollout.
+
+The incident commander acknowledges every escalation.
+
+Follow the [operator runbook](https://docs.example.test/atlas/2.4).
+
+The release commander validates every operator handoff.
+
+Customer **launch update** is ready for publication.
+
+Checkout remains available throughout the launch.
+
+${EVIDENCE_SECTION}
+
+${READINESS_SECTION}
+
+${ROLLBACK_SECTION}
+
+## Decision protocol
+
+The release commander records every traffic decision.
+
+## Rollout checklist
+
+- [x] Freeze schema changes
+- [x] Confirm support coverage
+- [x] Enable the pilot cohort
+- [ ] Publish the customer update
+
+## Schedule
+
+| Stage | Owner | Traffic |
+| --- | --- | --- |
+| Canary | Maya | 25% |
+| General availability | Lee | 100% |
+| Rollback rehearsal | Noor | Complete |
+
+Checkout remains available throughout the launch.
+
+::: warn
+The checkout health gate must remain green for fifteen minutes.
+:::
+
+Health checks are sampled from every checkout region.
+
+<details>
+<summary>Escalation contacts</summary>
+Maya leads release decisions; Noor executes rollback and Lee owns customer communication.
+</details>
+
+## Guardrail
+
+\`\`\`js
+const rolloutPercent = 25
+const rollbackThreshold = 0.015
+\`\`\`
+
+Rollback if error rate exceeds \`1.5%\` for five minutes.
+
+The rollout decision is recorded in the release evidence.[^atlas-launch]
+
+Visual evidence follows the signed release decision.
+
+![Atlas launch control room](/core/img/logo/logo.svg)
+
+The image checksum is recorded separately.
+
+[^atlas-launch]: Launch approval requires checkout error rate below one and a half percent for five minutes.
+`
+
+const INITIAL_PHRASE = '10% pilot cohort'
+const REVIEWED_PHRASE = '15% reviewed cohort'
+const CURRENT_PHRASE = '25% progressive rollout'
+const STABLE_LINK_CURRENT = 'Stable comparison snapshot'
+const STABLE_LINK_UPDATED = 'Later page update'
+const RAPID_FIRST_PHRASE = 'Rapid comparison first save'
+const RAPID_SECOND_PHRASE = 'Rapid comparison second save'
+
+describeSemantic('Page versions semantic comparison', function() {
 	before(function() {
-		cy.loginAs('bob')
-		cy.deleteAndSeedCollective('Versions Collective')
-			.seedPage('Page', '', 'Readme.md')
+		provisionTestUser(OWNER)
+		provisionTestUser(READER)
+		cy.login(OWNER)
+		cy.deleteAndSeedCollective(COLLECTIVE_NAME)
+			.seedPage(PAGE_NAME, '', 'Readme.md')
+		cy.getCollectives()
+			.findBy({ name: COLLECTIVE_NAME })
+			.seedPage(FRESH_PAGE_NAME, '', 'Readme.md')
+		cy.getCollectives()
+			.findBy({ name: COLLECTIVE_NAME })
+			.seedPage(STABLE_PAGE_NAME, '', 'Readme.md')
+
+		cy.getCollectives()
+			.findBy({ name: COLLECTIVE_NAME })
+			.seedPage(REMOVED_VERSION_PAGE_NAME, '', 'Readme.md')
+		cy.getCollectives()
+			.findBy({ name: COLLECTIVE_NAME })
+			.seedPage(SINGLE_REMOVED_VERSION_PAGE_NAME, '', 'Readme.md')
+		cy.getCollectives()
+			.findBy({ name: COLLECTIVE_NAME })
+			.seedPage(VIEWER_FALLBACK_PAGE_NAME, '', 'Readme.md')
+		cy.getCollectives()
+			.findBy({ name: COLLECTIVE_NAME })
+			.seedPage(RAPID_COMPARE_PAGE_NAME, '', 'Readme.md')
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${RAPID_COMPARE_PAGE_NAME}.md`, RAPID_FIRST_PHRASE)
+			.wait(1100)
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${RAPID_COMPARE_PAGE_NAME}.md`, RAPID_SECOND_PHRASE)
+		cy.getCollectives()
+			.findBy({ name: COLLECTIVE_NAME })
+			.seedPage(RAPID_GENERATION_PAGE_NAME, '', 'Readme.md')
+		cy.getCollectives()
+			.findBy({ name: COLLECTIVE_NAME })
+			.seedPage(RESTORE_AUTH_PAGE_NAME, '', 'Readme.md')
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${RESTORE_AUTH_PAGE_NAME}.md`, INITIAL_CONTENT)
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.wait(1100)
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${RESTORE_AUTH_PAGE_NAME}.md`, CURRENT_CONTENT)
 
 		// A new version will not be created if the changes occur within less than one second of each other.
 		// eslint-disable-next-line cypress/no-unnecessary-waiting
-		cy.seedPageContent('Versions Collective/Page.md', 'v1')
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${PAGE_NAME}.md`, INITIAL_CONTENT)
 			.wait(1100)
 		// eslint-disable-next-line cypress/no-unnecessary-waiting
-		cy.seedPageContent('Versions Collective/Page.md', 'v2')
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${PAGE_NAME}.md`, SECOND_CONTENT)
 			.wait(1100)
 		// eslint-disable-next-line cypress/no-unnecessary-waiting
-		cy.seedPageContent('Versions Collective/Page.md', 'v3')
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${PAGE_NAME}.md`, REVIEWED_CONTENT)
 			.wait(1100)
-		cy.seedPageContent('Versions Collective/Page.md', 'v4')
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${PAGE_NAME}.md`, CURRENT_CONTENT)
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${STABLE_PAGE_NAME}.md`, 'Stable comparison baseline')
+			.wait(1100)
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${STABLE_PAGE_NAME}.md`, STABLE_LINK_CURRENT)
+
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${REMOVED_VERSION_PAGE_NAME}.md`, INITIAL_CONTENT)
+			.wait(1100)
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${REMOVED_VERSION_PAGE_NAME}.md`, CURRENT_CONTENT)
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${SINGLE_REMOVED_VERSION_PAGE_NAME}.md`, INITIAL_CONTENT)
+			.wait(1100)
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${SINGLE_REMOVED_VERSION_PAGE_NAME}.md`, CURRENT_CONTENT)
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${VIEWER_FALLBACK_PAGE_NAME}.md`, INITIAL_CONTENT)
+			.wait(1100)
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${VIEWER_FALLBACK_PAGE_NAME}.md`, CURRENT_CONTENT)
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${RAPID_GENERATION_PAGE_NAME}.md`, INITIAL_CONTENT)
+			.wait(1100)
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${RAPID_GENERATION_PAGE_NAME}.md`, REVIEWED_CONTENT)
+			.wait(1100)
+		cy.seedPageContent(`${COLLECTIVE_NAME}/${RAPID_GENERATION_PAGE_NAME}.md`, CURRENT_CONTENT)
+		cy.getCollectives()
+			.findBy({ name: COLLECTIVE_NAME })
+			.then(({ circleId }) => cy.wrap({ id: circleId })
+				.circleAddMember(READER_USER)
+				.circleSetMemberLevel(4))
+		cy.seedCollectivePermissions(COLLECTIVE_NAME, 'edit', 8)
+		cy.getCollectives()
+			.findBy({ name: COLLECTIVE_NAME })
+			.then(({ id }) => createCollectiveShare(id).then(({ data }) => {
+				const { token } = data.ocs.data
+				publicShare = { collectiveId: id, pageId: 0, token }
+				publicSharePath = `/apps/collectives/p/${token}/${COLLECTIVE_NAME}/${PAGE_NAME}`
+			}))
+	})
+
+	after(function() {
+		cy.login(OWNER)
+		cy.then(() => publicShare && deleteShare(publicShare))
+		cy.deleteCollective(COLLECTIVE_NAME)
+		deleteTestUser(READER)
+		deleteTestUser(OWNER)
 	})
 
 	beforeEach(function() {
-		cy.loginAs('bob')
-		cy.visit('/apps/collectives/Versions Collective/Page')
+		cy.login(OWNER)
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}`)
+		cy.window().should((window) => {
+			expect(typeof window.OCA?.Text?.createMarkdownContentComparison, 'Text semantic comparison factory is available')
+				.to.equal('function')
+		})
 
-		cy.get('button.page-sidebar-button').click()
-		cy.get('#tab-button-versions').click()
+		openVersionsSidebar()
 	})
 
 	it('Lists versions', function() {
 		cy.getReadOnlyEditor()
-			.should('contain', 'v4')
+			.should('contain', CURRENT_PHRASE)
 
 		cy.get('.app-sidebar-tabs__content .version-list .list-item')
 			.should('have.length', 4)
@@ -44,6 +575,23 @@ describe('Page versions', function() {
 			.should('contain', 'Initial version')
 	})
 
+	it('Hides comparison when no historical version exists', function() {
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${FRESH_PAGE_NAME}`)
+		cy.get('#tab-button-versions').click()
+		cy.get('.app-sidebar-tabs__content .version-list .list-item')
+			.should('have.length', 1)
+		cy.contains('button', 'Compare versions…').should('not.exist')
+	})
+
+	it('distinguishes every version selector option down to the second', function() {
+		cy.contains('button', 'Compare versions…').click()
+		cy.get('.version-comparison-dialog select').each(($select) => {
+			const labels = [...$select[0].options].map(({ text }) => text.trim())
+			expect(new Set(labels).size).to.equal(labels.length)
+			expect(labels.every((label) => /\d{1,2}:\d{2}:\d{2}/.test(label))).to.equal(true)
+		})
+	})
+
 	it('Open initial and current version', function() {
 		cy.get('.app-sidebar-tabs__content .version-list .list-item')
 			.contains('Initial version')
@@ -53,7 +601,7 @@ describe('Page versions', function() {
 			.find('.title-version')
 			.should('be.visible')
 		cy.getReadOnlyEditor()
-			.should('contain', 'v1')
+			.should('contain', INITIAL_PHRASE)
 
 		cy.get('.app-sidebar-tabs__content .version-list .list-item')
 			.contains('Current version')
@@ -63,7 +611,7 @@ describe('Page versions', function() {
 			.find('.title-version')
 			.should('not.exist')
 		cy.getReadOnlyEditor()
-			.should('contain', 'v4')
+			.should('contain', CURRENT_PHRASE)
 	})
 
 	it('Add label to version', function() {
@@ -81,7 +629,30 @@ describe('Page versions', function() {
 			.should('contain', 'v3')
 	})
 
-	it('Compare initial and current version', function() {
+	it('C01 compares a historical snapshot before the current snapshot', function() {
+		let beforeScrollTop
+		let afterScrollTop
+		const unexpectedFailures = []
+		cy.window().then((window) => {
+			window.addEventListener('error', ({ message }) => {
+				if (!message.includes('ResizeObserver')) {
+					unexpectedFailures.push(`page error: ${message}`)
+				}
+			})
+			window.addEventListener('unhandledrejection', ({ reason }) => unexpectedFailures.push(`unhandled rejection: ${String(reason)}`))
+			cy.stub(window.console, 'error').callsFake((...args) => unexpectedFailures.push(`console error: ${args.join(' ')}`))
+		})
+		const recordFailedResponse = (request) => request.continue((response) => {
+			response.headers['cache-control'] = 'no-store'
+			if (response.statusCode >= 400) {
+				unexpectedFailures.push(`${response.statusCode} ${request.url}`)
+			}
+		})
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL, recordFailedResponse)
+			.as('historicalSnapshotRequest')
+		cy.intercept('GET', CURRENT_SNAPSHOT_URL, recordFailedResponse)
+			.as('currentSnapshotRequest')
+		cy.get('.search-dialog-container').should('not.exist')
 		cy.get('.app-sidebar-tabs__content .version-list .list-item')
 			.eq(3)
 			.find('.list-item-content__actions')
@@ -89,16 +660,1011 @@ describe('Page versions', function() {
 
 		cy.clickMenuButton('Compare with current version')
 
-		cy.get('#viewer .text-editor')
-			.should('contain', 'v1')
-		cy.get('#viewer .text-editor')
-			.should('contain', 'v4')
+		getVersionComparisonModal()
+			.parent()
+			.should('have.class', 'modal-wrapper--full')
+		getVersionComparisonModal().find('button[type="submit"]').should('not.exist')
+		getVersionComparisonModal().contains('button', 'Copy comparison link').should('be.visible')
+		cy.get('.version-comparison-dialog')
+			.should('have.css', 'display', 'flex')
+			.and('have.css', 'overflow', 'hidden')
+		cy.get('.version-comparison-dialog__comparison')
+			.should('have.css', 'display', 'flex')
+			.and('have.css', 'overflow', 'hidden')
+			.then(($host) => {
+				const host = $host[0].getBoundingClientRect()
+				const content = $host[0].parentElement.getBoundingClientRect()
+				expect(Math.abs(host.bottom - content.bottom), 'host fills remaining dialog height')
+					.to.be.lessThan(2)
+			})
+		cy.get('.version-comparison-dialog__selectors .text-comparison').should('not.exist')
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Changes')
+			.should('have.attr', 'aria-selected', 'true')
+		assertMeasuredComparisonLayout('paired')
+		cy.get('.version-comparison-dialog .text-comparison__change-list')
+			.should('be.visible')
+			.and('contain', 'Moved section')
+			.and('contain', 'Bold changed')
+			.and('contain', 'Italic changed')
+			.and('contain', 'Link changed')
+			.and('contain', 'Task state changed')
+			.and('contain', 'Callout type changed')
+			.and('contain', 'Image description changed')
+			.and('contain', 'Footnote changed')
+		cy.get('.version-comparison-dialog [data-comparison-select]')
+			.should(($records) => {
+				expect($records.length).to.be.greaterThan(10)
+			})
+		cy.contains('.version-comparison-dialog [data-comparison-select]', 'Quote changed')
+			.should('be.visible')
+		cy.get('.version-comparison-dialog .text-comparison__change-list')
+			.should('not.contain', 'Unknown change')
+		cy.get('.version-comparison-dialog [data-comparison-select]').each(($record) => {
+			expect($record.attr('aria-label'), 'accessible change summary').to.match(/\S/)
+			expect($record.text().trim(), 'visible change summary').not.to.be.empty
+		})
+		cy.get('.version-comparison-dialog .text-comparison__change-list [data-comparison-select]')
+			.its('length')
+			.then((unfilteredCount) => {
+				cy.contains('.version-comparison-dialog label', 'Hide formatting-only changes')
+					.find('input[type="checkbox"]')
+					.check()
+				cy.get('.version-comparison-dialog .text-comparison__change-list [data-comparison-select]')
+					.should('have.length', unfilteredCount - 2)
+				cy.contains('.version-comparison-dialog label', 'Hide formatting-only changes')
+					.find('input[type="checkbox"]')
+					.uncheck()
+			})
 
-		cy.get('#viewer .header-close')
+		cy.contains('.version-comparison-dialog [data-comparison-select]', 'Moved section')
+			.then(($record) => {
+				const changeId = $record.attr('data-comparison-select')
+				expect(changeId).to.be.a('string').and.not.be.empty
+				cy.wrap($record).click()
+				cy.wrap($record).should('have.attr', 'aria-current', 'true')
+				cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents')
+					.should('have.attr', 'aria-selected', 'true')
+				cy.get('.version-comparison-dialog .text-comparison__document--before [data-comparison-change].text-comparison-change--current')
+					.should('have.class', 'text-comparison-change--current')
+				cy.get('.version-comparison-dialog .text-comparison__document--after [data-comparison-change].text-comparison-change--current')
+					.should('have.class', 'text-comparison-change--current')
+			})
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Changes')
 			.click()
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Changes')
+			.should('have.attr', 'aria-selected', 'true')
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents')
+			.click()
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents')
+			.should('have.attr', 'aria-selected', 'true')
+		cy.get('.version-comparison-dialog .text-comparison__document-scroller')
+			.should('have.length', 2)
+		cy.get('.version-comparison-dialog .text-comparison__document--before')
+			.should('contain', INITIAL_PHRASE)
+			.and('contain', 'Audit archive')
+		cy.get('.version-comparison-dialog .text-comparison__document--after')
+			.should('contain', CURRENT_PHRASE)
+			.and('contain', 'Audit archive')
+		cy.get('.version-comparison-dialog .ProseMirror')
+			.should('have.length', 2)
+			.find('table')
+			.should('have.length', 2)
+		cy.get('.version-comparison-dialog .ProseMirror').should(($documents) => {
+			const placeholderSelector = '.text-comparison-change--empty, [data-comparison-empty], [data-comparison-placeholder]'
+			expect($documents.find(placeholderSelector), 'synthetic empty-side nodes').to.have.length(0)
+			const structuralParents = $documents.find('tr, tbody, table, ul, ol, li, p, span')
+			expect(
+				[...structuralParents].some((element) => element.textContent?.includes('•')),
+				'synthetic counterpart bullets in structural or inline parents',
+			).to.equal(false)
+		})
+		cy.get('.version-comparison-dialog .text-comparison__document--before .text-comparison__document-scroller')
+			.then(($scroller) => {
+				$scroller[0].scrollTo({ top: 80, behavior: 'instant' })
+				expect($scroller[0].scrollTop).to.be.greaterThan(0)
+			})
+		cy.get('.version-comparison-dialog .text-comparison__document--after .text-comparison__document-scroller')
+			.then(($scroller) => {
+				$scroller[0].scrollTo({ top: 240, behavior: 'instant' })
+				expect($scroller[0].scrollTop).to.be.greaterThan(80)
+			})
+		cy.get('.version-comparison-dialog .text-comparison__document--before .text-comparison__document-scroller')
+			.then(($scroller) => {
+				beforeScrollTop = $scroller[0].scrollTop
+			})
+		cy.get('.version-comparison-dialog .text-comparison__document--after .text-comparison__document-scroller')
+			.then(($scroller) => {
+				afterScrollTop = $scroller[0].scrollTop
+			})
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Changes')
+			.click()
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Changes')
+			.should('have.attr', 'aria-selected', 'true')
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents')
+			.click()
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents')
+			.should('have.attr', 'aria-selected', 'true')
+		cy.get('.version-comparison-dialog .text-comparison__document--before .text-comparison__document-scroller')
+			.should(($scroller) => {
+				expect($scroller[0].scrollTop).to.equal(beforeScrollTop)
+			})
+		cy.get('.version-comparison-dialog .text-comparison__document--after .text-comparison__document-scroller')
+			.should(($scroller) => {
+				expect($scroller[0].scrollTop).to.equal(afterScrollTop)
+			})
+		cy.get('.version-comparison-dialog .text-comparison__document figure[data-component="image-view"][data-attachment-type="image"]')
+			.should('have.length', 2)
+		cy.get('@historicalSnapshotRequest.all')
+			.should('have.length', 1)
+			.its('0.request.url')
+			.should('not.contain', 'timestamp=')
+		cy.get('@currentSnapshotRequest.all').should('have.length', 1)
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Markdown source').click()
+		cy.get('.version-comparison-dialog .text-source-comparison')
+			.should('contain', 'status: draft')
+			.and('contain', 'status: launch-ready')
+		cy.viewport(768, 900)
+		assertMeasuredComparisonLayout('single')
+
+		closeSemanticComparison()
+		cy.viewport(1280, 900)
+
+		cy.get('.app-sidebar-tabs__content .version-list .list-item')
+			.eq(3)
+			.find('.list-item-content__actions')
+			.click()
+		cy.clickMenuButton('Compare with current version')
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		assertMeasuredComparisonLayout('paired')
+		cy.get('@historicalSnapshotRequest.all').should('have.length', 2)
+		cy.get('@currentSnapshotRequest.all').should('have.length', 2)
+		closeSemanticComparison()
+		cy.get('.search-dialog-container').should('not.exist')
+		cy.get('#tab-button-attachments').click()
+		cy.get('.app-sidebar-tabs__content').should('contain', 'No attachments')
+		cy.then(() => expect(JSON.stringify(unexpectedFailures), 'unexplained comparison failures').to.equal('[]'))
 	})
 
-	it('Restore initial version', function() {
+	it('C05 reuses a successful historical snapshot while the dialog remains open', function() {
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL).as('cachedHistoricalSnapshot')
+		openInitialCurrentSemanticComparison()
+		cy.get('@cachedHistoricalSnapshot.all').should('have.length', 1)
+
+		selectVersionAt(0, 2)
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		cy.get('@cachedHistoricalSnapshot.all').should('have.length', 2)
+
+		selectVersionAt(0, 3)
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		cy.get('@cachedHistoricalSnapshot.all').should('have.length', 2)
+	})
+
+	it('C06 reloads the current snapshot for every comparison attempt', function() {
+		cy.intercept('GET', CURRENT_SNAPSHOT_URL).as('uncachedCurrentSnapshot')
+		openInitialCurrentSemanticComparison()
+		cy.get('@uncachedCurrentSnapshot.all').should('have.length', 1)
+
+		selectVersionAt(0, 2)
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		cy.get('@uncachedCurrentSnapshot.all').should('have.length', 2)
+
+		selectVersionAt(0, 3)
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		cy.get('@uncachedCurrentSnapshot.all').should('have.length', 3)
+	})
+
+	it('F11 completes comparison with no unexplained browser or snapshot failures', function() {
+		const unexpectedFailures = []
+		cy.window().then((window) => {
+			window.addEventListener('error', ({ message }) => {
+				if (!message.includes('ResizeObserver')) {
+					unexpectedFailures.push(`page error: ${message}`)
+				}
+			})
+			window.addEventListener('unhandledrejection', ({ reason }) => unexpectedFailures.push(`unhandled rejection: ${String(reason)}`))
+			cy.stub(window.console, 'error').callsFake((...args) => unexpectedFailures.push(`console error: ${args.join(' ')}`))
+		})
+		const recordFailedResponse = (request) => request.continue((response) => {
+			if (response.statusCode >= 400) {
+				unexpectedFailures.push(`${response.statusCode} ${request.url}`)
+			}
+		})
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL, recordFailedResponse)
+		cy.intercept('GET', CURRENT_SNAPSHOT_URL, recordFailedResponse)
+
+		cy.get('.app-sidebar-tabs__content .version-list .list-item')
+			.eq(3)
+			.find('.list-item-content__actions')
+			.click()
+		cy.clickMenuButton('Compare with current version')
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		closeSemanticComparison()
+		cy.then(() => expect(JSON.stringify(unexpectedFailures), 'unexplained comparison failures').to.equal('[]'))
+	})
+
+	it('C02 loads two immutable historical snapshots', function() {
+		cy.contains('button', 'Compare versions…').click()
+		selectVersionFromEnd(0, 1)
+		selectVersionFromEnd(1, 3)
+		getVersionComparisonModal().find('button[type="submit"]').click()
+
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents').click()
+		cy.get('.version-comparison-dialog .text-comparison__document--before')
+			.should('contain', INITIAL_PHRASE)
+		cy.get('.version-comparison-dialog .text-comparison__document--after')
+			.should('contain', REVIEWED_PHRASE)
+	})
+
+	it('C03 normalizes reversed selectors without swapping visible labels', function() {
+		let expectedEarlierLabel
+		let expectedLaterLabel
+		cy.contains('button', 'Compare versions…').click()
+		selectVersionFromEnd(0, 3)
+		selectVersionFromEnd(1, 1)
+		cy.get('.version-comparison-dialog select').eq(0).find('option:selected').invoke('text')
+			.then((label) => { expectedLaterLabel = label.trim() })
+		cy.get('.version-comparison-dialog select').eq(1).find('option:selected').invoke('text')
+			.then((label) => { expectedEarlierLabel = label.trim() })
+		getVersionComparisonModal().find('button[type="submit"]').click()
+
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents').click()
+		cy.get('.version-comparison-dialog .text-comparison__document--before')
+			.should('contain', INITIAL_PHRASE)
+		cy.get('.version-comparison-dialog .text-comparison__document--after')
+			.should('contain', REVIEWED_PHRASE)
+		cy.get('.version-comparison-dialog select').eq(0).should(($select) => {
+			expect($select.val()).to.match(/^version:[^/\\]+$/)
+			expect($select.find('option:selected').text().trim()).to.equal(expectedEarlierLabel)
+		})
+		cy.get('.version-comparison-dialog select').eq(1).should(($select) => {
+			expect($select.find('option:selected').text().trim()).to.equal(expectedLaterLabel)
+		})
+	})
+
+	it('shows syntax-only Markdown differences without inventing rendered changes', function() {
+		cy.contains('button', 'Compare versions…').click()
+		selectVersionFromEnd(0, 1)
+		selectVersionFromEnd(1, 2)
+		getVersionComparisonModal().find('button[type="submit"]').click()
+
+		cy.get('.version-comparison-dialog .text-comparison')
+			.should('contain', 'No rendered differences — Markdown syntax differs.')
+			.and('not.contain', 'Moved section')
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Markdown source').click()
+		cy.get('.version-comparison-dialog .text-source-comparison')
+			.should('contain', '# Atlas 2.4 release plan #')
+			.and('contain', 'Line endings changed: lf → crlf')
+			.and('contain', 'crlf')
+			.and('contain', 'No newline at end of file')
+		cy.get('.version-comparison-dialog .text-source-comparison__line--added code')
+			.should(($lines) => {
+				expect([...$lines].some((line) => line.textContent.endsWith(' ')), 'literal trailing space').to.equal(true)
+			})
+		closeSemanticComparison()
+	})
+
+	it('R01 encodes the exact ordered pair in a canonical comparison route', function() {
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}?view=grid#rollout`)
+		openVersionsSidebar()
+		openInitialCurrentSemanticComparison()
+
+		cy.get('.version-comparison-dialog select').then(($selects) => {
+			cy.location().should((location) => {
+				const query = new URLSearchParams(location.search)
+				expect(query.get('compareFrom')).to.equal($selects.eq(0).val())
+				expect(query.get('compareTo')).to.match(/^current:\d+$/)
+				expect(query.get('view')).to.equal('grid')
+				expect(location.hash).to.equal('#rollout')
+				expect(location.href).not.to.contain('/remote.php/dav')
+			})
+		})
+	})
+
+	it('R02 reload restores the exact comparison pair and view', function() {
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}?view=grid#rollout`)
+		openVersionsSidebar()
+		openInitialCurrentSemanticComparison()
+		cy.location('href').as('reloadedComparisonUrl')
+
+		cy.reload()
+
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		cy.get('@reloadedComparisonUrl').then((comparisonUrl) => {
+			cy.location('href').should('eq', comparisonUrl)
+		})
+	})
+
+	it('R03 Back closes the managed comparison and restores the prior route', function() {
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}?view=grid#rollout`)
+		openVersionsSidebar()
+		openInitialCurrentSemanticComparison()
+
+		cy.go('back')
+
+		cy.get('.version-comparison-dialog').should('not.exist')
+		cy.location().should((location) => {
+			const query = new URLSearchParams(location.search)
+			expect(query.get('compareFrom')).to.be.null
+			expect(query.get('compareTo')).to.be.null
+			expect(query.get('view')).to.equal('grid')
+			expect(location.hash).to.equal('#rollout')
+		})
+	})
+
+	it('R05 copied link opens the same pair in a fresh authenticated session', function() {
+		cy.stubClipboardAndVisit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}?view=grid#rollout`)
+		openVersionsSidebar()
+		openInitialCurrentSemanticComparison()
+		cy.location('href').as('freshSessionComparisonUrl')
+		getVersionComparisonModal().contains('button', 'Copy comparison link').click()
+		cy.get('@freshSessionComparisonUrl').then((comparisonUrl) => {
+			cy.getClipboardText().should('eq', comparisonUrl)
+			cy.clearCookies()
+			cy.clearLocalStorage()
+			cy.login(OWNER)
+			cy.visit(comparisonUrl)
+		})
+
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		cy.get('@freshSessionComparisonUrl').then((comparisonUrl) => {
+			cy.location('href').should('eq', comparisonUrl)
+		})
+	})
+
+	it('R10 closing a managed route preserves unrelated query and history state', function() {
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}?view=grid#rollout`)
+		openVersionsSidebar()
+		openInitialCurrentSemanticComparison()
+
+		closeSemanticComparison()
+
+		cy.location().should((location) => {
+			const query = new URLSearchParams(location.search)
+			expect(query.get('compareFrom')).to.be.null
+			expect(query.get('compareTo')).to.be.null
+			expect(query.get('view')).to.equal('grid')
+			expect(location.hash).to.equal('#rollout')
+		})
+		cy.window().should(({ history }) => {
+			expect(history.state?.collectivesVersionComparison).not.to.equal(true)
+		})
+	})
+
+	it('R04 Forward reopens the exact semantic comparison state', function() {
+		cy.stubClipboardAndVisit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}?view=grid#rollout`)
+		openVersionsSidebar()
+		cy.get('.app-sidebar-tabs__content .version-list .list-item')
+			.eq(3)
+			.find('.list-item-content__actions')
+			.click()
+		cy.clickMenuButton('Compare with current version')
+
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		cy.location().then((location) => {
+			const query = new URLSearchParams(location.search)
+			expect(query.get('compareFrom')).to.match(/^version:[^/\\]+$/)
+			expect(query.get('compareTo')).to.match(/^current:\d+$/)
+			expect(query.get('view')).to.equal('grid')
+			expect(location.hash).to.equal('#rollout')
+			expect(location.href).not.to.contain('/remote.php/dav')
+		})
+		cy.location('href').as('comparisonUrl')
+		cy.go('back')
+		cy.get('.version-comparison-dialog').should('not.exist')
+		cy.location('search').should('eq', '?view=grid')
+		cy.go('forward')
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		getVersionComparisonModal()
+			.contains('button', 'Copy comparison link')
+			.should('not.be.disabled')
+			.click()
+		cy.get('@comparisonUrl').then((comparisonUrl) => {
+			cy.getClipboardText().should('eq', comparisonUrl)
+		})
+		cy.contains('.toastify', 'Comparison link copied')
+			.find('.toast-close')
+			.click()
+		cy.get('@clipboardWriteText').then((writeText) => {
+			writeText.rejects(new Error('clipboard denied'))
+		})
+		getVersionComparisonModal().contains('button', 'Copy comparison link').click()
+		cy.contains('.toast-error', 'Could not copy the comparison link.')
+			.should('be.visible')
+			.find('.toast-close')
+			.click()
+		cy.reload()
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		cy.get('@comparisonUrl').then((comparisonUrl) => {
+			cy.location('href').should('eq', comparisonUrl)
+		})
+
+		closeSemanticComparison()
+		cy.location('search').should('eq', '?view=grid')
+		cy.go('forward')
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		selectVersionAt(0, 2)
+		cy.location('search').should('eq', '?view=grid')
+		getVersionComparisonModal().should('be.visible')
+		cy.get('.version-comparison-dialog .text-comparison').should('not.exist')
+		closeSemanticComparison()
+		cy.window().should(({ history }) => {
+			expect(history.state?.collectivesVersionComparison).not.to.equal(true)
+		})
+
+		cy.intercept('GET', CURRENT_SNAPSHOT_URL).as('routedCurrentSnapshotRequest')
+		cy.get('@comparisonUrl').then((comparisonUrl) => cy.stubClipboardAndVisit(comparisonUrl))
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		cy.get('@routedCurrentSnapshotRequest.all').should('have.length', 1)
+		closeSemanticComparison()
+		cy.location().should((location) => {
+			const query = new URLSearchParams(location.search)
+			expect(query.get('compareFrom')).to.be.null
+			expect(query.get('compareTo')).to.be.null
+			expect(query.get('view')).to.equal('grid')
+			expect(location.hash).to.equal('#rollout')
+		})
+	})
+
+	it('keeps a copied Current comparison stable after a later page edit', function() {
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${STABLE_PAGE_NAME}`)
+		openVersionsSidebar()
+		cy.get('.app-sidebar-tabs__content .version-list .list-item')
+			.eq(1)
+			.find('.list-item-content__actions')
+			.click()
+		cy.clickMenuButton('Compare with current version')
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+
+		cy.location().then((location) => {
+			const query = new URLSearchParams(location.search)
+			expect(query.get('compareFrom')).to.match(/^version:[^/\\]+$/)
+			expect(query.get('compareTo')).to.match(/^current:\d+$/)
+		})
+		cy.location('href').as('stableComparisonUrl')
+		closeSemanticComparison()
+		cy.switchToEditMode()
+		cy.getEditorContent(true).type(`{selectall}${STABLE_LINK_UPDATED}`)
+		cy.switchToPreviewMode()
+		cy.getReadOnlyEditor().should('contain', STABLE_LINK_UPDATED)
+		cy.get('@stableComparisonUrl').then((comparisonUrl) => cy.visit(comparisonUrl))
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents').click()
+		cy.get('.version-comparison-dialog .text-comparison__document--after')
+			.should('contain', STABLE_LINK_CURRENT)
+			.and('not.contain', STABLE_LINK_UPDATED)
+	})
+
+	it('R07 keeps an unavailable routed identity visible without requesting a snapshot', function() {
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL).as('historicalSnapshotRequest')
+		cy.intercept('GET', CURRENT_SNAPSHOT_URL).as('currentSnapshotRequest')
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}?compareFrom=missing-version&compareTo=current`)
+		getVersionComparisonModal()
+			.should('contain', 'Unavailable version (missing-version)')
+			.and('contain', 'One of the selected versions has expired or was removed.')
+		cy.get('@historicalSnapshotRequest.all').should('have.length', 0)
+		cy.get('@currentSnapshotRequest.all').should('have.length', 0)
+		getVersionComparisonModal().contains('button', 'Retry').should('be.visible')
+		closeSemanticComparison()
+		cy.location('search').should('eq', '')
+	})
+
+	it('R08 keeps two unavailable routed identities visible without requesting snapshots', function() {
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL).as('historicalSnapshotRequest')
+		cy.intercept('GET', CURRENT_SNAPSHOT_URL).as('currentSnapshotRequest')
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}?compareFrom=missing-one&compareTo=missing-two`)
+		getVersionComparisonModal()
+			.should('contain', 'Unavailable version (missing-one)')
+			.and('contain', 'Unavailable version (missing-two)')
+			.and('contain', 'The selected versions have expired or were removed.')
+		cy.get('@historicalSnapshotRequest.all').should('have.length', 0)
+		cy.get('@currentSnapshotRequest.all').should('have.length', 0)
+	})
+
+	it('R09 quarantines ambiguous DAV identities without disabling valid versions', function() {
+		let duplicateVersionId
+		let expectedOptionCount
+		cy.get('.app-sidebar-tabs__content .version-list .list-item')
+			.its('length')
+			.then((count) => { expectedOptionCount = count })
+		cy.intercept('PROPFIND', '**/remote.php/dav/versions/**', (request) => {
+			request.continue((response) => {
+				const mutated = appendQuarantinedVersionEntries(response.body)
+				duplicateVersionId = mutated.duplicateVersionId
+				response.body = mutated.body
+			})
+		}).as('versionsWithQuarantinedEntries')
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}`)
+		openVersionsSidebar()
+		cy.wait('@versionsWithQuarantinedEntries')
+		cy.then(() => {
+			cy.get('.app-sidebar-tabs__content .version-list .version')
+				.filter((_index, element) => element.dataset.versionId === String(duplicateVersionId))
+				.should('have.length', 2)
+				.first()
+				.find('.list-item-content__actions')
+				.click()
+			cy.clickMenuButton('Compare with current version')
+			cy.contains('.toast-error', 'This page version cannot be used for comparison.')
+				.should('be.visible')
+				.find('.toast-close')
+				.click()
+			cy.get('.version-comparison-dialog').should('not.exist')
+		})
+
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal()
+			.find('[role="status"]')
+			.filter(':contains("Some page versions could not be used for comparison.")')
+			.should('have.length', 1)
+		cy.get('.version-comparison-dialog select').each(($select) => {
+			cy.wrap($select).find('option').should('have.length', expectedOptionCount)
+			cy.wrap($select).find('option[value="version:current"]').should('have.length', 1)
+		})
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog .text-comparison').should('be.visible')
+		closeSemanticComparison()
+
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL).as('historicalSnapshotRequest')
+		cy.intercept('GET', CURRENT_SNAPSHOT_URL).as('currentSnapshotRequest')
+		cy.then(() => {
+			expect(duplicateVersionId).to.be.a('string').and.not.be.empty
+			cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}?compareFrom=${encodeURIComponent(`version:${duplicateVersionId}`)}&compareTo=current`)
+		})
+		getVersionComparisonModal()
+			.should('contain', 'Ambiguous version')
+			.and('contain', 'The version comparison link is ambiguous and could not be opened.')
+			.and('not.contain', duplicateVersionId)
+		cy.get('@historicalSnapshotRequest.all').should('have.length', 0)
+		cy.get('@currentSnapshotRequest.all').should('have.length', 0)
+	})
+
+	it('R09 rejects malformed pair parameters before requesting versions', function() {
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL).as('versionRequest')
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}?compareFrom=versions%2F1&compareTo=current&view=grid#rollout`)
+		cy.location().should((location) => {
+			const query = new URLSearchParams(location.search)
+			expect(query.get('compareFrom')).to.be.null
+			expect(query.get('compareTo')).to.be.null
+			expect(query.get('view')).to.equal('grid')
+			expect(location.hash).to.equal('#rollout')
+		})
+		cy.get('.version-comparison-dialog').should('not.exist')
+		cy.get('@versionRequest.all').should('have.length', 0)
+	})
+
+	it('C16 does not expose version comparison on public routes', function() {
+		logoutAndClearSession()
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL).as('versionRequest')
+		cy.visit(`${publicSharePath}?compareFrom=missing-version&compareTo=current&view=grid#rollout`)
+		cy.getReadOnlyEditor().should('contain', CURRENT_PHRASE)
+		cy.location().should((location) => {
+			const query = new URLSearchParams(location.search)
+			expect(query.get('compareFrom')).to.be.null
+			expect(query.get('compareTo')).to.be.null
+			expect(query.get('view')).to.equal('grid')
+			expect(location.hash).to.equal('#rollout')
+		})
+		cy.contains('Version comparison is not available for public links.').should('be.visible')
+		cy.get('#tab-button-versions').should('not.exist')
+		cy.get('@versionRequest.all').should('have.length', 0)
+	})
+
+	it('F10 denies a direct anonymous historical DAV snapshot read', function() {
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL).as('authorizedSnapshotRead')
+		cy.get('.app-sidebar-tabs__content .version-list .list-item')
+			.eq(3)
+			.find('.list-item-content__actions')
+			.click()
+		cy.clickMenuButton('Compare with current version')
+		cy.wait('@authorizedSnapshotRead').its('request.url').then((snapshotUrl) => {
+			closeSemanticComparison()
+			logoutAndClearSession()
+			cy.request({
+				url: snapshotUrl,
+				failOnStatusCode: false,
+				followRedirect: false,
+			}).its('status').should('be.oneOf', [401, 403])
+		})
+	})
+
+	it('C04 Blocks comparing a version with itself', function() {
+		cy.contains('button', 'Compare versions…').click()
+		selectVersionAt(0, 1)
+		selectVersionAt(1, 1)
+		cy.get('.version-comparison-dialog')
+			.should('contain', 'Select two different versions.')
+		getVersionComparisonModal().find('button[type="submit"]')
+			.should('be.disabled')
+	})
+
+	it('Uses an accessible Before and After toggle on mobile', function() {
+		cy.viewport(768, 900)
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents').click()
+		cy.get('.version-comparison-dialog .text-comparison')
+			.should('have.class', 'text-comparison--single')
+		assertMeasuredComparisonLayout('single')
+		cy.get('.version-comparison-dialog .text-comparison__documents')
+			.should('have.css', 'display', 'flex')
+		cy.get('.version-comparison-dialog .text-comparison__document-grid')
+			.should('have.css', 'display', 'block')
+		cy.get('.version-comparison-dialog [role="tablist"]').should('be.visible')
+		cy.get('.version-comparison-dialog [role="tab"]').contains('Before')
+			.trigger('keydown', { key: 'ArrowRight' })
+		cy.get('.version-comparison-dialog [role="tab"][aria-selected="true"]')
+			.should('contain', 'After')
+		cy.get('.version-comparison-dialog [role="tabpanel"]:visible')
+			.should('contain', CURRENT_PHRASE)
+		cy.viewport(320, 900)
+		cy.get('.version-comparison-dialog [role="tabpanel"]:visible')
+			.should('be.visible')
+		cy.get('.version-comparison-dialog .text-comparison')
+			.should(($comparison) => {
+				expect($comparison[0].scrollWidth).to.be.at.most($comparison[0].clientWidth + 1)
+			})
+	})
+
+	it('uses the comparison container width independently of the desktop viewport', function() {
+		cy.viewport(1440, 900)
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		assertMeasuredComparisonLayout('paired')
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents').click()
+		cy.get('.version-comparison-dialog .text-comparison__document-grid')
+			.should('have.css', 'display', 'grid')
+		getVersionComparisonModal().then(($modal) => {
+			$modal[0].style.width = '700px'
+		})
+		assertMeasuredComparisonLayout('single')
+		getVersionComparisonModal().then(($modal) => {
+			$modal[0].style.width = ''
+		})
+		assertMeasuredComparisonLayout('paired')
+	})
+
+	it('AUD-06 uses a callable semantic factory despite an unexpected Text API version', function() {
+		cy.window().then((window) => {
+			window.OCA.Text.apiVersion = 'unexpected'
+		})
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog .text-comparison').should('be.visible')
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Markdown source').should('be.visible')
+		cy.get('#viewer').should('not.exist')
+	})
+
+	it('X03 falls back to Viewer when the advertised semantic factory is missing', function() {
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL).as('viewerSnapshotRequest')
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${VIEWER_FALLBACK_PAGE_NAME}`)
+		cy.switchToEditMode()
+		cy.intercept('POST', '**/apps/text/session/*/save').as('viewerPreparationSave')
+		const typedBytes = 'No-wait Viewer fallback bytes 7f56c599'
+		insertEditorContent(typedBytes, true)
+		openVersionsSidebar()
+		cy.window().then((window) => {
+			window.OCA.Text.apiVersion = '1.5'
+			cy.stub(window.OCA.Text, 'createMarkdownContentComparison').value(undefined).as('missingSemanticFactory')
+		})
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.wait('@viewerPreparationSave')
+		cy.get('.version-comparison-dialog').should('not.exist')
+		cy.get('#viewer .viewer--split > .viewer__file-wrapper:visible')
+			.should('have.length', 2)
+			.eq(1)
+			.should('contain', typedBytes)
+		cy.get('@viewerSnapshotRequest.all').should('have.length', 1)
+		closeViewerComparison()
+		cy.get('@missingSemanticFactory').then((stub) => stub.restore())
+	})
+
+	it('prepares current bytes before Viewer fallback dispatch', function() {
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${VIEWER_FALLBACK_PAGE_NAME}`)
+		cy.switchToEditMode()
+		cy.intercept('POST', '**/apps/text/session/*/save', { statusCode: 500 }).as('failedViewerPreparationSave')
+		insertEditorContent('Viewer preparation must fail closed 7f56c599', true)
+		openVersionsSidebar()
+		cy.window().then((window) => {
+			cy.stub(window.OCA.Text, 'createMarkdownContentComparison').value(undefined).as('missingSemanticFactory')
+		})
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.wait('@failedViewerPreparationSave')
+		cy.get('#viewer').should('not.exist')
+		cy.get('.version-comparison-dialog [role="alert"]')
+			.should('contain', 'Could not save current changes before comparison. Please try again.')
+		cy.get('@missingSemanticFactory').then((stub) => stub.restore())
+	})
+
+	it('C11 retry clears a removed-version error and publishes fresh comparison state', function() {
+		cy.intercept({
+			method: 'GET',
+			times: 1,
+			url: HISTORICAL_SNAPSHOT_URL,
+		}, { statusCode: 404 }).as('removedVersion')
+
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${REMOVED_VERSION_PAGE_NAME}`)
+		openVersionsSidebar()
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.wait('@removedVersion')
+		cy.get('.version-comparison-dialog [role="alert"]')
+			.should('contain', 'One of the selected versions has expired or was removed.')
+		cy.get('.version-comparison-dialog .text-comparison').should('not.exist')
+
+		getVersionComparisonModal().contains('button', 'Retry').click()
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+	})
+
+	it('C13 reports one removed version for a single 404 snapshot response', function() {
+		cy.intercept({
+			method: 'GET',
+			times: 1,
+			url: HISTORICAL_SNAPSHOT_URL,
+		}, { statusCode: 404 }).as('singleRemovedVersion')
+
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${SINGLE_REMOVED_VERSION_PAGE_NAME}`)
+		openVersionsSidebar()
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.wait('@singleRemovedVersion')
+		cy.get('.version-comparison-dialog [role="alert"]')
+			.should('contain', 'One of the selected versions has expired or was removed.')
+		cy.get('.version-comparison-dialog .text-comparison').should('not.exist')
+	})
+
+	it('C12 Shows a permission error when both snapshots are unavailable', function() {
+		cy.get('body').then(($body) => {
+			if ($body.find('.version-comparison-dialog').length > 0) {
+				closeSemanticComparison()
+			}
+		})
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL, { statusCode: 403 })
+			.as('deniedSnapshots')
+
+		cy.contains('button', 'Compare versions…').click()
+		selectVersionAt(0, 1)
+		selectVersionAt(1, 3)
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.wait('@deniedSnapshots')
+		cy.wait('@deniedSnapshots')
+		cy.get('.version-comparison-dialog [role="alert"]')
+			.should('contain', 'You do not have permission to load the selected versions.')
+		cy.get('.version-comparison-dialog .text-comparison').should('not.exist')
+		cy.get('#viewer').should('not.exist')
+	})
+
+	it('C12 Shows a permission error when one selected snapshot is unavailable', function() {
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL, { statusCode: 403 }).as('deniedSnapshot')
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.wait('@deniedSnapshot')
+		cy.get('.version-comparison-dialog [role="alert"]')
+			.should('contain', 'You do not have permission to load one of the selected versions.')
+		cy.get('.version-comparison-dialog .text-comparison').should('not.exist')
+	})
+
+	it('C13 Shows a two-version expiry error for 404 and 410 responses', function() {
+		let requestCount = 0
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL, (request) => {
+			request.reply({ statusCode: requestCount++ === 0 ? 410 : 404 })
+		}).as('expiredSnapshots')
+		cy.contains('button', 'Compare versions…').click()
+		selectVersionAt(0, 1)
+		selectVersionAt(1, 3)
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.wait('@expiredSnapshots')
+		cy.wait('@expiredSnapshots')
+		cy.get('.version-comparison-dialog [role="alert"]')
+			.should('contain', 'The selected versions have expired or were removed.')
+		cy.get('.version-comparison-dialog .text-comparison').should('not.exist')
+	})
+
+	it('C14 reports a network failure instead of treating it as cancellation', function() {
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL, (request) => {
+			request.destroy()
+		}).as('networkFailure')
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.wait('@networkFailure')
+		cy.get('.version-comparison-dialog [role="alert"]')
+			.should('contain', 'Could not load the selected versions because of a network error.')
+		cy.get('.version-comparison-dialog .text-comparison').should('not.exist')
+		cy.get('#viewer').should('not.exist')
+	})
+
+	it('C09 cancels a superseded request and prevents stale publication', function() {
+		const delayedSnapshot = Promise.withResolvers()
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL, (request) => {
+			return delayedSnapshot.promise.then(() => request.reply('Delayed snapshot'))
+		}).as('delayedSnapshot')
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog__loading').should('be.visible')
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${FRESH_PAGE_NAME}`)
+		cy.location('pathname').should('contain', `/${FRESH_PAGE_NAME}`)
+		cy.getReadOnlyEditor().should('be.visible')
+		cy.then(() => delayedSnapshot.resolve())
+		cy.wait('@delayedSnapshot')
+		cy.get('.version-comparison-dialog').should('not.exist')
+		cy.get('.text-comparison').should('not.exist')
+		cy.get('[role="alert"]').should('not.exist')
+	})
+
+	it('C10 publishes only the latest generation after rapid pair changes', function() {
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${RAPID_GENERATION_PAGE_NAME}`)
+		openVersionsSidebar()
+		const delayedSnapshot = Promise.withResolvers()
+		let delayedFirstSnapshot = false
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL, (request) => {
+			if (!delayedFirstSnapshot) {
+				delayedFirstSnapshot = true
+				request.alias = 'supersededSnapshot'
+				request.continue(() => delayedSnapshot.promise)
+			}
+		}).as('rapidHistoricalSnapshots')
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog__loading').should('be.visible')
+		selectVersionFromEnd(0, 1, { force: true })
+		selectVersionFromEnd(1, 2, { force: true })
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents').click()
+		cy.get('.version-comparison-dialog .text-comparison__document--before')
+			.should('contain', INITIAL_PHRASE)
+		cy.get('.version-comparison-dialog .text-comparison__document--after')
+			.should('contain', REVIEWED_PHRASE)
+		cy.then(() => delayedSnapshot.resolve())
+		cy.wait('@supersededSnapshot')
+		cy.get('.version-comparison-dialog .text-comparison__document--after')
+			.should('contain', REVIEWED_PHRASE)
+			.and('not.contain', CURRENT_PHRASE)
+	})
+
+	it('Reports semantic comparison initialization failures', function() {
+		cy.window().then((window) => {
+			cy.stub(window.OCA.Text, 'createMarkdownContentComparison')
+				.rejects(new Error('comparison failed'))
+		})
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog [role="alert"]')
+			.should('contain', 'Could not initialize version comparison.')
+		cy.get('.version-comparison-dialog .text-comparison').should('not.exist')
+	})
+
+	it('C15 Compares versions for a read-only member', function() {
+		cy.login(READER)
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}`)
+		cy.get('button.titleform-button').should('not.exist')
+		cy.getReadOnlyEditor().should('contain', CURRENT_PHRASE)
+		cy.get('button.page-sidebar-button').click()
+		cy.get('#tab-button-versions').click()
+		cy.get('.app-sidebar-tabs__content .version-list .list-item')
+			.contains('Initial version')
+			.closest('.list-item')
+			.find('.list-item-content__actions')
+			.click()
+		cy.contains('button', 'Name this version').should('not.exist')
+		cy.contains('button', 'Restore version').should('not.exist')
+		cy.contains('button', 'Delete version').should('not.exist')
+		cy.clickMenuButton('Compare with current version')
+
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+	})
+
+	it('denies a crafted reader restore and allows the equivalent owner restore', function() {
+		cy.login(READER)
+		cy.intercept('PROPFIND', '**/remote.php/dav/versions/**').as('readerVersions')
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${RESTORE_AUTH_PAGE_NAME}`)
+		cy.getReadOnlyEditor().should('contain', CURRENT_PHRASE)
+		openVersionsSidebar()
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+
+		cy.wait('@readerVersions').then(({ request, response }) => {
+			const beforeEntries = versionEntries(response.body)
+			expect(beforeEntries.length, 'reader-visible version snapshots').to.be.greaterThan(1)
+			const sourceUrl = new URL(beforeEntries[0].href, request.url).href
+			const fileId = new URL(sourceUrl).pathname.split('/').at(-2)
+			expect(fileId, 'versioned file id').to.not.be.empty
+			const collectionUrl = request.url
+			const pageUrl = `${Cypress.expose('baseUrl')}/remote.php/webdav/.Collectives/${encodeURIComponent(COLLECTIVE_NAME)}/${encodeURIComponent(RESTORE_AUTH_PAGE_NAME)}.md`
+			const destination = `${Cypress.expose('baseUrl')}/remote.php/dav/versions/${encodeURIComponent(READER.userId)}/restore/target`
+
+			return authenticatedDavRequest(READER, { url: pageUrl }).then(({ body: beforeBytes }) => {
+				return authenticatedDavRequest(READER, {
+					method: 'MOVE',
+					url: sourceUrl,
+					headers: { Destination: destination },
+					failOnStatusCode: false,
+				}).then(({ status, body }) => {
+					if (status === 500) {
+						expect(body).to.contain('<s:exception>OCP\\Files\\NotPermittedException</s:exception>')
+						expect(body).to.contain('<s:message>Failed to restore version</s:message>')
+					} else {
+						expect(status).to.equal(403)
+					}
+					return authenticatedDavRequest(READER, { url: pageUrl })
+				}).then(({ body }) => {
+					expect(body).to.equal(beforeBytes)
+					return listDavVersions(READER, collectionUrl)
+				}).then(({ body }) => {
+					expect(versionEntries(body)).to.deep.equal(beforeEntries)
+					return { fileId, pageUrl }
+				})
+			})
+		}).then(({ fileId, pageUrl }) => {
+			const ownerCollectionUrl = `${Cypress.expose('baseUrl')}/remote.php/dav/versions/${encodeURIComponent(OWNER.userId)}/versions/${fileId}`
+			return listDavVersions(OWNER, ownerCollectionUrl).then(({ body }) => {
+				const ownerEntries = versionEntries(body)
+				expect(ownerEntries.length, 'owner-visible version snapshots').to.be.greaterThan(1)
+				const sourceUrl = new URL(ownerEntries[0].href, ownerCollectionUrl).href
+				return authenticatedDavRequest(OWNER, { url: sourceUrl }).then(({ body: historicalBytes }) => {
+					return authenticatedDavRequest(OWNER, {
+						method: 'MOVE',
+						url: sourceUrl,
+						headers: { Destination: `${Cypress.expose('baseUrl')}/remote.php/dav/versions/${encodeURIComponent(OWNER.userId)}/restore/target` },
+					}).then(({ status }) => {
+						expect(status).to.be.oneOf([201, 204])
+						return authenticatedDavRequest(OWNER, { url: pageUrl })
+					}).its('body').should('equal', historicalBytes)
+				})
+			})
+		})
+	})
+
+	it('C07 saves no-wait editor bytes before fetching a current comparison', function() {
+		cy.login(OWNER)
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${RAPID_COMPARE_PAGE_NAME}`)
+		cy.switchToEditMode()
+		cy.intercept('POST', '**/apps/text/session/*/save').as('comparisonPreparationSave')
+		cy.intercept('GET', CURRENT_SNAPSHOT_URL).as('preparedCurrentSnapshot')
+		const typedBytes = 'No-wait current bytes 7f56c599'
+		insertEditorContent(typedBytes, true)
+
+		openVersionsSidebar()
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.wait('@comparisonPreparationSave')
+		cy.wait('@preparedCurrentSnapshot')
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents').click()
+		cy.get('.version-comparison-dialog .text-comparison__document--after')
+			.should('contain', typedBytes)
+		cy.get('[data-cy-collectives="editor"] .ProseMirror').should('exist')
+		cy.location('search').should('match', /compareTo=current(?::|%3A)/)
+		cy.reload()
+		cy.get('.version-comparison-dialog .text-comparison__change-list').should('be.visible')
+		cy.contains('.version-comparison-dialog [role="tab"]', 'Full documents').click()
+		cy.get('.version-comparison-dialog .text-comparison__document--after')
+			.should('contain', typedBytes)
+		closeSemanticComparison()
+	})
+
+	it('C08 prevents snapshot reads and reports an actionable preparation failure', function() {
+		cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${RAPID_COMPARE_PAGE_NAME}`)
+		cy.switchToEditMode()
+		cy.intercept('POST', '**/apps/text/session/*/save', { statusCode: 500 }).as('failedPreparationSave')
+		cy.intercept('GET', HISTORICAL_SNAPSHOT_URL).as('historicalSnapshotRequest')
+		cy.intercept('GET', CURRENT_SNAPSHOT_URL).as('currentSnapshotRequest')
+		insertEditorContent('Preparation must fail before snapshot reads', true)
+		openVersionsSidebar()
+		cy.contains('button', 'Compare versions…').click()
+		getVersionComparisonModal().find('button[type="submit"]').click()
+		cy.wait('@failedPreparationSave')
+		cy.get('.version-comparison-dialog [role="alert"]')
+			.should('contain', 'Could not save current changes before comparison. Please try again.')
+		cy.get('@historicalSnapshotRequest.all').should('have.length', 0)
+		cy.get('@currentSnapshotRequest.all').should('have.length', 0)
+		cy.get('.version-comparison-dialog .text-comparison').should('not.exist')
+	})
+
+	it('restores the initial version through DAV MOVE', function() {
 		cy.get('.app-sidebar-tabs__content .version-list .list-item')
 			.eq(3)
 			.find('.list-item-content__actions')
@@ -106,31 +1672,81 @@ describe('Page versions', function() {
 
 		cy.intercept('MOVE', '**/dav/versions/**').as('moveVersion')
 		cy.clickMenuButton('Restore version')
-		cy.wait('@moveVersion')
-		cy.get('.toast-success')
-			.should('contain', 'Restored')
+		cy.wait('@moveVersion').its('response.statusCode').should('be.oneOf', [201, 204])
+		cy.get('.toast-success').should('contain', 'Restored')
 
-		// Check the restored file content via WebDAV instead of reloading:
-		// reloading makes the text client replay its cached (pre-restore)
-		// document state into the open session, overwriting the restore.
 		cy.request('/csrftoken').then(({ body }) => {
 			cy.request({
-				url: `${Cypress.expose('baseUrl')}/remote.php/webdav/.Collectives/${encodeURIComponent('Versions Collective')}/Page.md`,
+				url: `${Cypress.expose('baseUrl')}/remote.php/webdav/.Collectives/${encodeURIComponent(COLLECTIVE_NAME)}/${encodeURIComponent(PAGE_NAME)}.md`,
 				headers: { requesttoken: body.token },
-			}).its('body').should('contain', 'v1')
+			}).its('body')
+				.should('contain', INITIAL_PHRASE)
+				.and('not.contain', CURRENT_PHRASE)
 		})
 	})
 
 	it('Delete version', function() {
 		cy.get('.app-sidebar-tabs__content .version-list .list-item')
-			.eq(2)
-			.find('.list-item-content__actions')
-			.click()
+			.then(($versions) => {
+				cy.wrap($versions)
+					.filter(':not(:first)')
+					.first()
+					.find('.list-item-content__actions')
+					.click()
 
-		cy.intercept('MOVE', '**/dav/versions/**').as('moveVersion')
-		cy.clickMenuButton('Delete version')
+				cy.intercept('DELETE', '**/dav/versions/**').as('deleteVersion')
+				cy.clickMenuButton('Delete version')
+				cy.wait('@deleteVersion')
 
-		cy.get('.app-sidebar-tabs__content .version-list .list-item')
-			.should('have.length', 3)
+				cy.get('.app-sidebar-tabs__content .version-list .list-item')
+					.should('have.length', $versions.length - 1)
+			})
 	})
 })
+
+if (!SEMANTIC_E2E) {
+	describe('Page versions Viewer fallback', function() {
+		before(function() {
+			provisionTestUser(OWNER)
+			cy.login(OWNER)
+			cy.deleteAndSeedCollective(COLLECTIVE_NAME)
+				.seedPage(PAGE_NAME, '', 'Readme.md')
+			// eslint-disable-next-line cypress/no-unnecessary-waiting
+			cy.seedPageContent(`${COLLECTIVE_NAME}/${PAGE_NAME}.md`, INITIAL_CONTENT)
+				.wait(1100)
+			cy.seedPageContent(`${COLLECTIVE_NAME}/${PAGE_NAME}.md`, CURRENT_CONTENT)
+		})
+
+		after(function() {
+			cy.login(OWNER)
+			cy.deleteCollective(COLLECTIVE_NAME)
+			deleteTestUser(OWNER)
+		})
+
+		it('AUD-06 stable branches compare through Viewer without the semantic Text factory', function() {
+			cy.login(OWNER)
+			cy.visit(`/apps/collectives/${COLLECTIVE_NAME}/${PAGE_NAME}`)
+			cy.window().then((window) => {
+				if (typeof window.OCA?.Text?.createMarkdownContentComparison === 'function') {
+					cy.stub(window.OCA.Text, 'createMarkdownContentComparison').value(undefined)
+				}
+				expect(window.OCA?.Text?.createMarkdownContentComparison).not.to.be.a('function')
+				expect(window.OCA?.Viewer?.compare).to.be.a('function')
+			})
+			openVersionsSidebar()
+			cy.contains('.app-sidebar-tabs__content .version-list .list-item', 'Initial version')
+				.find('.list-item-content__actions')
+				.click()
+			cy.clickMenuButton('Compare with current version')
+
+			cy.get('#viewer .viewer--split > .viewer__file-wrapper:visible')
+				.should('have.length', 2)
+				.first()
+				.should('contain', INITIAL_PHRASE)
+			cy.get('#viewer .viewer--split > .viewer__file-wrapper:visible')
+				.eq(1)
+				.should('contain', CURRENT_PHRASE)
+			closeViewerComparison()
+		})
+	})
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -442,7 +442,7 @@ Cypress.Commands.add('stubClipboardAndVisit', (url) => {
 })
 
 Cypress.Commands.add('getClipboardText', () => {
-	cy.get('@clipboardWriteText')
+	return cy.get('@clipboardWriteText')
 		.should('have.been.called')
-		.its('lastCall.args[0]')
+		.then((writeText) => writeText.lastCall.args[0])
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,12 +23,60 @@ const CI_CONFIG = {
 	// blob (so we can merge reports and download them for inspection),
 	// dot (so we have a quick overview in the logs while the tests are running)
 	// github (to have annotations in the PR)
-	reporter: [['blob'], ['line'], ['github']] as ReporterDescription[],
+	reporter: [
+		['blob'],
+		['json', { outputFile: 'test-results/results.json' }],
+		['line'],
+		['github'],
+	] as ReporterDescription[],
 	retries: 1,
 	timeout: 45_000,
 	// we shard to speed up the tests so no parallelism in workers
 	workers: 1,
 } as const
+
+const baseURL = process.env.baseURL || 'http://localhost:8089/index.php/'
+const externalServer = Boolean(process.env.baseURL)
+const SEMANTIC_E2E = process.env.COLLECTIVES_SEMANTIC_E2E === '1'
+const VERSION_COMPARISON_TESTS = '**/version-comparison.spec.ts'
+const VIEWER_FALLBACK_TAG = /@viewer-fallback/
+
+const semanticComparisonProjects = SEMANTIC_E2E
+	? [{
+			name: 'comparison-chromium',
+			testMatch: VERSION_COMPARISON_TESTS,
+			grepInvert: VIEWER_FALLBACK_TAG,
+			use: {
+				...devices['Desktop Chrome'],
+				ignoreHTTPSErrors: true,
+			},
+		}]
+	: []
+
+const webServer = externalServer
+	? undefined
+	: {
+		// Don't set `url` as it would take precedence over `wait.stdout` and tests start too early
+		// url: 'http://127.0.0.1:8089',
+		// Starts the Nextcloud docker container
+		command: 'node playwright/start-nextcloud-server.js',
+		// we use sigterm to notify the script to stop the container
+		// if it does not respond, we force kill it after 10 seconds
+		gracefulShutdown: {
+			signal: 'SIGTERM' as const,
+			timeout: 10000,
+		},
+		// `start-nextcloud-server.mjs` only starts the server if not reachable yet.
+		reuseExistingServer: false,
+		stderr: 'pipe' as const,
+		stdout: 'pipe' as const,
+		// max. 5 minutes for creating the container
+		timeout: 5 * 60 * 1000,
+		wait: {
+			// we wait for this line to appear in the output of the webserver until consider it done
+			stdout: /Nextcloud is now ready to use/,
+		},
+	}
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -38,7 +86,7 @@ export default defineConfig({
 	...(process.env.CI ? CI_CONFIG : LOCAL_CONFIG),
 	use: {
 		// Base URL to use in actions like `await page.goto('./')`.
-		baseURL: process.env.baseURL ?? 'http://localhost:8089/index.php/',
+		baseURL,
 		// record traces but only keep them when the test fails
 		trace: 'on-first-retry',
 	},
@@ -46,32 +94,22 @@ export default defineConfig({
 	projects: [
 		{
 			name: 'chromium',
+			testIgnore: VERSION_COMPARISON_TESTS,
 			use: {
 				...devices['Desktop Chrome'],
 			},
 		},
+		{
+			name: 'comparison-viewer-chromium',
+			testMatch: VERSION_COMPARISON_TESTS,
+			grep: VIEWER_FALLBACK_TAG,
+			use: {
+				...devices['Desktop Chrome'],
+				ignoreHTTPSErrors: true,
+			},
+		},
+		...semanticComparisonProjects,
 	],
 
-	webServer: {
-		// Don't set `url` as it would take precedence over `wait.stdout` and tests start too early
-		// url: 'http://127.0.0.1:8089',
-		// Starts the Nextcloud docker container
-		command: 'node playwright/start-nextcloud-server.js',
-		// we use sigterm to notify the script to stop the container
-		// if it does not respond, we force kill it after 10 seconds
-		gracefulShutdown: {
-			signal: 'SIGTERM',
-			timeout: 10000,
-		},
-		// `start-nextcloud-server.mjs` only starts the server if not reachable yet.
-		reuseExistingServer: false,
-		stderr: 'pipe',
-		stdout: 'pipe',
-		// max. 5 minutes for creating the container
-		timeout: 5 * 60 * 1000,
-		wait: {
-			// we wait for this line to appear in the output of the webserver until consider it done
-			stdout: /Nextcloud is now ready to use/,
-		},
-	},
+	webServer,
 })

--- a/playwright/e2e/version-comparison.spec.ts
+++ b/playwright/e2e/version-comparison.spec.ts
@@ -1,0 +1,766 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { User as Account } from '@nextcloud/e2e-test-server'
+import type { Page } from '@playwright/test'
+import type { Collective } from '../support/fixtures/Collective.ts'
+import type { CollectivePage } from '../support/fixtures/CollectivePage.ts'
+
+import { docker, getContainer, runOcc } from '@nextcloud/e2e-test-server/docker'
+import { test as base, expect, mergeTests } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
+import { test as editorTest } from '../support/fixtures/editor.ts'
+import { loginAsUser } from '../support/fixtures/random-user.ts'
+import { User } from '../support/fixtures/User.ts'
+import { apiUrl, circlesApiUrl, ocsHeaders } from '../support/helpers/urls.ts'
+import {
+	createVersionComparisonAccount,
+	deleteVersionComparisonUser,
+	provisionVersionComparisonUser,
+} from '../support/helpers/versionComparisonFixtures.ts'
+
+const SNAPSHOT_URL = /\/remote\.php\/dav\/(?:versions|files)\//
+const container = process.env.PLAYWRIGHT_NC_CONTAINER
+	? docker.getContainer(process.env.PLAYWRIGHT_NC_CONTAINER)
+	: getContainer()
+const runPersistentStackOcc = (command: string[], options = {}) => runOcc(command, { container, ...options })
+const runNamespace = randomUUID().slice(0, 8)
+
+interface ProvisionedFixtures {
+	collective: Collective
+}
+
+interface ProvisionedWorkerFixtures {
+	account: Account
+	readerAccount: Account
+	user: User
+}
+
+function namespacedAccount(prefix: string, workerIndex: number, projectName: string): Account {
+	return createVersionComparisonAccount(`${prefix}-${runNamespace}-${projectName.replace(/[^a-z0-9]+/gi, '-').toLowerCase()}`, workerIndex, randomUUID) as Account
+}
+
+async function provisionAccount(account: Account) {
+	await provisionVersionComparisonUser(account, runPersistentStackOcc)
+}
+
+async function deleteAccount(account: Account) {
+	await deleteVersionComparisonUser(account.userId, runPersistentStackOcc)
+}
+
+const provisionedTest = base.extend<ProvisionedFixtures, ProvisionedWorkerFixtures>({
+	// eslint-disable-next-line no-empty-pattern
+	account: [async ({}, use, workerInfo) => {
+		const account = namespacedAccount('pw-owner', workerInfo.workerIndex, workerInfo.project.name)
+		await provisionAccount(account)
+		await use(account)
+		await deleteAccount(account)
+	}, { scope: 'worker' }],
+	// eslint-disable-next-line no-empty-pattern
+	readerAccount: [async ({}, use, workerInfo) => {
+		const account = namespacedAccount('pw-reader', workerInfo.workerIndex, workerInfo.project.name)
+		await provisionAccount(account)
+		await use(account)
+		await deleteAccount(account)
+	}, { scope: 'worker' }],
+	page: async ({ account, baseURL, browser }, use) => {
+		const page = await loginAsUser(browser, baseURL, account)
+		await use(page)
+		await page.close()
+	},
+	user: [async ({ account }, use) => {
+		await use(new User(account))
+	}, { scope: 'worker' }],
+	collective: async ({ page, user }, use) => {
+		const collective = await user.createCollective({
+			name: `c599-e2e-pw-${randomUUID()}`,
+		}, page)
+		await use(collective)
+		await user.deleteCollective({ id: collective.data.id }, page)
+	},
+})
+
+const test = mergeTests(provisionedTest, editorTest)
+
+async function openVersions(page: Page) {
+	const tab = page.locator('#tab-button-versions')
+	if (!await tab.isVisible()) {
+		await page.locator('button.page-sidebar-button').click()
+	}
+	await tab.click()
+}
+
+async function seedVersionPair(collectivePage: CollectivePage, user: User, page: Page) {
+	await collectivePage.setContent({ content: 'Historical comparison bytes', user, page })
+	await page.waitForTimeout(1100)
+	await collectivePage.setContent({ content: 'Current comparison bytes', user, page })
+}
+
+async function seedTwoHistoricalVersions(collectivePage: CollectivePage, user: User, page: Page) {
+	await collectivePage.setContent({ content: 'First historical comparison bytes', user, page })
+	await page.waitForTimeout(1100)
+	await collectivePage.setContent({ content: 'Second historical comparison bytes', user, page })
+	await page.waitForTimeout(1100)
+	await collectivePage.setContent({ content: 'Current comparison bytes', user, page })
+}
+
+async function openSeededVersionSelector(collective: Collective, user: User, page: Page, title: string) {
+	const collectivePage = await collective.createPage({ title, user, page })
+	await seedVersionPair(collectivePage, user, page)
+	await collectivePage.open()
+	await openVersions(page)
+	const opener = page.getByRole('button', { name: 'Compare versions…' })
+	await opener.click()
+	const dialog = page.getByRole('dialog', { name: 'Compare versions' })
+	await expect(dialog).toBeVisible()
+	await expect.poll(() => dialog.evaluate((element) => element.contains(document.activeElement))).toBe(true)
+	return { dialog, opener }
+}
+
+async function openSeededComparison(collective: Collective, user: User, page: Page, title: string) {
+	const { dialog, opener } = await openSeededVersionSelector(collective, user, page, title)
+	await dialog.getByRole('button', { name: 'Compare', exact: true }).click()
+	await expect(page.locator('.text-comparison')).toBeVisible()
+	return { dialog, opener }
+}
+
+function auditComparisonFailures(page: Page) {
+	const failures: string[] = []
+	let sawEmptyUserStatus = false
+	page.on('console', (message) => {
+		const text = message.text()
+		const isExpectedEmptyUserStatus = text.includes('core: Failed to load user status')
+		if (message.type() === 'error' && !isExpectedEmptyUserStatus) {
+			failures.push(`console: ${text}`)
+		}
+	})
+	page.on('pageerror', (error) => {
+		if (error.message !== 'ResizeObserver loop completed with undelivered notifications.') {
+			failures.push(`page: ${error.message}`)
+		}
+	})
+	page.on('requestfailed', (request) => {
+		failures.push(`request: ${request.url()} ${request.failure()?.errorText ?? 'failed'}`)
+	})
+	page.on('response', (response) => {
+		if (response.status() === 404 && new URL(response.url()).pathname.endsWith('/apps/user_status/api/v1/user_status')) {
+			sawEmptyUserStatus = true
+			return
+		}
+		if (response.status() >= 400) {
+			failures.push(`response: ${response.status()} ${response.url()}`)
+		}
+	})
+	return () => expect(failures.filter((failure) => !(
+		sawEmptyUserStatus
+		&& /^console: Failed to load resource: the server responded with a status of 404(?: \(Not Found\)| \(\))?$/.test(failure)
+	))).toEqual([])
+}
+
+async function installClipboardCapture(page: Page) {
+	await page.evaluate(() => {
+		Object.defineProperty(navigator, 'clipboard', {
+			configurable: true,
+			value: {
+				writeText: async (value: string) => sessionStorage.setItem('c599-copied-link', value),
+			},
+		})
+	})
+}
+
+async function freshAuthenticatedContext(page: Page, serviceWorkers: 'allow' | 'block' = 'allow') {
+	return await page.context().browser()!.newContext({
+		baseURL: process.env.baseURL || 'http://localhost:8089/index.php/',
+		ignoreHTTPSErrors: true,
+		serviceWorkers,
+		storageState: await page.context().storageState(),
+	})
+}
+
+test.describe('Version comparison route and current-byte contract', () => {
+	test('AUD-06 scheduled browser uses the compatible Text comparison API', async ({ user, page, collective }) => {
+		const { dialog } = await openSeededComparison(collective, user, page, 'c599-e2e-text-api-page')
+		await expect(page.getByRole('tab', { name: 'Changes' })).toBeVisible()
+		await expect(page.getByRole('tab', { name: 'Full documents' })).toBeVisible()
+		const changesTab = page.locator('.text-comparison .view-tabs').getByRole('tab', { name: 'Changes' })
+		const selectedBorderColor = await changesTab.evaluate((element) => getComputedStyle(element).borderBottomColor)
+		await changesTab.hover()
+		await expect(changesTab).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+		await expect(changesTab).toHaveCSS('border-bottom-color', selectedBorderColor)
+		await expect(changesTab).toHaveCSS('border-radius', '0px')
+		await page.keyboard.press('Tab')
+		await changesTab.focus()
+		await expect(changesTab).toHaveCSS('box-shadow', 'none')
+		await expect(changesTab).toHaveCSS('outline-style', 'solid')
+		const controls = dialog.locator('.version-comparison-dialog__selectors select, .version-comparison-dialog__selectors .copy')
+		const rectangles = await controls.evaluateAll((elements) => elements.map((element) => {
+			const rect = element.getBoundingClientRect()
+			return { top: rect.top, bottom: rect.bottom }
+		}))
+		expect(Math.max(...rectangles.map(({ top }) => top)) - Math.min(...rectangles.map(({ top }) => top))).toBeLessThan(1)
+		expect(Math.max(...rectangles.map(({ bottom }) => bottom)) - Math.min(...rectangles.map(({ bottom }) => bottom))).toBeLessThan(1)
+		await expect(dialog.getByRole('button', { name: 'Copy comparison link' })).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+
+		await page.setViewportSize({ width: 620, height: 900 })
+		await page.getByRole('tab', { name: 'Full documents' }).click()
+		await expect(page.locator('.text-comparison')).toHaveClass(/text-comparison--single/)
+		const documentSideTabs = page.locator('.text-comparison .side-tabs [role="tab"]')
+		expect(await documentSideTabs.evaluateAll((elements) => elements.map((element) => getComputedStyle(element).borderRadius))).toEqual(['0px', '0px'])
+
+		await page.getByRole('tab', { name: 'Markdown source' }).click()
+		const sourceSideTabs = page.locator('.text-source-comparison__side-tabs [role="tab"]')
+		await expect(sourceSideTabs).toHaveCount(2)
+		expect(await sourceSideTabs.evaluateAll((elements) => elements.map((element) => getComputedStyle(element).borderRadius))).toEqual(['0px', '0px'])
+	})
+
+	test('C01 displays a historical snapshot before the current snapshot', async ({ user, page, collective }) => {
+		await openSeededComparison(collective, user, page, 'c599-e2e-current-historical-page')
+		await page.getByRole('tab', { name: 'Full documents' }).click()
+		await expect(page.locator('.text-comparison__document--before')).toContainText('Historical comparison bytes')
+		await expect(page.locator('.text-comparison__document--after')).toContainText('Current comparison bytes')
+	})
+
+	test('C07 sends unsaved editor bytes to the current comparison', async ({ user, page, collective, editor }) => {
+		const collectivePage = await collective.createPage({ title: 'c599-e2e-comparison-page', user, page })
+		await seedVersionPair(collectivePage, user, page)
+		await collectivePage.open()
+		const sessionCreated = page.waitForResponse((response) => response.request().method() === 'PUT'
+			&& /\/apps\/text\/session\/.*\/create/.test(response.url()))
+		await collectivePage.switchMode(true)
+		await sessionCreated
+		await expect(page.locator('.text-menubar--ready')).toBeVisible()
+		editor.setMode(true)
+		const typedBytes = 'No-wait Playwright bytes 7f56c599'
+		await editor.getContent().fill(typedBytes)
+
+		await openVersions(page)
+		await page.getByRole('button', { name: 'Compare versions…' }).click()
+		await page.getByRole('dialog').getByRole('button', { name: 'Compare', exact: true }).click()
+		await page.getByRole('tab', { name: 'Full documents' }).click()
+		await expect(page.locator('.text-comparison__document--after')).toContainText(typedBytes)
+		await expect(collectivePage.getContent(true)).toBeAttached()
+	})
+
+	test('R01 encodes the exact ordered snapshot pair in the canonical route', async ({ user, page, collective }) => {
+		await openSeededComparison(collective, user, page, 'c599-e2e-canonical-route-page')
+		const comparison = new URL(page.url())
+		expect(comparison.searchParams.get('compareFrom')).toMatch(/^version:[^/\\]+$/)
+		expect(comparison.searchParams.get('compareTo')).toMatch(/^current:[^/\\]+$/)
+		const selectors = page.locator('.version-comparison-dialog select')
+		await expect(selectors.nth(0)).toHaveValue(comparison.searchParams.get('compareFrom')!)
+		await expect(selectors.nth(1)).toHaveValue('current')
+	})
+
+	test('R02 reload restores the exact comparison pair and view', async ({ user, page, collective }) => {
+		await openSeededComparison(collective, user, page, 'c599-e2e-reload-route-page')
+		await page.getByRole('tab', { name: 'Full documents' }).click()
+		const comparisonUrl = page.url()
+		const comparison = new URL(comparisonUrl)
+
+		await page.reload()
+
+		await expect(page.locator('.text-comparison')).toBeVisible()
+		await page.getByRole('tab', { name: 'Full documents' }).click()
+		await expect(page.locator('.text-comparison__document--before')).toContainText('Historical comparison bytes')
+		await expect(page.locator('.text-comparison__document--after')).toContainText('Current comparison bytes')
+		const restored = new URL(page.url())
+		expect(restored.searchParams.get('compareFrom')).toBe(comparison.searchParams.get('compareFrom'))
+		expect(restored.searchParams.get('compareTo')).toBe(comparison.searchParams.get('compareTo'))
+	})
+
+	test('R03 Back closes the managed comparison and restores the prior route', async ({ user, page, collective }) => {
+		await openSeededComparison(collective, user, page, 'c599-e2e-back-route-page')
+
+		await page.goBack()
+
+		await expect(page.locator('.version-comparison-dialog')).toHaveCount(0)
+		const restored = new URL(page.url())
+		expect(restored.searchParams.has('compareFrom')).toBe(false)
+		expect(restored.searchParams.has('compareTo')).toBe(false)
+	})
+
+	test('R04 Forward reopens the exact managed comparison state', async ({ user, page, collective }) => {
+		await openSeededComparison(collective, user, page, 'c599-e2e-forward-route-page')
+		const comparisonUrl = page.url()
+
+		await page.goBack()
+		await expect(page.locator('.version-comparison-dialog')).toHaveCount(0)
+		await page.goForward()
+
+		await expect(page).toHaveURL(comparisonUrl)
+		await expect(page.locator('.text-comparison')).toBeVisible()
+	})
+
+	test('R05 copied link opens the exact pair in a fresh authenticated context', async ({ user, page, collective }) => {
+		await openSeededComparison(collective, user, page, 'c599-e2e-copied-route-page')
+		const comparisonUrl = page.url()
+
+		await installClipboardCapture(page)
+		await page.getByRole('button', { name: 'Copy comparison link' }).click()
+		const copiedUrl = await page.evaluate(() => sessionStorage.getItem('c599-copied-link'))
+		expect(copiedUrl).toBe(comparisonUrl)
+
+		const copiedContext = await freshAuthenticatedContext(page)
+		const copiedPage = await copiedContext.newPage()
+		await copiedPage.goto(copiedUrl!)
+		await expect(copiedPage.locator('.text-comparison')).toBeVisible()
+		await copiedPage.getByRole('tab', { name: 'Full documents' }).click()
+		await expect(copiedPage.locator('.text-comparison__document--before')).toContainText('Historical comparison bytes')
+		await expect(copiedPage.locator('.text-comparison__document--after')).toContainText('Current comparison bytes')
+		const copiedPair = new URL(copiedPage.url())
+		expect(copiedPair.searchParams.get('compareFrom')).toBe(new URL(comparisonUrl).searchParams.get('compareFrom'))
+		expect(copiedPair.searchParams.get('compareTo')).toBe(new URL(comparisonUrl).searchParams.get('compareTo'))
+		await copiedContext.close()
+	})
+
+	test('F11 completes comparison with no unexplained browser or network failures', async ({ user, page, collective }) => {
+		const assertNoFailures = auditComparisonFailures(page)
+		await openSeededComparison(collective, user, page, 'c599-e2e-clean-failures-page')
+		await page.waitForLoadState('networkidle')
+
+		assertNoFailures()
+	})
+
+	test('C02 loads two immutable historical snapshots in chronological panes', async ({ user, page, collective }) => {
+		const collectivePage = await collective.createPage({ title: 'c599-e2e-historical-pair-page', user, page })
+		await seedTwoHistoricalVersions(collectivePage, user, page)
+		await collectivePage.open()
+		await openVersions(page)
+		await page.getByRole('button', { name: 'Compare versions…' }).click()
+		const selectors = page.locator('.version-comparison-dialog select')
+		await selectors.nth(0).selectOption({ index: 2 })
+		await selectors.nth(1).selectOption({ index: 1 })
+		await page.getByRole('dialog').getByRole('button', { name: 'Compare', exact: true }).click()
+		await page.getByRole('tab', { name: 'Full documents' }).click()
+		await expect(page.locator('.text-comparison__document--before')).toContainText('First historical comparison bytes')
+		await expect(page.locator('.text-comparison__document--after')).toContainText('Second historical comparison bytes')
+	})
+
+	test('C15 read-only member compares only permitted snapshots', async ({ readerAccount, user, page, baseURL, browser, collective }) => {
+		const collectivePage = await collective.createPage({ title: 'c599-e2e-read-only-comparison-page', user, page })
+		await seedVersionPair(collectivePage, user, page)
+		const memberResponse = await page.request.post(circlesApiUrl(collective.data.circleId, 'members'), {
+			headers: ocsHeaders,
+			data: { userId: readerAccount.userId, type: 1 },
+			failOnStatusCode: true,
+		})
+		const memberBody = await memberResponse.json()
+		expect(memberBody.ocs.meta.statuscode).toBe(200)
+		expect(memberBody.ocs.data).toMatchObject({ userId: readerAccount.userId })
+		await page.request.put(circlesApiUrl(collective.data.circleId, 'members', memberBody.ocs.data.id, 'level'), {
+			headers: ocsHeaders,
+			data: { level: 4 },
+			failOnStatusCode: true,
+		})
+		await page.request.put(apiUrl('v1.0', 'collectives', collective.data.id, 'editLevel'), {
+			headers: ocsHeaders,
+			data: { level: 8 },
+			failOnStatusCode: true,
+		})
+
+		const readerPage = await loginAsUser(browser, baseURL, readerAccount)
+		const snapshotStatuses: number[] = []
+		readerPage.on('response', (response) => {
+			if (SNAPSHOT_URL.test(response.url())) {
+				snapshotStatuses.push(response.status())
+			}
+		})
+		await readerPage.goto(collectivePage.getPageUrl())
+		await expect(readerPage.locator('button.titleform-button')).toHaveCount(0)
+		await openVersions(readerPage)
+		await readerPage.getByRole('button', { name: 'Compare versions…' }).click()
+		await readerPage.getByRole('dialog').getByRole('button', { name: 'Compare', exact: true }).click()
+		await expect(readerPage.locator('.text-comparison')).toBeVisible()
+		expect(snapshotStatuses.length).toBeGreaterThan(0)
+		expect(snapshotStatuses.every((status) => status >= 200 && status < 300)).toBe(true)
+		await readerPage.close()
+	})
+
+	test('C16 rejects public comparison parameters without snapshot requests', async ({ user, page, collective }) => {
+		const collectivePage = await collective.createPage({ title: 'c599-e2e-public-comparison-page', user, page })
+		const share = await collective.createShare({ page })
+		try {
+			const snapshotRequests: string[] = []
+			page.on('request', (request) => {
+				if (SNAPSHOT_URL.test(request.url())) {
+					snapshotRequests.push(request.url())
+				}
+			})
+			await page.goto(`${collectivePage.getPageUrl(share.data.token)}?compareFrom=version:1&compareTo=current:2&view=grid#kept`)
+			await expect(page.locator('#tab-button-versions')).toHaveCount(0)
+			await expect(page.locator('.version-comparison-dialog')).toHaveCount(0)
+			await expect(page).toHaveURL(/\?view=grid#kept$/)
+			expect(snapshotRequests).toEqual([])
+		} finally {
+			await share.delete()
+		}
+	})
+
+	test('R06 preserves the exact pair while canonicalizing a renamed page path', async ({ user, page, collective }) => {
+		const collectivePage = await collective.createPage({ title: 'c599-e2e-route-rename-page', user, page })
+		await seedVersionPair(collectivePage, user, page)
+		await collectivePage.open()
+		await openVersions(page)
+		await page.getByRole('button', { name: 'Compare versions…' }).click()
+		await page.getByRole('dialog').getByRole('button', { name: 'Compare', exact: true }).click()
+		await expect(page.locator('.text-comparison')).toBeVisible()
+		const beforeRename = new URL(page.url())
+		const pair = [beforeRename.searchParams.get('compareFrom'), beforeRename.searchParams.get('compareTo')]
+
+		await page.request.put(apiUrl('v1.0', 'collectives', collective.data.id, 'pages', collectivePage.data.id), {
+			headers: ocsHeaders,
+			data: { title: 'c599-e2e-renamed-comparison-page' },
+			failOnStatusCode: true,
+		})
+		await page.reload()
+		await expect(page).toHaveURL(/c599-e2e-renamed-comparison-page/)
+		const afterRename = new URL(page.url())
+		expect([afterRename.searchParams.get('compareFrom'), afterRename.searchParams.get('compareTo')]).toEqual(pair)
+		await expect(page.locator('.text-comparison')).toBeVisible()
+	})
+
+	test('AUD-03 binds displayed current bytes and route identity to the committed snapshot', async ({ user, page, collective, editor }) => {
+		const collectivePage = await collective.createPage({ title: 'c599-e2e-committed-generation-page', user, page })
+		await seedVersionPair(collectivePage, user, page)
+		await collectivePage.open()
+		const sessionCreated = page.waitForResponse((response) => response.request().method() === 'PUT'
+			&& /\/apps\/text\/session\/.*\/create/.test(response.url()))
+		await collectivePage.switchMode(true)
+		await sessionCreated
+		await expect(page.locator('.text-menubar--ready')).toBeVisible()
+		editor.setMode(true)
+		const typedBytes = 'Committed generation bytes 7f56c599'
+		await editor.getContent().fill(typedBytes)
+		const currentSnapshotGets: string[] = []
+		page.on('request', (request) => {
+			if (request.method() === 'GET'
+				&& /\/remote\.php\/dav\/versions\//.test(request.url())
+				&& new URL(request.url()).searchParams.has('timestamp')) {
+				currentSnapshotGets.push(request.url())
+			}
+		})
+
+		await openVersions(page)
+		await page.getByRole('button', { name: 'Compare versions…' }).click()
+		await page.getByRole('dialog').getByRole('button', { name: 'Compare', exact: true }).click()
+		await page.getByRole('tab', { name: 'Full documents' }).click()
+
+		await expect(page.locator('.text-comparison__document--after')).toContainText(typedBytes)
+		await expect.poll(() => currentSnapshotGets.length).toBeGreaterThan(0)
+		const currentSnapshotUrl = new URL(currentSnapshotGets[currentSnapshotGets.length - 1])
+		const pathParts = currentSnapshotUrl.pathname.split('/')
+		const requestedIdentity = decodeURIComponent(pathParts[pathParts.length - 1])
+		expect(new URL(page.url()).searchParams.get('compareTo')).toBe(`current:${requestedIdentity}`)
+	})
+
+	test('AUD-08 bounds streamed snapshot bodies and does not cache oversized failures', async ({ user, page, collective }) => {
+		const oversizedBody = 'x'.repeat(2_000_001)
+		let completeHistoricalGets = 0
+		const collectivePage = await collective.createPage({ title: 'c599-e2e-stream-limit-page', user, page })
+		await seedVersionPair(collectivePage, user, page)
+		const context = await freshAuthenticatedContext(page, 'block')
+		const boundedPage = await context.newPage()
+		await boundedPage.route(/\/remote\.php\/dav\/versions\//, async (route) => {
+			const request = route.request()
+			const url = new URL(request.url())
+			if (request.method() !== 'GET' || url.searchParams.has('timestamp')) {
+				await route.continue()
+				return
+			}
+			if (request.headers().range) {
+				await route.fulfill({
+					body: 'Bounded historical preview',
+					headers: { 'Content-Range': 'bytes 0-25/2000001' },
+					status: 206,
+				})
+				return
+			}
+			completeHistoricalGets += 1
+			await route.fulfill({ body: oversizedBody, status: 200 })
+		})
+
+		try {
+			await boundedPage.goto(collectivePage.getPageUrl())
+			await boundedPage.locator('[data-cy-collectives="reader"] .ProseMirror').waitFor({ state: 'visible' })
+			await openVersions(boundedPage)
+			await boundedPage.getByRole('button', { name: 'Compare versions…' }).click()
+			const dialog = boundedPage.getByRole('dialog', { name: 'Compare versions' })
+			await expect(dialog).toBeVisible()
+			await dialog.getByRole('button', { name: 'Compare', exact: true }).click()
+
+			await expect(dialog.getByRole('alert')).toContainText('too large for complete comparison')
+			await expect(dialog.locator('.version-comparison-dialog__preview')).toContainText('Bounded historical preview')
+			await expect(dialog.locator('.text-comparison')).toHaveCount(0)
+			expect(completeHistoricalGets).toBe(1)
+
+			await dialog.getByRole('button', { name: 'Retry' }).click()
+			await expect.poll(() => completeHistoricalGets).toBe(2)
+			await expect(dialog.getByRole('alert')).toContainText('too large for complete comparison')
+			await expect(dialog.locator('.text-comparison')).toHaveCount(0)
+		} finally {
+			await context.close()
+		}
+	})
+
+	test('AUD-15 clears the historical snapshot cache when the dialog closes', async ({ user, page, collective }) => {
+		const historicalSnapshotGets: string[] = []
+		page.on('request', (request) => {
+			const url = new URL(request.url())
+			if (request.method() === 'GET'
+				&& /\/remote\.php\/dav\/versions\//.test(url.pathname)
+				&& !url.searchParams.has('timestamp')) {
+				historicalSnapshotGets.push(request.url())
+			}
+		})
+		const { dialog } = await openSeededComparison(collective, user, page, 'c599-e2e-cache-lifecycle-page')
+		await expect.poll(() => historicalSnapshotGets.length).toBe(1)
+
+		await dialog.focus()
+		await page.keyboard.press('Escape')
+		await expect(page.locator('.version-comparison-dialog')).toHaveCount(0)
+		await page.getByRole('button', { name: 'Compare versions…' }).click()
+		await page.getByRole('dialog').getByRole('button', { name: 'Compare', exact: true }).click()
+		await expect(page.locator('.text-comparison')).toBeVisible()
+
+		await expect.poll(() => historicalSnapshotGets.length).toBe(2)
+	})
+
+	test('AUD-20 rejects current aliases that resolve to the same snapshot before body fetch', async ({ user, page, collective }) => {
+		await openSeededComparison(collective, user, page, 'c599-e2e-route-self-pair-page')
+		const currentRouteId = new URL(page.url()).searchParams.get('compareTo')
+		expect(currentRouteId).toMatch(/^current:[^/\\]+$/)
+		await page.getByRole('dialog', { name: 'Compare versions' }).getByRole('button', { name: 'Close' }).click()
+		await expect(page.locator('.version-comparison-dialog')).toHaveCount(0)
+
+		const snapshotGets: string[] = []
+		page.on('request', (request) => {
+			if (request.method() === 'GET' && /\/remote\.php\/dav\/versions\//.test(request.url())) {
+				snapshotGets.push(request.url())
+			}
+		})
+		const aliasUrl = new URL(page.url())
+		aliasUrl.searchParams.set('compareFrom', currentRouteId!)
+		aliasUrl.searchParams.set('compareTo', 'current')
+		await page.goto(aliasUrl.toString())
+
+		const dialog = page.getByRole('dialog', { name: 'Compare versions' })
+		await expect(dialog.getByRole('status')).toContainText('Select two different versions.')
+		await expect(dialog.getByRole('alert')).toHaveCount(0)
+		await expect(dialog.getByRole('button', { name: 'Retry' })).toHaveCount(0)
+		expect(snapshotGets).toEqual([])
+	})
+
+	test('AUD-09 settled forward and backward Tab remain inside the comparison dialog', async ({ user, page, collective }) => {
+		const { dialog } = await openSeededVersionSelector(collective, user, page, 'c599-e2e-focus-containment-page')
+		const focusableSelector = 'a[href], button:not([disabled]), select:not([disabled]), textarea:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+		await expect.poll(async () => dialog.evaluate((element, selector) => (
+			Array.from(element.querySelectorAll<HTMLElement>(selector))
+				.filter((candidate) => candidate.getClientRects().length > 0)
+				.length
+		), focusableSelector)).toBeGreaterThan(1)
+
+		await dialog.evaluate((element, selector) => {
+			const focusable = Array.from(element.querySelectorAll<HTMLElement>(selector))
+				.filter((candidate) => candidate.getClientRects().length > 0)
+			focusable[focusable.length - 1]?.focus()
+		}, focusableSelector)
+		await page.keyboard.press('Tab')
+		expect(await dialog.evaluate((element) => element.contains(document.activeElement))).toBe(true)
+
+		await dialog.evaluate((element, selector) => {
+			const focusable = Array.from(element.querySelectorAll<HTMLElement>(selector))
+				.filter((candidate) => candidate.getClientRects().length > 0)
+			focusable[0]?.focus()
+		}, focusableSelector)
+		await page.keyboard.press('Shift+Tab')
+		expect(await dialog.evaluate((element) => element.contains(document.activeElement))).toBe(true)
+	})
+
+	test('AUD-09 Escape restores focus to the exact comparison opener', async ({ user, page, collective }) => {
+		const { dialog, opener } = await openSeededVersionSelector(collective, user, page, 'c599-e2e-focus-restore-page')
+
+		await dialog.focus()
+		await page.keyboard.press('Escape')
+
+		await expect(dialog).toHaveCount(0)
+		await expect(opener).toBeFocused()
+	})
+
+	test('AUD-21 throwing destroy still clears dialog route cache and restores focus', async ({ user, page, collective }) => {
+		const { dialog, opener } = await openSeededVersionSelector(collective, user, page, 'c599-e2e-throwing-destroy-page')
+		const historicalSnapshotGets: string[] = []
+		page.on('request', (request) => {
+			if (request.method() === 'GET' && /\/remote\.php\/dav\/versions\//.test(request.url())) {
+				historicalSnapshotGets.push(request.url())
+			}
+		})
+		await page.evaluate(() => {
+			const auditWindow = window as typeof window & { __c599DestroyCalls?: number }
+			auditWindow.__c599DestroyCalls = 0
+			Object.defineProperty(window.OCA.Text, 'createMarkdownContentComparison', {
+				configurable: true,
+				value: async ({ el }: { el: HTMLElement }) => {
+					const marker = document.createElement('div')
+					marker.className = 'c599-throwing-destroy-comparison'
+					marker.textContent = 'Comparison ready'
+					el.append(marker)
+					return {
+						destroy() {
+							auditWindow.__c599DestroyCalls! += 1
+							throw new Error('AUD-21 destroy failure')
+						},
+					}
+				},
+			})
+		})
+
+		await dialog.getByRole('button', { name: 'Compare', exact: true }).click()
+		await expect(dialog.locator('.c599-throwing-destroy-comparison')).toBeVisible()
+		await expect.poll(() => new URL(page.url()).searchParams.has('compareFrom')).toBe(true)
+		expect(historicalSnapshotGets.length).toBeGreaterThan(0)
+		const firstFetchCount = historicalSnapshotGets.length
+
+		await dialog.focus()
+		await page.keyboard.press('Escape')
+
+		await expect(dialog).toHaveCount(0)
+		await expect.poll(() => {
+			const url = new URL(page.url())
+			return [url.searchParams.get('compareFrom'), url.searchParams.get('compareTo')]
+		}).toEqual([null, null])
+		await expect(opener).toBeFocused()
+		await expect.poll(() => page.evaluate(() => (
+			window as typeof window & { __c599DestroyCalls?: number }
+		).__c599DestroyCalls)).toBe(1)
+
+		await opener.click()
+		await dialog.getByRole('button', { name: 'Compare', exact: true }).click()
+		await expect(dialog.locator('.c599-throwing-destroy-comparison')).toBeVisible()
+		await expect.poll(() => historicalSnapshotGets.length).toBeGreaterThan(firstFetchCount)
+	})
+
+	test('AUD-21 malformed semantic factory fails closed without publishing content or route', async ({ user, page, collective }) => {
+		const { dialog } = await openSeededVersionSelector(collective, user, page, 'c599-e2e-malformed-factory-page')
+		await page.evaluate(() => {
+			Object.defineProperty(window.OCA.Text, 'createMarkdownContentComparison', {
+				configurable: true,
+				value: async ({ el }: { el: HTMLElement }) => {
+					const marker = document.createElement('div')
+					marker.className = 'c599-malformed-factory-content'
+					el.append(marker)
+					return {}
+				},
+			})
+		})
+
+		await dialog.getByRole('button', { name: 'Compare', exact: true }).click()
+
+		await expect(dialog.getByRole('alert')).toContainText('Could not initialize version comparison.')
+		await expect(dialog.locator('.c599-malformed-factory-content')).toHaveCount(0)
+		await expect(dialog.locator('.version-comparison-dialog__comparison')).toBeEmpty()
+		const url = new URL(page.url())
+		expect([url.searchParams.get('compareFrom'), url.searchParams.get('compareTo')]).toEqual([null, null])
+	})
+
+	test('AUD-21 delayed stale factory instance is destroyed exactly once', async ({ user, page, collective }) => {
+		const { dialog, opener } = await openSeededVersionSelector(collective, user, page, 'c599-e2e-delayed-stale-factory-page')
+		await page.evaluate(() => {
+			interface DelayedFactoryState {
+				destroyCalls: number
+				pending: boolean
+				release?: () => void
+			}
+			const auditWindow = window as typeof window & { __c599DelayedFactory?: DelayedFactoryState }
+			const state: DelayedFactoryState = { destroyCalls: 0, pending: false }
+			auditWindow.__c599DelayedFactory = state
+			Object.defineProperty(window.OCA.Text, 'createMarkdownContentComparison', {
+				configurable: true,
+				value: async ({ el }: { el: HTMLElement }) => {
+					const marker = document.createElement('div')
+					marker.className = 'c599-delayed-factory-content'
+					el.append(marker)
+					state.pending = true
+					await new Promise<void>((resolve) => {
+						state.release = resolve
+					})
+					return {
+						destroy() {
+							state.destroyCalls += 1
+						},
+					}
+				},
+			})
+		})
+
+		await dialog.getByRole('button', { name: 'Compare', exact: true }).click()
+		await expect.poll(() => page.evaluate(() => (
+			window as typeof window & { __c599DelayedFactory?: { pending: boolean } }
+		).__c599DelayedFactory?.pending)).toBe(true)
+
+		await dialog.focus()
+		await page.keyboard.press('Escape')
+		await expect(dialog).toHaveCount(0)
+		await expect(opener).toBeFocused()
+		await page.evaluate(() => (
+			window as typeof window & { __c599DelayedFactory?: { release?: () => void } }
+		).__c599DelayedFactory?.release?.())
+		await expect.poll(() => page.evaluate(() => (
+			window as typeof window & { __c599DelayedFactory?: { destroyCalls: number } }
+		).__c599DelayedFactory?.destroyCalls)).toBe(1)
+		await page.waitForTimeout(100)
+		expect(await page.evaluate(() => (
+			window as typeof window & { __c599DelayedFactory?: { destroyCalls: number } }
+		).__c599DelayedFactory?.destroyCalls)).toBe(1)
+		await expect(page.locator('.c599-delayed-factory-content')).toHaveCount(0)
+	})
+
+	test('X03 uses existing Viewer.compare when the Text semantic factory is absent', { tag: '@viewer-fallback' }, async ({ user, page, collective }) => {
+		const assertNoFailures = auditComparisonFailures(page)
+		const collectivePage = await collective.createPage({ title: 'c599-e2e-viewer-fallback-page', user, page })
+		await seedVersionPair(collectivePage, user, page)
+		await collectivePage.open()
+		await openVersions(page)
+		await page.evaluate(() => {
+			Object.defineProperty(window.OCA.Text, 'createMarkdownContentComparison', {
+				configurable: true,
+				value: async ({ el }: { el: HTMLElement }) => {
+					const marker = document.createElement('div')
+					marker.className = 'viewer-fallback-route-source'
+					el.append(marker)
+					return { destroy: () => marker.remove() }
+				},
+			})
+		})
+		await page.getByRole('button', { name: 'Compare versions…' }).click()
+		await page.getByRole('dialog').getByRole('button', { name: 'Compare', exact: true }).click()
+		await expect(page.locator('.viewer-fallback-route-source')).toHaveCount(1)
+		await expect(page).toHaveURL(/compareFrom=/)
+		const comparisonUrl = page.url()
+		const comparisonPair = new URL(comparisonUrl)
+		await page.goBack()
+		await expect(page.locator('.version-comparison-dialog')).toHaveCount(0)
+		await page.evaluate(() => {
+			Object.defineProperty(window.OCA.Text, 'createMarkdownContentComparison', {
+				configurable: true,
+				value: undefined,
+			})
+		})
+		await page.evaluate((url) => {
+			window.history.pushState({}, '', url)
+			window.dispatchEvent(new PopStateEvent('popstate', { state: window.history.state }))
+		}, comparisonUrl)
+		const viewerPanes = page.locator('#viewer .viewer--split > .viewer__file-wrapper:visible')
+		await expect(viewerPanes).toHaveCount(2)
+		await expect(page.locator('.version-comparison-dialog')).toHaveCount(0)
+		const retained = new URL(page.url())
+		expect([retained.searchParams.get('compareFrom'), retained.searchParams.get('compareTo')]).toEqual([
+			comparisonPair.searchParams.get('compareFrom'),
+			comparisonPair.searchParams.get('compareTo'),
+		])
+		await expect(viewerPanes.nth(0)).toContainText('Historical comparison bytes')
+		await expect(viewerPanes.nth(1)).toContainText('Current comparison bytes')
+		assertNoFailures()
+	})
+})

--- a/playwright/start-nextcloud-server.js
+++ b/playwright/start-nextcloud-server.js
@@ -5,14 +5,21 @@
 
 import {
 	configureNextcloud,
+	getContainer,
 	runExec,
 	startNextcloud,
 	stopNextcloud,
 	waitOnNextcloud,
 } from '@nextcloud/e2e-test-server/docker'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 const serverBranch = process.env.PLAYWRIGHT_NC_SERVER_BRANCH ?? 'master'
-const textBranch = serverBranch === 'master' ? 'main' : serverBranch
+const textRef = process.env.PLAYWRIGHT_TEXT_REF ?? (serverBranch === 'master' ? 'main' : serverBranch)
+const textRepository = process.env.PLAYWRIGHT_TEXT_REPOSITORY ?? 'nextcloud/text'
+const textRepositoryUrl = `https://github.com/${textRepository}.git`
 
 /**
  *
@@ -35,6 +42,45 @@ async function start() {
 	})
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
+async function checkoutText() {
+	if (!/^[0-9a-f]{40}$/.test(textRef)) {
+		await runExec(['git', 'clone', '--depth=1', `--branch=${textRef}`, textRepositoryUrl, 'apps/text'], { verbose: true })
+		return
+	}
+
+	await runExec(['git', 'init', 'apps/text'], { verbose: true })
+	await runExec(['git', '-C', 'apps/text', 'remote', 'add', 'origin', textRepositoryUrl], { verbose: true })
+	await runExec(['git', '-C', 'apps/text', 'fetch', '--depth=1', 'origin', textRef], { verbose: true })
+	await runExec(['git', '-C', 'apps/text', 'checkout', '--detach', 'FETCH_HEAD'], { verbose: true })
+	const { stdout } = await runExec(['git', '-C', 'apps/text', 'rev-parse', 'HEAD'])
+	if (stdout.trim() !== textRef) {
+		throw new Error(`Text checkout resolved to ${stdout.trim()}, expected ${textRef}`)
+	}
+}
+
+/**
+ * Build Text with the host Node runtime and install its assets in the test server.
+ */
+function buildText() {
+	const directory = mkdtempSync(join(tmpdir(), 'collectives-text-'))
+	const target = `${getContainer().id}:/var/www/html/apps/text`
+	try {
+		execFileSync('docker', ['cp', `${target}/.`, directory], { stdio: 'inherit' })
+		execFileSync('npm', ['ci'], {
+			cwd: directory,
+			stdio: 'inherit',
+			env: { ...process.env, CYPRESS_INSTALL_BINARY: '0' },
+		})
+		execFileSync('npm', ['run', 'build'], { cwd: directory, stdio: 'inherit' })
+		for (const path of ['js', 'css']) {
+			execFileSync('docker', ['cp', `${directory}/${path}/.`, `${target}/${path}`], { stdio: 'inherit' })
+		}
+	} finally {
+		rmSync(directory, { recursive: true, force: true })
+	}
+}
+
 /**
  * Stops the Nextcloud server and exits the process.
  */
@@ -54,7 +100,10 @@ if (await isServerRunning()) {
 	const ip = await start()
 	await waitOnNextcloud(ip)
 	await runExec(['git', 'clone', '--depth=1', `--branch=${serverBranch}`, 'https://github.com/nextcloud/password_policy.git', 'apps/password_policy'], { verbose: true })
-	await runExec(['git', 'clone', '--depth=1', `--branch=${textBranch}`, 'https://github.com/nextcloud/text.git', 'apps/text'], { verbose: true })
+	await checkoutText()
+	if (process.env.COLLECTIVES_SEMANTIC_E2E === '1') {
+		buildText()
+	}
 	await configureNextcloud(['collectives', 'circles', 'files_pdfviewer', 'files_lock', 'notifications', 'text', 'viewer'])
 }
 

--- a/playwright/support/fixtures/random-user.ts
+++ b/playwright/support/fixtures/random-user.ts
@@ -24,7 +24,11 @@ export interface UserFixture {
  */
 export async function loginAsUser(browser: Browser, baseURL: string | undefined, account: Account): Promise<Page> {
 	// Important: make sure we authenticate in a clean environment by unsetting storage state.
-	const page = await browser.newPage({ storageState: undefined, baseURL })
+	const page = await browser.newPage({
+		storageState: undefined,
+		baseURL,
+		ignoreHTTPSErrors: baseURL?.startsWith('https://nextcloud.local') ?? false,
+	})
 	await login(page.request, account)
 	const tokenResponse = await page.request.get('./csrftoken', { failOnStatusCode: true })
 	const { token } = (await tokenResponse.json()) as { token: string }

--- a/playwright/support/helpers/versionComparisonFixtures.ts
+++ b/playwright/support/helpers/versionComparisonFixtures.ts
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/* eslint-disable jsdoc/require-jsdoc */
+
+export const VERSION_COMPARISON_FIXTURE_PREFIX = 'vc-e2e-'
+
+export type VersionComparisonAccount = {
+	userId: string
+	password: string
+	language: string
+}
+
+type OccOptions = {
+	env?: string[]
+	failOnError?: boolean
+}
+
+type OccRunner = (command: string[], options?: OccOptions) => Promise<unknown>
+
+export function assertVersionComparisonFixtureName(name: string): void {
+	if (!name.startsWith(VERSION_COMPARISON_FIXTURE_PREFIX) || name.length === VERSION_COMPARISON_FIXTURE_PREFIX.length) {
+		throw new Error(`Fixture mutations require a ${VERSION_COMPARISON_FIXTURE_PREFIX} name`)
+	}
+}
+
+export function createVersionComparisonAccount(
+	role: string,
+	suffix: string | number,
+	passwordFactory: () => string,
+): VersionComparisonAccount {
+	const userId = `${VERSION_COMPARISON_FIXTURE_PREFIX}${role}-${suffix}`
+	assertVersionComparisonFixtureName(userId)
+	return {
+		userId,
+		password: `VersionComparison-${passwordFactory()}-Strong`,
+		language: 'en',
+	}
+}
+
+export async function provisionVersionComparisonUser(account: VersionComparisonAccount, runOcc: OccRunner): Promise<void> {
+	assertVersionComparisonFixtureName(account.userId)
+	await runOcc(['user:delete', account.userId], { failOnError: false })
+	await runOcc([
+		'user:add',
+		'--password-from-env',
+		`--display-name=${account.userId}`,
+		account.userId,
+	], { env: [`OC_PASS=${account.password}`] })
+}
+
+export async function deleteVersionComparisonUser(userId: string, runOcc: OccRunner): Promise<void> {
+	assertVersionComparisonFixtureName(userId)
+	await runOcc(['user:delete', userId])
+}

--- a/src/components/CollectiveContainer.vue
+++ b/src/components/CollectiveContainer.vue
@@ -55,6 +55,7 @@ import { useSharesStore } from '../stores/shares.js'
 import { useTagsStore } from '../stores/tags.js'
 import { useVersionsStore } from '../stores/versions.js'
 import displayError from '../util/displayError.js'
+import { canonicalPathRoute } from '../util/versionComparisonRoute.js'
 
 export default {
 	name: 'CollectiveContainer',
@@ -163,13 +164,10 @@ export default {
 			if (this.currentCollective
 				&& this.isLandingPage
 				&& this.$route.path !== this.currentCollectivePath) {
-				this.$router.replace({ path: this.currentCollectivePath, hash: document.location.hash })
+				this.$router.replace(canonicalPathRoute(this.$route, this.currentCollectivePath))
 			} else if (this.currentPage
-				&& this.$route.fullPath !== this.currentPagePath) {
-				this.$router.replace({
-					path: this.currentPagePath,
-					hash: document.location.hash,
-				})
+				&& this.$route.path !== this.currentPagePath) {
+				this.$router.replace(canonicalPathRoute(this.$route, this.currentPagePath))
 			}
 		},
 	},

--- a/src/components/Page/PageTitleBar.vue
+++ b/src/components/Page/PageTitleBar.vue
@@ -135,6 +135,7 @@ import pageMixin from '../../mixins/pageMixin.js'
 import { useCollectivesStore } from '../../stores/collectives.js'
 import { usePagesStore } from '../../stores/pages.js'
 import { useRootStore } from '../../stores/root.js'
+import { canonicalPathRoute } from '../../util/versionComparisonRoute.js'
 
 export default {
 	name: 'PageTitleBar',
@@ -296,7 +297,7 @@ export default {
 				// The resulting title may be different due to sanitizing
 				this.newTitle = this.currentPage.title
 				this.getPages(false)
-				await this.$router.replace(this.currentPagePath)
+				await this.$router.replace(canonicalPathRoute(this.$route, this.currentPagePath))
 			} catch (e) {
 				console.error(e)
 				showError(t('collectives', 'Could not rename the page'))

--- a/src/components/PageSidebar.vue
+++ b/src/components/PageSidebar.vue
@@ -39,7 +39,7 @@
 			<SidebarTabSharing v-if="showingSidebar" :pageId="currentPageId" />
 		</NcAppSidebarTab>
 		<NcAppSidebarTab
-			v-if="!isPublic && currentCollectiveCanEdit"
+			v-if="!isPublic"
 			id="versions"
 			:order="3"
 			:name="t('collectives', 'Versions')">
@@ -55,6 +55,7 @@
 </template>
 
 <script>
+import { showWarning } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
 import { mapActions, mapState } from 'pinia'
 import NcAppSidebar from '@nextcloud/vue/components/NcAppSidebar'
@@ -71,6 +72,11 @@ import { useCollectivesStore } from '../stores/collectives.js'
 import { usePagesStore } from '../stores/pages.js'
 import { useRootStore } from '../stores/root.js'
 import { useVersionsStore } from '../stores/versions.js'
+import {
+	claimVersionComparisonRouteWarning,
+	parseVersionComparisonRoute,
+	rejectedVersionComparisonRoute,
+} from '../util/versionComparisonRoute.js'
 
 export default {
 	name: 'PageSidebar',
@@ -88,12 +94,15 @@ export default {
 		SidebarTabVersions,
 	},
 
+	data() {
+		return {
+			comparisonRouteHandling: false,
+		}
+	},
+
 	computed: {
 		...mapState(useRootStore, ['activeSidebarTab', 'isPublic', 'showingSidebar']),
-		...mapState(useCollectivesStore, [
-			'currentCollectiveCanEdit',
-			'currentCollectiveCanShare',
-		]),
+		...mapState(useCollectivesStore, ['currentCollectiveCanShare']),
 
 		...mapState(usePagesStore, ['currentPage', 'currentPageId', 'title']),
 
@@ -122,6 +131,15 @@ export default {
 		},
 	},
 
+	watch: {
+		'$route.fullPath': 'handleComparisonRoute',
+		currentPageId: 'handleComparisonRoute',
+	},
+
+	mounted() {
+		this.handleComparisonRoute()
+	},
+
 	methods: {
 		t,
 
@@ -139,6 +157,37 @@ export default {
 		close() {
 			this.selectVersion(null)
 			this.hideSidebar()
+		},
+
+		async handleComparisonRoute() {
+			if (this.comparisonRouteHandling || !this.currentPageId) {
+				return
+			}
+			const comparisonRoute = parseVersionComparisonRoute(this.$route.query)
+			if (comparisonRoute.kind === 'absent') {
+				return
+			}
+
+			if (comparisonRoute.kind === 'valid' && !this.isPublic) {
+				this.showSidebar()
+				this.setActiveSidebarTab('versions')
+				return
+			}
+
+			this.comparisonRouteHandling = true
+			const warning = claimVersionComparisonRouteWarning(this.$route.query)
+				? comparisonRoute.kind === 'invalid'
+					? t('collectives', 'This version comparison link is invalid.')
+					: t('collectives', 'Version comparison is not available for public links.')
+				: null
+			try {
+				await this.$router.replace(rejectedVersionComparisonRoute(this.$route))
+			} finally {
+				this.comparisonRouteHandling = false
+				if (warning) {
+					showWarning(warning)
+				}
+			}
 		},
 	},
 }

--- a/src/tests/playwrightConfig.spec.ts
+++ b/src/tests/playwrightConfig.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const originalBaseURL = process.env.baseURL
+const originalSemanticE2E = process.env.COLLECTIVES_SEMANTIC_E2E
+
+afterEach(() => {
+	if (originalBaseURL === undefined) {
+		delete process.env.baseURL
+	} else {
+		process.env.baseURL = originalBaseURL
+	}
+	if (originalSemanticE2E === undefined) {
+		delete process.env.COLLECTIVES_SEMANTIC_E2E
+	} else {
+		process.env.COLLECTIVES_SEMANTIC_E2E = originalSemanticE2E
+	}
+})
+
+async function loadConfig(baseURL: string | undefined, semanticE2E = false) {
+	if (baseURL === undefined) {
+		delete process.env.baseURL
+	} else {
+		process.env.baseURL = baseURL
+	}
+	process.env.COLLECTIVES_SEMANTIC_E2E = semanticE2E ? '1' : '0'
+	vi.resetModules()
+	return (await import('../../playwright.config.ts')).default
+}
+
+describe('Playwright server selection', () => {
+	it.each([undefined, ''])('uses the managed server for %s baseURL', async (baseURL) => {
+		const config = await loadConfig(baseURL)
+
+		expect(config.use?.baseURL).toBe('http://localhost:8089/index.php/')
+		expect(config.webServer).toBeDefined()
+	})
+
+	it('uses a non-empty external baseURL without the managed server', async () => {
+		const config = await loadConfig('https://nextcloud.local/index.php/')
+
+		expect(config.use?.baseURL).toBe('https://nextcloud.local/index.php/')
+		expect(config.webServer).toBeUndefined()
+	})
+
+	it('runs only the tagged Viewer fallback in the stable project', async () => {
+		const config = await loadConfig(undefined)
+		const project = config.projects?.find(({ name }) => name === 'comparison-viewer-chromium')
+
+		expect(project?.grep).toEqual(/@viewer-fallback/)
+		expect(config.projects?.map(({ name }) => name)).not.toContain('comparison-chromium')
+	})
+
+	it('runs semantic comparison in Chromium without the Viewer fallback', async () => {
+		const config = await loadConfig(undefined, true)
+		const projects = config.projects?.filter(({ name }) => name?.startsWith('comparison-') && name !== 'comparison-viewer-chromium')
+
+		expect(projects?.map(({ name }) => name)).toEqual(['comparison-chromium'])
+		expect(projects?.map(({ grepInvert }) => grepInvert)).toEqual([/@viewer-fallback/])
+	})
+})

--- a/src/tests/util/versionComparisonE2eFixtures.spec.ts
+++ b/src/tests/util/versionComparisonE2eFixtures.spec.ts
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+	assertVersionComparisonFixtureName,
+	createVersionComparisonAccount,
+	deleteVersionComparisonUser,
+	provisionVersionComparisonUser,
+} from '../../../playwright/support/helpers/versionComparisonFixtures.ts'
+
+describe('version comparison persistent-stack fixtures', () => {
+	it.each([
+		'owner',
+		'vc-owner',
+		'vc-e2e',
+		'other-vc-e2e-owner',
+	])('rejects non-namespaced fixture mutations for %s', (name) => {
+		expect(() => assertVersionComparisonFixtureName(name)).toThrow('vc-e2e-')
+	})
+
+	it('creates a namespaced account with an opaque password', () => {
+		const account = createVersionComparisonAccount('pw-owner', 7, () => 'opaque-secret')
+
+		expect(account).toEqual({
+			userId: 'vc-e2e-pw-owner-7',
+			password: 'VersionComparison-opaque-secret-Strong',
+			language: 'en',
+		})
+	})
+
+	it('keeps the longest browser worker account within the server limit', () => {
+		const account = createVersionComparisonAccount('pw-owner-12345678-comparison-viewer-chromium', 0, () => 'opaque-secret')
+
+		expect(account.userId.length).toBeLessThanOrEqual(64)
+	})
+
+	it('provisions only an exact namespaced user with password-from-env', async () => {
+		const runOcc = vi.fn().mockResolvedValue({ exitCode: 0 })
+		const account = createVersionComparisonAccount('owner', 'cypress', () => 'opaque-secret')
+
+		await provisionVersionComparisonUser(account, runOcc)
+
+		expect(runOcc).toHaveBeenNthCalledWith(1, ['user:delete', account.userId], { failOnError: false })
+		expect(runOcc).toHaveBeenNthCalledWith(2, [
+			'user:add',
+			'--password-from-env',
+			`--display-name=${account.userId}`,
+			account.userId,
+		], { env: ['OC_PASS=VersionComparison-opaque-secret-Strong'] })
+	})
+
+	it('fails closed before provisioning a non-namespaced user', async () => {
+		const runOcc = vi.fn()
+
+		await expect(provisionVersionComparisonUser({
+			userId: 'developer',
+			password: 'opaque-secret',
+			language: 'en',
+		}, runOcc)).rejects.toThrow('vc-e2e-')
+		expect(runOcc).not.toHaveBeenCalled()
+	})
+
+	it('deletes only the exact namespaced user and surfaces cleanup failures', async () => {
+		const runOcc = vi.fn().mockResolvedValue({ exitCode: 0 })
+
+		await deleteVersionComparisonUser('vc-e2e-owner-cypress', runOcc)
+
+		expect(runOcc).toHaveBeenCalledExactlyOnceWith(['user:delete', 'vc-e2e-owner-cypress'])
+	})
+
+	it('fails closed before deleting a non-namespaced user', async () => {
+		const runOcc = vi.fn()
+
+		await expect(deleteVersionComparisonUser('developer', runOcc)).rejects.toThrow('vc-e2e-')
+		expect(runOcc).not.toHaveBeenCalled()
+	})
+})

--- a/src/tests/util/versionComparisonRoute.spec.js
+++ b/src/tests/util/versionComparisonRoute.spec.js
@@ -6,8 +6,10 @@
 import { describe, expect, it } from 'vitest'
 import {
 	canonicalPathRoute,
+	claimVersionComparisonRouteWarning,
 	MAX_COMPARISON_ID_LENGTH,
 	parseVersionComparisonRoute,
+	rejectedVersionComparisonRoute,
 	resolveVersionComparisonRoute,
 	withoutVersionComparisonRoute,
 	withVersionComparisonRoute,
@@ -20,6 +22,16 @@ const route = {
 }
 
 describe('canonical version comparison routes', () => {
+	it('warns once per rejected history entry and again after re-entry', () => {
+		const query = { ...route.query, compareFrom: 'version:1', compareTo: 'current:2' }
+		const rejected = rejectedVersionComparisonRoute({ ...route, query }, {})
+
+		expect(claimVersionComparisonRouteWarning(query, {})).toBe(true)
+		expect(claimVersionComparisonRouteWarning(query, rejected.state)).toBe(false)
+		expect(claimVersionComparisonRouteWarning(query, {})).toBe(true)
+		expect(rejected.query).toEqual(route.query)
+	})
+
 	it('R01 round-trips an exact ordered current/historical or historical/historical pair', () => {
 		for (const [from, to] of [
 			['version:1', 'current:2'],
@@ -79,16 +91,6 @@ describe('canonical version comparison routes', () => {
 			.toEqual(['missing-1', 'missing-2'])
 	})
 
-	it('R09 resolves an unavailable ambiguous identity to a fail-closed missing result', () => {
-		const current = { routeId: 'current:2', routeAliases: ['current'] }
-		const resolved = resolveVersionComparisonRoute(
-			[current, { routeId: 'version:1' }],
-			{ from: 'current:2', to: 'current' },
-			['current:2'],
-		)
-		expect(resolved).toEqual({ first: null, second: current, missing: ['current:2'] })
-	})
-
 	it.each([
 		['canonical ID then alias', 'current:2', 'current'],
 		['alias then canonical ID', 'current', 'current:2'],
@@ -103,7 +105,7 @@ describe('canonical version comparison routes', () => {
 			first: current,
 			second: current,
 			missing: [],
-			invalid: 'self-pair',
+			invalid: true,
 		})
 	})
 
@@ -118,7 +120,7 @@ describe('canonical version comparison routes', () => {
 			first: canonical,
 			second: alias,
 			missing: [],
-			invalid: 'self-pair',
+			invalid: true,
 		})
 	})
 })

--- a/src/util/versionComparisonRoute.js
+++ b/src/util/versionComparisonRoute.js
@@ -6,30 +6,35 @@
 export const COMPARE_FROM_QUERY = 'compareFrom'
 export const COMPARE_TO_QUERY = 'compareTo'
 export const COMPARISON_HISTORY_STATE = 'collectivesVersionComparison'
+export const COMPARISON_WARNING_STATE = 'collectivesVersionComparisonWarning'
 export const MAX_COMPARISON_ID_LENGTH = 255
 
-/**
- * Replace only a route path during slug canonicalization.
- *
- * @param {object} route Current route
- * @param {string} path Canonical path
- * @return {object} Vue Router location
- */
-export function canonicalPathRoute(route, path) {
+/* eslint-disable jsdoc/require-jsdoc */
+
+const warningKey = (query) => JSON.stringify([query[COMPARE_FROM_QUERY], query[COMPARE_TO_QUERY]])
+const routeLocation = (route, query = route.query) => ({ path: route.path, query, hash: route.hash })
+function invalidComparisonIdCharacter(character) {
+	const codePoint = character.codePointAt(0)
+	return character === '/' || character === '\\' || codePoint <= 31 || codePoint === 127
+}
+
+export function claimVersionComparisonRouteWarning(query, state = window.history.state) {
+	return state?.[COMPARISON_WARNING_STATE] !== warningKey(query)
+}
+
+export function rejectedVersionComparisonRoute(route) {
 	return {
-		path,
-		query: route.query,
-		hash: route.hash,
+		...withoutVersionComparisonRoute(route),
+		state: {
+			[COMPARISON_WARNING_STATE]: warningKey(route.query),
+		},
 	}
 }
 
-/**
- * Parse the two comparison-only parameters without accepting Vue Router's
- * array representation for duplicate values.
- *
- * @param {object} query Decoded Vue Router query
- * @return {{kind: 'absent'}|{kind: 'invalid'}|{kind: 'valid', from: string, to: string}}
- */
+export function canonicalPathRoute(route, path) {
+	return routeLocation({ ...route, path })
+}
+
 export function parseVersionComparisonRoute(query) {
 	const hasFrom = Object.hasOwn(query, COMPARE_FROM_QUERY)
 	const hasTo = Object.hasOwn(query, COMPARE_TO_QUERY)
@@ -51,92 +56,32 @@ export function parseVersionComparisonRoute(query) {
 	return { kind: 'valid', from, to }
 }
 
-/**
- * Build a route location containing one comparison pair.
- *
- * @param {object} route Current route
- * @param {string} from Earlier/current opaque identity
- * @param {string} to Later/current opaque identity
- * @return {object} Vue Router location
- */
 export function withVersionComparisonRoute(route, from, to) {
-	return {
-		path: route.path,
-		query: {
-			...route.query,
-			[COMPARE_FROM_QUERY]: from,
-			[COMPARE_TO_QUERY]: to,
-		},
-		hash: route.hash,
-	}
+	return routeLocation(route, {
+		...route.query,
+		[COMPARE_FROM_QUERY]: from,
+		[COMPARE_TO_QUERY]: to,
+	})
 }
 
-/**
- * Remove only comparison parameters.
- *
- * @param {object} route Current route
- * @return {object} Vue Router location
- */
 export function withoutVersionComparisonRoute(route) {
 	const query = { ...route.query }
 	delete query[COMPARE_FROM_QUERY]
 	delete query[COMPARE_TO_QUERY]
-	return {
-		path: route.path,
-		query,
-		hash: route.hash,
-	}
+	return routeLocation(route, query)
 }
 
-/**
- * Resolve a URL identity against selector options without substituting.
- *
- * @param {object[]} options Comparison options
- * @param {{from: string, to: string}} requested Requested pair
- * @param {Iterable<string>} unavailableRouteIds Ambiguous identities to reject
- * @return {{first: object|null, second: object|null, missing: string[], invalid?: 'self-pair'}}
- */
-export function resolveVersionComparisonRoute(options, requested, unavailableRouteIds = []) {
-	const unavailable = new Set(unavailableRouteIds)
-	const byRouteId = new Map()
-	for (const option of options) {
-		for (const routeId of [option.routeId, ...(option.routeAliases ?? [])]) {
-			if (!unavailable.has(routeId)) {
-				byRouteId.set(routeId, option)
-			}
-		}
-	}
+export function resolveVersionComparisonRoute(options, requested) {
+	const byRouteId = new Map(options.flatMap((option) => [option.routeId, ...(option.routeAliases ?? [])].map((routeId) => [routeId, option])))
 	const first = byRouteId.get(requested.from) ?? null
 	const second = byRouteId.get(requested.to) ?? null
-	const missing = [
-		...first ? [] : [requested.from],
-		...second ? [] : [requested.to],
-	]
-	return {
-		first,
-		second,
-		missing,
-		...(first && second
-			&& (first === second || (first.key !== undefined && first.key === second.key))
-			? { invalid: 'self-pair' }
-			: {}),
-	}
+	const missing = [requested.from, requested.to].filter((routeId) => !byRouteId.has(routeId))
+	return { first, second, missing, invalid: Boolean(first && second && (first === second || (first.key !== undefined && first.key === second.key))) }
 }
 
-/**
- * Test an already-decoded opaque version identity.
- *
- * @param {unknown} value Candidate identity
- * @return {value is string} Whether it is a bounded route identity
- */
 export function isValidComparisonId(value) {
 	return typeof value === 'string'
 		&& value.length > 0
 		&& value.length <= MAX_COMPARISON_ID_LENGTH
-		&& !value.includes('/')
-		&& !value.includes('\\')
-		&& ![...value].some((character) => {
-			const codePoint = character.codePointAt(0)
-			return codePoint <= 31 || codePoint === 127
-		})
+		&& ![...value].some(invalidComparisonIdCharacter)
 }


### PR DESCRIPTION
Part 6 of the version-comparison work for nextcloud/collectives#599: shareable comparison links that pin two exact revisions.

- compareFrom / compareTo pin two revisions; the pair survives reload, Back, Forward, copy and page rename
- Namespaced identities (current:<id> / version:<id>) with aliases for older links; validation rejects non-strings, path separators, control characters, over-long values, identical and half-pairs
- A missing version stays in the selector with a Retry action, never silently replaced; one history entry per path; rename canonicalizes only the slug
- The e2e workflows now run against the signed Text comparison commit b5ff1b0ce8, pinned as the checkout ref in cypress-e2e.yml and playwright.yml; the semantic suite runs in Chromium

Depends on: #2699 (base review/collectives-version-comparison). Final unit of the six.

Full story, screenshots and the test matrix live in the #599 implementation update: https://github.com/nextcloud/collectives/issues/599#issuecomment-5295582982

AI disclosure: developed with OpenAI Codex (gpt-5.6-sol). Codex generated the implementation and tests under my direction; I reviewed, cleaned and verified the code, ran the full test and CI matrix, and signed the commits personally.
