### PR TITLE
fix(collectives): add cleanup background job and occ command

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -55,6 +55,7 @@ to structure shared knowledge and cultivate trust.
 		<job>OCA\Collectives\BackgroundJob\ExpirePageVersions</job>
 		<job>OCA\Collectives\BackgroundJob\IndexCollectives</job>
 		<job>OCA\Collectives\BackgroundJob\PurgeObsoletePages</job>
+		<job>OCA\Collectives\BackgroundJob\PurgeOrphanedCollectives</job>
 	</background-jobs>
 
 	<repair-steps>
@@ -76,6 +77,7 @@ to structure shared knowledge and cultivate trust.
 		<command>OCA\Collectives\Command\IndexCollectives</command>
 		<command>OCA\Collectives\Command\PageTrashCleanup</command>
 		<command>OCA\Collectives\Command\PurgeObsoletePages</command>
+		<command>OCA\Collectives\Command\PurgeOrphanedCollectives</command>
 	</commands>
 
 	<settings>

--- a/lib/BackgroundJob/PurgeOrphanedCollectives.php
+++ b/lib/BackgroundJob/PurgeOrphanedCollectives.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\BackgroundJob;
+
+use OCA\Collectives\Service\CollectiveGarbageCollector;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\TimedJob;
+
+class PurgeOrphanedCollectives extends TimedJob {
+	public function __construct(
+		ITimeFactory $time,
+		private readonly CollectiveGarbageCollector $garbageCollector,
+	) {
+		parent::__construct($time);
+
+		// Run once every two days
+		$this->setInterval(60 * 60 * 24 * 2);
+		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+	}
+
+	/**
+	 * @param $argument
+	 */
+	protected function run($argument): void {
+		$this->garbageCollector->purgeOrphanedCollectives();
+	}
+}

--- a/lib/Command/PurgeOrphanedCollectives.php
+++ b/lib/Command/PurgeOrphanedCollectives.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Command;
+
+use OCA\Collectives\Service\CollectiveGarbageCollector;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PurgeOrphanedCollectives extends Command {
+	public function __construct(
+		private readonly CollectiveGarbageCollector $garbageCollector,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('collectives:purge-orphaned')
+			->setDescription('Purge collectives whose team no longer exists');
+		parent::configure();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$output->write('Purging orphaned collectives …');
+		$count = $this->garbageCollector->purgeOrphanedCollectives();
+		$output->writeln('done.');
+		$output->writeln(sprintf('Purged %d orphaned collectives.', $count));
+		return 0;
+	}
+}

--- a/lib/Listeners/CircleDestroyedListener.php
+++ b/lib/Listeners/CircleDestroyedListener.php
@@ -11,25 +11,20 @@ namespace OCA\Collectives\Listeners;
 
 use OCA\Circles\Events\CircleDestroyedEvent;
 use OCA\Collectives\Db\CollectiveMapper;
-use OCA\Collectives\Mount\CollectiveFolderManager;
+use OCA\Collectives\Service\CollectiveService;
 use OCA\Collectives\Service\NotFoundException;
