### PR TITLE
feat(publish): add publish button and modal

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -35,6 +35,7 @@ use OCA\Collectives\Search\CollectiveProvider;
 use OCA\Collectives\Search\PageContentProvider;
 use OCA\Collectives\Search\PageProvider;
 use OCA\Collectives\Service\CollectiveHelper;
+use OCA\Collectives\Service\PublishSettings;
 use OCA\Collectives\SetupChecks\CirclesAppIsEnableCheck;
 use OCA\Collectives\Team\CollectiveTeamResourceProvider;
 use OCA\Collectives\Trash\PageTrashBackend;
@@ -54,6 +55,7 @@ use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\Events\Node\NodeRenamedEvent;
 use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\Files\IMimeTypeLoader;
+use OCP\IAppConfig;
 use OCP\IDBConnection;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -85,6 +87,10 @@ class Application extends App implements IBootstrap {
 		$context->registerNotifierService(Notifier::class);
 
 		$context->registerMiddleware(PublicOCSMiddleware::class);
+
+		$context->registerService(PublishSettings::class, fn (ContainerInterface $c) => new PublishSettings(
+			$c->get(IAppConfig::class)
+		));
 
 		$context->registerService(MountProvider::class, fn (ContainerInterface $c) => new MountProvider(
 			$c->get(CollectiveHelper::class),

--- a/lib/Listeners/BeforeTemplateRenderedListener.php
+++ b/lib/Listeners/BeforeTemplateRenderedListener.php
@@ -13,6 +13,7 @@ use OCA\Collectives\AppInfo\Application;
 use OCA\Collectives\Fs\UserFolderHelper;
 use OCA\Collectives\Service\NotFoundException;
 use OCA\Collectives\Service\NotPermittedException;
+use OCA\Collectives\Service\PublishSettings;
 use OCA\Guests\GuestManager;
 use OCA\Text\Event\LoadEditor;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
@@ -21,6 +22,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Template\ITemplateManager;
+use OCP\IAppConfig;
 use OCP\IUserSession;
 use OCP\Server;
 use OCP\Util;
@@ -33,6 +35,8 @@ class BeforeTemplateRenderedListener implements IEventListener {
 		private readonly IEventDispatcher $eventDispatcher,
 		private readonly IInitialState $initialState,
 		private readonly ITemplateManager $templateManager,
+		private readonly IAppConfig $appConfig,
+		private readonly PublishSettings $publishSettings,
 	) {
 	}
 
@@ -73,5 +77,8 @@ class BeforeTemplateRenderedListener implements IEventListener {
 		$this->initialState->provideInitialState('user_folder', $userFolder);
 		$this->initialState->provideInitialState('templates', $this->templateManager->listCreators());
 		$this->initialState->provideInitialState('is_guest', $isGuest);
+
+		// Provide admin settings as initial state
+		$this->initialState->provideInitialState('publish_enabled', $this->publishSettings->isPublishEnabled());
 	}
 }

--- a/lib/Service/PublishSettings.php
+++ b/lib/Service/PublishSettings.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Service;
+
+use OCP\IAppConfig;
+
+class PublishSettings {
+	private const CONFIG_APP = 'collectives';
+	private const CONFIG_KEY_PUBLISH_ENABLED = 'publish_enabled';
+	private const DEFAULT_PUBLISH_ENABLED = 'false';
+
+	public function __construct(
+		private readonly IAppConfig $appConfig,
+	) {
+	}
+
+	public function isPublishEnabled(): bool {
+		return $this->appConfig->getValueString(
+			self::CONFIG_APP,
+			self::CONFIG_KEY_PUBLISH_ENABLED,
+			self::DEFAULT_PUBLISH_ENABLED
+		) === 'true';
+	}
+}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Collectives\Settings;
 
 use OCA\Collectives\AppInfo\Application;
+use OCA\Collectives\Service\PublishSettings;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IAppConfig;
@@ -20,12 +21,14 @@ class Admin implements ISettings {
 	public function __construct(
 		private readonly IAppConfig $appConfig,
 		private readonly IInitialState $initialState,
+		private readonly PublishSettings $publishSettings,
 	) {
 	}
 
 	public function getForm(): TemplateResponse {
 		$parameters = [
 			'default_user_folder' => $this->appConfig->getValueString('collectives', 'default_user_folder', ''),
+			'publish_enabled' => $this->publishSettings->isPublishEnabled(),
 		];
 		$this->initialState->provideInitialState('adminSettings', $parameters);
 

--- a/playwright/e2e/collective-publish.spec.ts
+++ b/playwright/e2e/collective-publish.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { User as Account } from '@nextcloud/e2e-test-server'
+import type { Page } from '@playwright/test'
+
+import { runOcc } from '@nextcloud/e2e-test-server/docker'
+import { login } from '@nextcloud/e2e-test-server/playwright'
+import { expect, mergeTests } from '@playwright/test'
+import { test as createCollectivesTest } from '../support/fixtures/create-collectives.ts'
+import { test as navigationTest } from '../support/fixtures/navigation.ts'
+
+const baseTest = mergeTests(createCollectivesTest, navigationTest)
+
+// Extend fixture to add a member user for permission tests
+const test = baseTest.extend<{ memberAccount: Account }>({
+	memberAccount: async ({ collective }, use) => {
+		const member = await collective.addMember()
+		await use(member)
+	},
+})
+
+/**
+ * The `publish_enabled` app config change made via `runOcc` is not always visible on the
+ * very first page load right after the change - there can be a short propagation delay
+ * before the server-rendered initial state reflects it. Reload until it does.
+ */
+async function waitForPublishEnabledState(page: Page, expected: boolean): Promise<void> {
+	await expect.poll(async () => {
+		await page.reload()
+		const raw = await page.locator('#initial-state-collectives-publish_enabled').getAttribute('value')
+		return raw && JSON.parse(Buffer.from(raw, 'base64').toString('utf-8'))
+	}, { timeout: 15_000 }).toBe(expected)
+}
+
+test.describe('Collective publish', () => {
+	test('admin can open publish modal', async ({ collective, navigation, page }) => {
+		await runOcc(['config:app:set', 'collectives', 'publish_enabled', '--value', 'true'])
+		await collective.openCollective()
+		await waitForPublishEnabledState(page, true)
+		await page.getByRole('button', { name: 'Collective actions' }).click()
+
+		// Publish button is visible for admin
+		const publishButton = page.locator('.action-item__popper:visible')
+			.getByRole('button', { name: 'Publish', exact: true })
+		await expect(publishButton).toBeVisible()
+
+		// Publish modal opens on publish button click
+		await publishButton.click()
+		const modal = page.getByRole('dialog')
+		await expect(modal
+			.filter({ has: page.getByRole('heading', { name: `Publish website for Collective ${collective.data.name}` }) }))
+			.toBeVisible()
+
+		// Modal can be closed
+		await modal.getByRole('button', { name: 'Close' }).click()
+		await expect(modal).toHaveCount(0)
+
+		// Modal can be opened again
+		await navigation.clickCollectiveMenu(collective.data.name, 'Publish')
+		const reopenedModal = page.getByRole('dialog')
+		await expect(reopenedModal).toBeVisible()
+		await expect(reopenedModal).toContainText(collective.data.name)
+	})
+
+	test('regular members cannot see publish button', async ({ collective, memberAccount, browser }) => {
+		await runOcc(['config:app:set', 'collectives', 'publish_enabled', '--value', 'true'])
+
+		// Use isolated browser session for member user to avoid permission issues with admin session
+		const memberContext = await browser.newContext()
+		const memberPage = await memberContext.newPage()
+
+		// Login as member in the new context
+		await login(memberPage.request, memberAccount)
+		await memberPage.goto(`/index.php/apps/collectives/${collective.getCollectiveUrlPart()}`)
+		await waitForPublishEnabledState(memberPage, true)
+
+		// Open the current collective's actions menu
+		await memberPage.getByRole('button', { name: 'Collective actions' }).click()
+
+		// Publish button should NOT be visible for regular member
+		const publishButton = memberPage.locator('.action-item__popper:visible')
+			.getByRole('button', { name: 'Publish', exact: true })
+		await expect(publishButton).toHaveCount(0)
+
+		// Cleanup member context
+		await memberContext.close()
+	})
+
+	test('publish feature toggle can be switched via app config', async ({ collective, page }) => {
+		await runOcc(['config:app:set', 'collectives', 'publish_enabled', '--value', 'true'])
+		await collective.openCollective()
+		await waitForPublishEnabledState(page, true)
+		await page.getByRole('button', { name: 'Collective actions' }).click()
+		await expect(page.locator('.action-item__popper:visible')
+			.getByRole('button', { name: 'Publish', exact: true })).toBeVisible()
+
+		await runOcc(['config:app:set', 'collectives', 'publish_enabled', '--value', 'false'])
+		await waitForPublishEnabledState(page, false)
+		await page.getByRole('button', { name: 'Collective actions' }).click()
+		await expect(page.locator('.action-item__popper:visible')
+			.getByRole('button', { name: 'Publish', exact: true })).toHaveCount(0)
+	})
+})

--- a/src/CollectivesApp.vue
+++ b/src/CollectivesApp.vue
@@ -39,6 +39,7 @@
 
 <script>
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
+import { loadState } from '@nextcloud/initial-state'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { mapActions, mapState } from 'pinia'
 import NcAppNavigation from '@nextcloud/vue/components/NcAppNavigation'
@@ -127,6 +128,7 @@ export default {
 	},
 
 	mounted() {
+		this.loadAdminSettings()
 		this.getCollectivesAndSettings()
 		subscribe('open-new-collective-modal', this.onOpenNewCollectiveModal)
 	},
@@ -142,6 +144,18 @@ export default {
 		...mapActions(useCollectivesStore, [
 			'getCollectives',
 		]),
+
+		...mapActions(useRootStore, ['setPublishFeatureEnabled']),
+
+		loadAdminSettings() {
+			try {
+				const publishEnabledState = loadState('collectives', 'publish_enabled', true)
+				const isPublishEnabled = publishEnabledState === true || publishEnabledState === 'true'
+				this.setPublishFeatureEnabled(isPublishEnabled)
+			} catch (e) {
+				console.error('Failed to load admin settings:', e)
+			}
+		},
 
 		onOpenNewCollectiveModal() {
 			this.showNewCollectiveModal = true

--- a/src/apis/collectives/settings.js
+++ b/src/apis/collectives/settings.js
@@ -14,6 +14,7 @@ import { apiUrl } from './urls.js'
 function settingsApiUrl(...parts) {
 	return apiUrl('v1.0', 'settings', parts)
 }
+
 /**
  * Get collectives folder setting for the current user
  */

--- a/src/components/Collective/NcActionCollectiveActions.vue
+++ b/src/components/Collective/NcActionCollectiveActions.vue
@@ -24,6 +24,16 @@
 				<ShareVariantIcon :size="20" />
 			</template>
 		</NcActionButton>
+		<NcActionButton
+			v-if="isCollectiveAdmin(collective) && isPublishFeatureEnabled"
+			closeAfterClick
+			@click="openPublishDialog()">
+			<!-- TRANSLATORS 'Publish' means to publish a selection of your collective pages to a public website -->
+			{{ t('collectives', 'Publish') }}
+			<template #icon>
+				<WebIcon :size="20" />
+			</template>
+		</NcActionButton>
 		<NcActionSeparator v-if="isCollectiveAdmin(collective) || collectiveCanShare(collective)" />
 		<NcActionButton
 			v-if="!isPublic && collective.canEdit"
@@ -128,6 +138,7 @@ import LogoutIcon from 'vue-material-design-icons/Logout.vue'
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import ShareVariantIcon from 'vue-material-design-icons/ShareVariantOutline.vue'
 import DownloadIcon from 'vue-material-design-icons/TrayArrowDown.vue'
+import WebIcon from 'vue-material-design-icons/Web.vue'
 import PageTemplateIcon from '../Icon/PageTemplateIcon.vue'
 import { notifyLevels } from '../../constants.js'
 import { useCirclesStore } from '../../stores/circles.js'
@@ -153,6 +164,7 @@ export default {
 		OpenInNewIcon,
 		PageTemplateIcon,
 		ShareVariantIcon,
+		WebIcon,
 	},
 
 	props: {
@@ -181,7 +193,7 @@ export default {
 	},
 
 	computed: {
-		...mapState(useRootStore, ['isPublic']),
+		...mapState(useRootStore, ['isPublic', 'isPublishFeatureEnabled']),
 		...mapState(useCollectivesStore, [
 			'collectiveCanShare',
 			'collectivePrintPath',
@@ -232,6 +244,7 @@ export default {
 		...mapActions(useCollectivesStore, [
 			'markCollectiveDeleted',
 			'setMembersCollectiveId',
+			'setPublishCollectiveId',
 			'setSettingsCollectiveId',
 			'setCollectiveUserSettingNotify',
 			'setTemplatesCollectiveId',
@@ -262,6 +275,10 @@ export default {
 				notify: level,
 			})
 			this.$emit('update:submenu', null)
+		},
+
+		openPublishDialog() {
+			this.setPublishCollectiveId(this.collective.id)
 		},
 
 		leaveCollectiveWithUndo(collective) {

--- a/src/components/Nav/CollectivePublishModal.vue
+++ b/src/components/Nav/CollectivePublishModal.vue
@@ -1,0 +1,76 @@
+<!--
+  - SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcModal
+		size="normal"
+		class="collective-publish-modal"
+		@close="onClose">
+		<div class="modal-publish">
+			<h2 class="modal-publish__name">
+				{{ t('collectives', 'Publish website for collective {name}', { name: collective.name }) }}
+			</h2>
+		</div>
+	</NcModal>
+</template>
+
+<script>
+import { t } from '@nextcloud/l10n'
+import NcModal from '@nextcloud/vue/components/NcModal'
+
+export default {
+	name: 'CollectivePublishModal',
+
+	components: {
+		NcModal,
+	},
+
+	props: {
+		collective: {
+			required: true,
+			type: Object,
+		},
+	},
+
+	emits: [
+		'close',
+	],
+
+	methods: {
+		t,
+
+		onClose() {
+			this.$emit('close')
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.collective-publish-modal {
+	:deep(.modal-wrapper .modal-container) {
+		display: flex !important;
+		padding-block: 4px 0;
+		padding-inline: 12px;
+	}
+
+	:deep(.modal-wrapper .modal-container__content) {
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+}
+
+.modal-publish {
+	height: 550px;
+	max-height: 80vh;
+
+	&__name {
+		font-size: 21px;
+		text-align: center;
+	}
+}
+
+</style>

--- a/src/components/Nav/CollectiveSelector.vue
+++ b/src/components/Nav/CollectiveSelector.vue
@@ -94,6 +94,10 @@
 			v-if="showCollectiveMembersModal"
 			:collective="membersCollective"
 			@close="onCloseCollectiveMembersModal" />
+		<CollectivePublishModal
+			v-if="showCollectivePublishModal"
+			:collective="publishCollective"
+			@close="onCloseCollectivePublishModal" />
 		<TemplatesDialog v-if="templatesCollectiveId" />
 	</div>
 </template>
@@ -116,6 +120,7 @@ import CollectivesIcon from '../Icon/CollectivesIcon.vue'
 import SkeletonLoading from '../SkeletonLoading.vue'
 import CollectiveListItem from './CollectiveListItem.vue'
 import CollectiveMembersModal from './CollectiveMembersModal.vue'
+import CollectivePublishModal from './CollectivePublishModal.vue'
 import CollectivesGlobalSettings from './CollectivesGlobalSettings.vue'
 import CollectivesTrash from './CollectivesTrash.vue'
 import TemplatesDialog from './TemplatesDialog.vue'
@@ -131,6 +136,7 @@ export default {
 		ChevronDownIcon,
 		CollectiveListItem,
 		CollectiveMembersModal,
+		CollectivePublishModal,
 		CollectivesGlobalSettings,
 		CollectivesIcon,
 		CollectivesTrash,
@@ -174,12 +180,17 @@ export default {
 			'collectivePath',
 			'currentCollective',
 			'membersCollective',
+			'publishCollective',
 			'sortedCollectives',
 			'templatesCollectiveId',
 		]),
 
 		showCollectiveMembersModal() {
 			return !!this.membersCollective
+		},
+
+		showCollectivePublishModal() {
+			return !!this.publishCollective
 		},
 	},
 
@@ -190,6 +201,7 @@ export default {
 			'deleteCollective',
 			'restoreCollective',
 			'setMembersCollectiveId',
+			'setPublishCollectiveId',
 		]),
 
 		onTriggerClick() {
@@ -217,6 +229,10 @@ export default {
 
 		onCloseCollectiveMembersModal() {
 			this.setMembersCollectiveId(null)
+		},
+
+		onCloseCollectivePublishModal() {
+			this.setPublishCollectiveId(null)
 		},
 	},
 }

--- a/src/stores/collectives.js
+++ b/src/stores/collectives.js
@@ -27,6 +27,7 @@ export const useCollectivesStore = defineStore('collectives', {
 		templatesCollectiveId: undefined,
 		membersCollectiveId: undefined,
 		settingsCollectiveId: undefined,
+		publishCollectiveId: undefined,
 	}),
 
 	getters: {
@@ -176,6 +177,12 @@ export const useCollectivesStore = defineStore('collectives', {
 		isFavoritePage: (state) => (id, pageId) => {
 			return state.collectives.find((c) => c.id === id).userFavoritePages.includes(pageId)
 		},
+
+		publishCollective(state) {
+			return state.publishCollectiveId
+				? state.collectives.find((c) => c.id === state.publishCollectiveId)
+				: null
+		},
 	},
 
 	actions: {
@@ -193,6 +200,10 @@ export const useCollectivesStore = defineStore('collectives', {
 
 		setLastVisitedCollectiveId(id) {
 			this.lastVisitedCollectiveId = id
+		},
+
+		setPublishCollectiveId(id) {
+			this.publishCollectiveId = id
 		},
 
 		/**

--- a/src/stores/root.js
+++ b/src/stores/root.js
@@ -24,6 +24,8 @@ export const useRootStore = defineStore('root', {
 		fileIdQuery: '',
 		listenPush: false,
 		isGuest: loadState('collectives', 'is_guest', false),
+		// Safety default - actual value gets loaded from backend by setPublishFeatureEnabled()
+		isPublishFeatureEnabled: false,
 	}),
 
 	getters: {
@@ -61,5 +63,7 @@ export const useRootStore = defineStore('root', {
 
 		setPrintView() { this.printView = true },
 		setActiveSidebarTab(id) { this.activeSidebarTab = id },
+
+		setPublishFeatureEnabled(enabled) { this.isPublishFeatureEnabled = enabled },
 	},
 })

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -17,6 +17,17 @@
 			@keydown.enter="saveDefaultUserFolder"
 			@blur="saveDefaultUserFolder" />
 	</NcSettingsSection>
+	<NcSettingsSection
+		:name="t('collectives', 'Publish feature')"
+		:description="t('collectives', 'Enable or disable the publish feature for collectives')">
+		<NcCheckboxRadioSwitch
+			id="isPublishFeatureEnabled"
+			v-model="isPublishFeatureEnabled"
+			type="switch"
+			@update:modelValue="savePublishFeatureToggle">
+			{{ t('collectives', 'Enable publish feature') }}
+		</NcCheckboxRadioSwitch>
+	</NcSettingsSection>
 </template>
 
 <script setup lang="ts">
@@ -24,12 +35,19 @@ import { showSuccess } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 import { computed, ref } from 'vue'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcSettingsSection from '@nextcloud/vue/components/NcSettingsSection'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 
-const adminSettings = loadState<{ default_user_folder: string }>('collectives', 'adminSettings')
+interface AdminSettingsState {
+	default_user_folder: string
+	publish_enabled: boolean
+}
+
+const adminSettings = loadState<AdminSettingsState>('collectives', 'adminSettings')
 let originalDefaultUserFolder = adminSettings.default_user_folder
 const defaultUserFolder = ref(adminSettings.default_user_folder)
+const isPublishFeatureEnabled = ref(adminSettings.publish_enabled)
 
 const defaultUserFolderError = computed(() => {
 	return defaultUserFolder.value !== ''
@@ -53,6 +71,17 @@ async function saveDefaultUserFolder() {
 		success() {
 			originalDefaultUserFolder = defaultUserFolder.value
 			showSuccess(t('collectives', 'Saved default user folder'))
+		},
+	})
+}
+
+/**
+ * Saves the publish_enabled setting to the server
+ */
+function savePublishFeatureToggle() {
+	globalThis.OCP.AppConfig.setValue('collectives', 'publish_enabled', isPublishFeatureEnabled.value ? 'true' : 'false', {
+		success() {
+			showSuccess(t('collectives', 'Publish feature setting saved'))
 		},
 	})
 }


### PR DESCRIPTION
### 📝 Summary

This is the first step towards the publishing feature, that we implement as part of the funding program Prototype Fund (get more information here: https://github.com/nextcloud-publish). This is not going to be merged after a first review, but works as intermediate working tree for the feature.

* See #666

#### Description

To initiate the publication of a website, each Collective should have a Publish button that opens a modal window where the publishing process can subsequently be configured.

The page selection and configuration process itself is out of scope for this issue.

#### Acceptance Criteria

- [x] A Publish button is available in the three-dot menu of a Collective, below the Share Link option.
- [x] Only the admin/owner of a Collective can use the Publish function.
- [x] The Publish function can be globally enabled or disabled via the Nextcloud Admin Settings.
- [x] If the function is disabled, the Publish button is not visible in the Collective menu.
- [x] The Publish function is disabled by default.
- [x] Clicking the Publish button opens a modal window that already displays the name of the Collective.

#### 🖼️ Screenshots
<img width="963" height="383" alt="Screenshot From 2026-09-01 16-04-21" src="https://github.com/user-attachments/assets/aaa222cd-dadb-4be8-85c4-aba7fc188d91" />
<img width="640" height="361" alt="Screenshot From 2026-09-01 16-05-02" src="https://github.com/user-attachments/assets/23bba539-145a-4c05-8506-42c4b418dd37" />
<img width="1239" height="844" alt="Screenshot From 2026-09-01 16-05-17" src="https://github.com/user-attachments/assets/c7f06aa7-c5e9-4f93-91d5-ef4ed38304c0" />

### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests
- [ ] Documentation ([README](https://github.com/nextcloud/collectives/blob/main/README.md) or [documentation](https://github.com/nextcloud/collectives/blob/main/docs/)) has been updated or is not required

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
