### PR TITLE
fix(EmojiHelper): accept country flags and keycap emojis as valid

### DIFF
--- a/lib/Service/EmojiHelper.php
+++ b/lib/Service/EmojiHelper.php
@@ -14,6 +14,10 @@ namespace OCA\Collectives\Service;
  */
 class EmojiHelper {
 	public const MAX_LENGTH = 8;
+	// Extended_Pictorgraphic covers most emoji, but not:
+	// - flag sequences: two regional indicator symbols (U+12F1E6..U+1F1FF)
+	// - keycap sequences: [0-9#*] + optional U+FE0F + U+20E3
+	private const EMOJI_REGEX = '/\p{Extended_Pictographic}|^[\x{1F1E6}-\x{1F1FF}]{2}$|^[0-9#*]\x{FE0F}?\x{20E3}$/u';
 	private static ?bool $hasExtendedPictographic = null;
 
 	/**
@@ -46,7 +50,7 @@ class EmojiHelper {
 		}
 
 		// Enforce a pictographic character (i.e. an emoji)
-		if (self::supportsExtendedPictographic() && preg_match('/\p{Extended_Pictographic}/u', $emoji) !== 1) {
+		if (self::supportsExtendedPictographic() && preg_match(self::EMOJI_REGEX, $emoji) !== 1) {
 			throw new UnprocessableEntityException('Emoji is not valid');
 		}
 

--- a/tests/Unit/Service/EmojiHelperTest.php
+++ b/tests/Unit/Service/EmojiHelperTest.php
@@ -31,6 +31,18 @@ class EmojiHelperTest extends TestCase {
 		self::assertTrue(true);
 	}
 
+	public function testFlagIsValid(): void {
+		EmojiHelper::assertValid('🇫🇷');
+		EmojiHelper::assertValid('🏴󠁧󠁢󠁳󠁣󠁴󠁿');
+		self::assertTrue(true);
+	}
+
+	public function testKeycapIsValid(): void {
+		EmojiHelper::assertValid('1️⃣');
+		EmojiHelper::assertValid('#⃣');
+		self::assertTrue(true);
+	}
+
 	public function testRejectsMultipleEmojis(): void {
 		$this->expectException(UnprocessableEntityException::class);
 		$this->expectExceptionMessage('single emoji');
@@ -65,5 +77,17 @@ class EmojiHelperTest extends TestCase {
 		$this->expectException(UnprocessableEntityException::class);
 		$this->expectExceptionMessage('invalid characters');
 		EmojiHelper::assertValid("👍\x07");
+	}
+
+	public function testRejectsSingleRegionalIndicator(): void {
+		$this->expectException(UnprocessableEntityException::class);
+		$this->expectExceptionMessage('not valid');
+		EmojiHelper::assertValid('🇫');
+	}
+
+	public function testRejectsSingleDigit(): void {
+		$this->expectException(UnprocessableEntityException::class);
+		$this->expectExceptionMessage('not valid');
+		EmojiHelper::assertValid('5');
 	}
 }


### PR DESCRIPTION
Fixes: #2752

Assisted-by: OpenCode:claude-fable-5

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
