### PR TITLE
chore(release): prepare 4.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 4.6.0 - 2026.08.24
+
+### ✨New
+* 🚀 Navigation dropdown to select collective (#2682)
+
+### 🌎Translations
+* 🗣️ Translation updates from Transifex. Thanks to all contributors.
+
+### 🚧Updates & Tooling
+* ⬆️ Update NPM dependencies.
+
+
 ## 4.5.0 - 2026.08.13
 
 ### ✨New

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ to structure shared knowledge and cultivate trust.
 * **🔤 Well-known [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax** for page formatting.
 * **🔎 Full-text search** to find content straight away.
 	]]></description>
-	<version>4.5.0</version>
+	<version>4.6.0</version>
 	<licence>agpl</licence>
 	<author>CollectiveCloud Team</author>
 	<namespace>Collectives</namespace>


### PR DESCRIPTION
## 4.6.0 - 2026.08.24

### ✨New
* 🚀 Navigation dropdown to select collective (#2682)

### 🌎Translations
* 🗣️ Translation updates from Transifex. Thanks to all contributors.

### 🚧Updates & Tooling
* ⬆️ Update NPM dependencies.