+use OCA\Collectives\Service\NotPermittedException;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\Files\InvalidPathException;
-use OCP\Files\NotFoundException as FilesNotFoundException;
-use OCP\Files\NotPermittedException as FilesNotPermittedException;
 
 /** @template-implements IEventListener<Event|CircleDestroyedEvent> */
 class CircleDestroyedListener implements IEventListener {
 	public function __construct(
 		private readonly CollectiveMapper $collectiveMapper,
-		private readonly CollectiveFolderManager $collectiveFolderManager,
+		private readonly CollectiveService $collectiveService,
 	) {
 	}
 
-	/**
-	 * @throws FilesNotPermittedException
-	 */
 	public function handle(Event $event): void {
 		if (!($event instanceof CircleDestroyedEvent)) {
 			return;
@@ -37,7 +32,7 @@ class CircleDestroyedListener implements IEventListener {
 
 		$collective = null;
 		try {
-			$collective = $this->collectiveMapper->findByCircleId($event->getCircle()->getSingleId());
+			$collective = $this->collectiveMapper->findByCircleId($event->getCircle()->getSingleId(), true);
 		} catch (NotFoundException) {
 		}
 
@@ -45,13 +40,10 @@ class CircleDestroyedListener implements IEventListener {
 			return;
 		}
 
-		// Try to find and delete collective folder
 		try {
-			$collectiveFolder = $this->collectiveFolderManager->getFolder($collective->getId());
-			$collectiveFolder->delete();
-		} catch (InvalidPathException|FilesNotFoundException) {
+			$this->collectiveService->purgeCollective($collective);
+		} catch (NotFoundException|NotPermittedException) {
+			// Leftovers get picked up by the PurgeOrphanedCollectives background job
 		}
-
-		$this->collectiveMapper->delete($collective);
 	}
 }

--- a/lib/Service/CollectiveGarbageCollector.php
+++ b/lib/Service/CollectiveGarbageCollector.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Collectives\Service;
+
+use OCA\Collectives\Db\Collective;
+use OCA\Collectives\Db\CollectiveMapper;
+use Psr\Log\LoggerInterface;
+
+class CollectiveGarbageCollector {
+	public function __construct(
+		private readonly CollectiveMapper $collectiveMapper,
+		private readonly CircleHelper $circleHelper,
+		private readonly CollectiveService $collectiveService,
+		private readonly LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Delete collectives (including trashed ones) whose team no longer exists
+	 */
+	public function purgeOrphanedCollectives(): int {
+		$purgeCount = 0;
+		foreach ($this->collectiveMapper->getAll() as $collective) {
+			try {
+				if (!$this->isOrphaned($collective)) {
+					continue;
+				}
+			} catch (MissingDependencyException $e) {
+				$this->logger->debug('Skipping purge of orphaned collectives, teams app not available: ' . $e->getMessage());
+				return $purgeCount;
+			}
+
+			try {
+				$this->collectiveService->purgeCollective($collective);
+			} catch (NotFoundException|NotPermittedException $e) {
+				$this->logger->warning('Failed to purge orphaned collective ' . $collective->getId() . ': ' . $e->getMessage(), ['exception' => $e]);
+				continue;
+			}
+
+			$this->logger->info('Purged orphaned collective ' . $collective->getId() . ', team ' . $collective->getCircleId() . ' does not exist anymore.');
+			$purgeCount++;
+		}
+
+		return $purgeCount;
+	}
+
+	/**
+	 * Only a definite "team not found" counts as orphaned. Any other error
+	 * (e.g. database or request errors) must never lead to deletion.
+	 *
+	 * @throws MissingDependencyException
+	 */
+	private function isOrphaned(Collective $collective): bool {
+		try {
+			$this->circleHelper->getCircle($collective->getCircleId(), null, true);
+		} catch (NotFoundException) {
+			return true;
+		} catch (NotPermittedException $e) {
+			$this->logger->warning('Failed to check team of collective ' . $collective->getId() . ': ' . $e->getMessage(), ['exception' => $e]);
+		}
+
+		return false;
+	}
+}

--- a/lib/Service/CollectiveService.php
+++ b/lib/Service/CollectiveService.php
@@ -344,11 +344,20 @@ class CollectiveService extends CollectiveServiceBase {
 			$this->circleHelper->unflagCircleAsAppManaged($collective->getCircleId());
 		}
 
+		return $this->purgeCollective($collective);
+	}
+
+	/**
+	 * @throws NotFoundException
+	 */
+	public function purgeCollective(Collective $collective): Collective {
 		// Delete collective folder and its contents
 		try {
 			$collectiveFolder = $this->collectiveFolderManager->getFolder($collective->getId());
 			$collectiveFolder->delete();
-		} catch (InvalidPathException|FilesNotFoundException|FilesNotPermittedException $e) {
+		} catch (FilesNotFoundException) {
+			// Collective folder is already gone, continue with cleanup
+		} catch (InvalidPathException|FilesNotPermittedException $e) {
 			throw new NotFoundException('Failed to delete collective folder', 0, $e);
 		} finally {
 			// Delete leftovers in any case (also if collective folder is already gone)

--- a/tests/Unit/Service/CollectiveGarbageCollectorTest.php
+++ b/tests/Unit/Service/CollectiveGarbageCollectorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Unit\Service;
+
+use OCA\Circles\Model\Circle;
+use OCA\Collectives\Db\Collective;
+use OCA\Collectives\Db\CollectiveMapper;
+use OCA\Collectives\Service\CircleHelper;
+use OCA\Collectives\Service\CollectiveGarbageCollector;
+use OCA\Collectives\Service\CollectiveService;
+use OCA\Collectives\Service\MissingDependencyException;
+use OCA\Collectives\Service\NotFoundException;
+use OCA\Collectives\Service\NotPermittedException;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class CollectiveGarbageCollectorTest extends TestCase {
+	private CircleHelper $circleHelper;
+	private CollectiveService $collectiveService;
+	private CollectiveGarbageCollector $garbageCollector;
+	private Collective $existing;
+	private Collective $orphaned;
+	private Collective $failing;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->existing = new Collective();
+		$this->existing->setId(1);
+		$this->existing->setCircleId('existing');
+		$this->orphaned = new Collective();
+		$this->orphaned->setId(2);
+		$this->orphaned->setCircleId('orphaned');
+		$this->failing = new Collective();
+		$this->failing->setId(3);
+		$this->failing->setCircleId('failing');
+
+		$collectiveMapper = $this->createMock(CollectiveMapper::class);
+		$collectiveMapper->method('getAll')
+			->willReturn([$this->existing, $this->orphaned, $this->failing]);
+
+		$this->circleHelper = $this->createMock(CircleHelper::class);
+		$this->collectiveService = $this->createMock(CollectiveService::class);
+
+		$this->garbageCollector = new CollectiveGarbageCollector(
+			$collectiveMapper,
+			$this->circleHelper,
+			$this->collectiveService,
+			$this->createMock(LoggerInterface::class),
+		);
+	}
+
+	public function testPurgeOrphanedCollectives(): void {
+		$this->circleHelper->method('getCircle')
+			->willReturnCallback(fn (string $circleId): Circle => match ($circleId) {
+				'existing' => $this->createMock(Circle::class),
+				'orphaned' => throw new NotFoundException('Circle not found'),
+				'failing' => throw new NotPermittedException('Database error'),
+			});
+
+		$this->collectiveService->expects($this->once())
+			->method('purgeCollective')
+			->with($this->orphaned)
+			->willReturn($this->orphaned);
+
+		self::assertEquals(1, $this->garbageCollector->purgeOrphanedCollectives());
+	}
+
+	public function testPurgeOrphanedCollectivesWithoutCirclesApp(): void {
+		$this->circleHelper->method('getCircle')
+			->willThrowException(new MissingDependencyException('Teams app disabled'));
+
+		$this->collectiveService->expects($this->never())
+			->method('purgeCollective');
+
+		self::assertEquals(0, $this->garbageCollector->purgeOrphanedCollectives());
+	}
+}


### PR DESCRIPTION
Allows to purge orphaned collectives.

Fixes: #2300

Assisted-by: OpenCode:claude-fable-5

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
