### PR TITLE
fix(pageMode): don't sync page mode across browser tabs

### DIFF
--- a/src/stores/pages.js
+++ b/src/stores/pages.js
@@ -24,7 +24,7 @@ export const usePagesStore = defineStore('pages', {
 		allPages: useLocalStorage(ALL_PAGES_STORE_NAME, {}),
 		allTrashPages: useLocalStorage(STORE_PREFIX + 'allTrashPages', {}),
 		allAttachments: useLocalStorage(STORE_PREFIX + 'allAttachments', {}),
-		textMode: useLocalStorage(STORE_PREFIX + 'textMode', {}),
+		textMode: {},
 		trashPagesLoaded: false,
 		newPage: undefined,
 		newPageParentId: null,


### PR DESCRIPTION
The page mode is already reset at page load, so we didn't persistent page mode across tab/browser reloads. There's no need to persist the page mode in browser local storage. The only effect was that it was synced across several browser tabs with the same page, which is rather unintuitive and unexpected.

Assisted-by: OpenCode:claude-fable-5

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
