### PR TITLE
Last user related fixes

### DIFF
--- a/lib/Listeners/NodeWrittenListener.php
+++ b/lib/Listeners/NodeWrittenListener.php
@@ -54,6 +54,7 @@ class NodeWrittenListener implements IEventListener {
 		$userId = $this->userSession->getUser()?->getUID();
 		if ($userId) {
 			$this->pageService->notifyContentChange($node, $collective, $userId);
+			$this->pageService->setLastUser($node->getId(), $userId);
 		}
 	}
 }

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -1051,6 +1051,13 @@ class PageService {
 		return $pageInfo;
 	}
 
+	public function setLastUser(int $fileId, string $userId): void {
+		$page = new Page();
+		$page->setFileId($fileId);
+		$page->setLastUserId($userId);
+		$this->pageMapper->updateOrInsert($page);
+	}
+
 	/**
 	 * @throws MissingDependencyException
 	 * @throws NotFoundException

--- a/lib/Service/PageService.php
+++ b/lib/Service/PageService.php
@@ -744,8 +744,6 @@ class PageService {
 		$folder = $this->getCollectiveFolder($collectiveId, $userId);
 		$file = $this->nodeHelper->getFileById($folder, $id);
 		$pageInfo = $this->getPageByFile($file);
-		$pageInfo->setLastUserId($userId);
-		$pageInfo->setLastUserDisplayName($this->userManager->getDisplayName($userId));
 		$pageInfo->setFullWidth($fullWidth);
 		$this->updatePage($collectiveId, $pageInfo->getId(), $userId, fullWidth: $fullWidth);
 		$this->notifyPush(['collectiveId' => $collectiveId, 'pages' => [$pageInfo]]);
@@ -1041,8 +1039,6 @@ class PageService {
 		$folder = $this->getCollectiveFolder($collectiveId, $userId);
 		$file = $this->nodeHelper->getFileById($folder, $id);
 		$pageInfo = $this->getPageByFile($file);
-		$pageInfo->setLastUserId($userId);
-		$pageInfo->setLastUserDisplayName($this->userManager->getDisplayName($userId));
 		$pageInfo->setEmoji($emoji);
 		$this->updatePage($collectiveId, $pageInfo->getId(), $userId, $emoji);
 		$this->notifyPush(['collectiveId' => $collectiveId, 'pages' => [$pageInfo]]);


### PR DESCRIPTION
### 📝 Summary

* fix: set last user id when the file content changed (Fixes: #480)
* fix(PageService): don't set last user on emoji/page width update (Fixes: #1780)

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
