### PR TITLE
Fix: fix duplicate entry during indexation (alternative approach)

### DIFF
--- a/lib/Db/CollectiveVersionMapper.php
+++ b/lib/Db/CollectiveVersionMapper.php
@@ -16,6 +16,8 @@ use OCP\IDBConnection;
  * @extends QBMapper<CollectiveVersion>
  */
 class CollectiveVersionMapper extends QBMapper {
+	use TInsertIgnoreConflict;
+
 	public function __construct(IDBConnection $db) {
 		parent::__construct($db, 'collectives_p_versions', CollectiveVersion::class);
 	}

--- a/lib/Db/TInsertIgnoreConflict.php
+++ b/lib/Db/TInsertIgnoreConflict.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Db;
+
+use OCP\AppFramework\Db\Entity;
+use OCP\AppFramework\Db\SnowflakeAwareEntity;
+
+/**
+ * Helper trait to insert entities while ignoring conflicts on unique constraints
+ */
+trait TInsertIgnoreConflict {
+	/**
+	 * Creates a new entry in the db from an entity, ignoring conflicts on
+	 * unique constraints
+	 *
+	 * @param Entity $entity the entity that should be created
+	 * @return int number of inserted rows (0 if a conflicting row already exists)
+	 * @throws \OCP\DB\Exception
+	 */
+	public function insertIgnoreConflict(Entity $entity): int {
+		if ($entity instanceof SnowflakeAwareEntity) {
+			/** @psalm-suppress DocblockTypeContradiction */
+			$entity->generateId();
+		}
+
+		$properties = $entity->getUpdatedFields();
+		$values = [];
+		foreach ($properties as $property => $updated) {
+			if ($property === 'id' && $entity->id === null) {
+				continue;
+			}
+
+			$getter = 'get' . ucfirst($property);
+			$values[$entity->propertyToColumn($property)] = $entity->$getter();
+		}
+
+		return $this->db->insertIgnoreConflict($this->tableName, $values);
+	}
+}

--- a/lib/Search/FileSearch/Db/SearchDocMapper.php
+++ b/lib/Search/FileSearch/Db/SearchDocMapper.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Collectives\Search\FileSearch\Db;
 
+use OCA\Collectives\Db\TInsertIgnoreConflict;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -21,17 +22,19 @@ use OCP\IDBConnection;
  * @template-extends QBMapper<SearchDoc>
  */
 class SearchDocMapper extends QBMapper {
+	use TInsertIgnoreConflict;
+
 	public function __construct(IDBConnection $db) {
 		parent::__construct($db, 'collectives_s_docs', SearchDoc::class);
 	}
 
-	public function insertDoc(int $collectiveId, int $wordId, int $fileId, int $hitCount): SearchDoc {
+	public function insertDoc(int $collectiveId, int $wordId, int $fileId, int $hitCount): void {
 		$doc = new SearchDoc();
 		$doc->setCollectiveId($collectiveId);
 		$doc->setWordId($wordId);
 		$doc->setFileId($fileId);
 		$doc->setHitCount($hitCount);
-		return $this->insert($doc);
+		$this->insertIgnoreConflict($doc);
 	}
 
 	public function deleteByCollective(int $collectiveId): void {

--- a/lib/Search/FileSearch/Db/SearchFileMapper.php
+++ b/lib/Search/FileSearch/Db/SearchFileMapper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Collectives\Search\FileSearch\Db;
 
 use Exception;
+use OCA\Collectives\Db\TInsertIgnoreConflict;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -23,18 +24,20 @@ use PDO;
  * @template-extends QBMapper<SearchFile>
  */
 class SearchFileMapper extends QBMapper {
+	use TInsertIgnoreConflict;
+
 	public function __construct(IDBConnection $db) {
 		parent::__construct($db, 'collectives_s_files', SearchFile::class);
 	}
 
-	public function insertFile(int $collectiveId, int $fileId, string $path, int $mtime, ?string $language = null): SearchFile {
+	public function insertFile(int $collectiveId, int $fileId, string $path, int $mtime, ?string $language = null): void {
 		$file = new SearchFile();
 		$file->setCollectiveId($collectiveId);
 		$file->setFileId($fileId);
 		$file->setPath($path);
 		$file->setMtime($mtime);
 		$file->setLanguage($language);
-		return $this->insert($file);
+		$this->insertIgnoreConflict($file);
 	}
 
 	public function findByCollectiveAndFileId(int $collectiveId, int $fileId): ?SearchFile {

--- a/lib/Search/FileSearch/FileIndexer.php
+++ b/lib/Search/FileSearch/FileIndexer.php
@@ -99,10 +99,7 @@ class FileIndexer {
 			}
 		}
 
-		try {
-			$this->fileMapper->insertFile($collectiveId, $file->getId(), $file->getInternalPath(), $file->getMTime(), $language);
-		} catch (Exception) {
-		}
+		$this->fileMapper->insertFile($collectiveId, $file->getId(), $file->getInternalPath(), $file->getMTime(), $language);
 	}
 
 	private function getDirectoryFiles(Folder $folder, bool $recursive = false): array {

--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -24,7 +24,6 @@ use OCA\Files_Versions\Versions\IVersionBackend;
 use OCA\Files_Versions\Versions\IVersionsImporterBackend;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Constants;
-use OCP\DB\Exception as DBException;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
@@ -108,12 +107,7 @@ class VersionsBackend implements IVersionBackend, IMetadataVersionBackend, IDele
 			$versionEntity->setSize($file->getSize());
 			$versionEntity->setMimetype($this->mimeTypeLoader->getId($file->getMimetype()));
 			$versionEntity->setDecodedMetadata([]);
-			try {
-				$this->collectiveVersionMapper->insert($versionEntity);
-			} catch (DBException $e) {
-				if ($e->getReason() !== DBException::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
-					throw $e;
-				}
+			if ($this->collectiveVersionMapper->insertIgnoreConflict($versionEntity) === 0) {
 				// Another concurrent request already populated the DB for this file; return what's there.
 				return $this->getVersionsForFileFromDb($file, $user);
 			}
@@ -142,14 +136,8 @@ class VersionsBackend implements IVersionBackend, IMetadataVersionBackend, IDele
 				// Use the main file mimetype for this initialization as the original mimetype is unknown.
 				$versionEntity->setMimetype($this->mimeTypeLoader->getId($file->getMimetype()));
 				$versionEntity->setDecodedMetadata([]);
-				try {
-					$this->collectiveVersionMapper->insert($versionEntity);
-				} catch (DBException $e) {
-					if ($e->getReason() !== DBException::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
-						throw $e;
-					}
-					// Duplicate on disk versions: skip this entry, it was already recorded.
-				}
+				// Duplicate on disk versions are ignored: the entry was already recorded.
+				$this->collectiveVersionMapper->insertIgnoreConflict($versionEntity);
 			}
 
 			return $this->getVersionsForFileFromDb($file, $user);
@@ -405,14 +393,8 @@ class VersionsBackend implements IVersionBackend, IMetadataVersionBackend, IDele
 		$versionEntity->setSize($file->getSize());
 		$versionEntity->setMimetype($this->mimeTypeLoader->getId($file->getMimetype()));
 		$versionEntity->setDecodedMetadata([]);
-		try {
-			$this->collectiveVersionMapper->insert($versionEntity);
-		} catch (DBException $e) {
-			if ($e->getReason() !== DBException::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
-				throw $e;
-			}
-			// Entity already exists (e.g. created by a concurrent request or the lazy-init path); nothing to do.
-		}
+		// The entity may already exist (e.g. created by a concurrent request or the lazy-init path); conflicts are ignored.
+		$this->collectiveVersionMapper->insertIgnoreConflict($versionEntity);
 	}
 
 	public function updateVersionEntity(File $sourceFile, int $revision, array $properties): void {
@@ -481,14 +463,8 @@ class VersionsBackend implements IVersionBackend, IMetadataVersionBackend, IDele
 				$versionEntity->setDecodedMetadata($version->getMetadata());
 			}
 
-			try {
-				$this->collectiveVersionMapper->insert($versionEntity);
-			} catch (DBException $e) {
-				if ($e->getReason() !== DBException::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
-					throw $e;
-				}
-				// Version was already imported (e.g. on a retry); skip.
-			}
+			// Version may have been already imported (e.g. on a retry); conflicts are ignored.
+			$this->collectiveVersionMapper->insertIgnoreConflict($versionEntity);
 		}
 	}
 


### PR DESCRIPTION
### 📝 Summary

This is alternative approach to fix #1886, #2405. Even after #2451 we observe tons of logs on PostgreSQL side related to duplication. In this PR this logs are gone

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [ ] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
