### PR TITLE
fix(CollectiveFolderManager): walk tree by parents instead of `LIKE path`

### DIFF
--- a/lib/Mount/CollectiveFolderManager.php
+++ b/lib/Mount/CollectiveFolderManager.php
@@ -20,6 +20,7 @@ use OCA\Richdocuments\Db\WopiMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Folder;
+use OCP\Files\IMimeTypeLoader;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
@@ -50,6 +51,7 @@ class CollectiveFolderManager {
 		private readonly IUserSession $userSession,
 		private readonly IRequest $request,
 		private readonly IFactory $l10nFactory,
+		private readonly IMimeTypeLoader $mimeTypeLoader,
 	) {
 	}
 
@@ -253,52 +255,61 @@ class CollectiveFolderManager {
 	}
 
 	/**
-	 * Load all filecache entries (files and folders) of a collective folder in a single query.
+	 * Load all filecache entries (files and folders) below a folder of a collective.
+	 * Skips hidden folders (starting with a dot).
+	 *
+	 * Walks the tree level by level via the `parent` column.
 	 *
 	 * @return CollectiveFileInfo[] Indexed by file id, with paths relative to the collective root folder
 	 *
 	 * @throws NotFoundException
 	 * @throws \OCP\DB\Exception
 	 */
-	public function getFileCacheForCollective(int $collectiveId, ?string $subdirectory = null): array {
-		$jailPath = $this->getJailPath($collectiveId);
+	public function getFileCacheForCollective(int $collectiveId, int $folderId): array {
+		$prefixLength = strlen($this->getJailPath($collectiveId) . '/');
 		$storageId = $this->getRootFolderStorageId();
+		$folderMimeTypeId = $this->mimeTypeLoader->getId(ICacheEntry::DIRECTORY_MIMETYPE);
 
 		$qb = $this->connection->getQueryBuilder();
-
-		// Trailing slash matters: it restricts to descendants and
-		// avoids matching siblings (e.g. `16` must not match `160`).
-		$likePath = $jailPath . '/' . ($subdirectory ? $subdirectory . '/' : '');
-		$likePath = $this->connection->escapeLikeParameter($likePath) . '%';
-
 		$qb->select('fileid', 'storage', 'path', 'parent', 'name', 'mimetype', 'mimepart',
 			'size', 'mtime', 'storage_mtime', 'encrypted', 'etag', 'permissions')
 			->from('filecache')
 			->where($qb->expr()->eq('storage', $qb->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
-			->andWhere($qb->expr()->like('path', $qb->createNamedParameter($likePath)));
+			->andWhere($qb->expr()->in('parent', $qb->createParameter('parentIds')));
 
-		$prefixLength = strlen($jailPath . '/');
 		$result = [];
-		$cursor = $qb->executeQuery();
-		while ($row = $cursor->fetch()) {
-			$relativePath = substr($row['path'], $prefixLength);
-			$result[(int)$row['fileid']] = new CollectiveFileInfo(
-				fileId: (int)$row['fileid'],
-				storage: (int)$row['storage'],
-				path: $relativePath,
-				parent: (int)$row['parent'],
-				name: (string)$row['name'],
-				mimetype: (int)$row['mimetype'],
-				mimepart: (int)$row['mimepart'],
-				size: (int)$row['size'],
-				mtime: (int)$row['mtime'],
-				storageMtime: (int)$row['storage_mtime'],
-				encrypted: (int)$row['encrypted'],
-				etag: (string)$row['etag'],
-				permissions: (int)$row['permissions'],
-			);
+		$parentIds = [$folderId];
+		while ($parentIds !== []) {
+			$nextParentIds = [];
+			foreach (array_chunk($parentIds, 1000) as $chunk) {
+				$qb->setParameter('parentIds', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
+				$cursor = $qb->executeQuery();
+				while ($row = $cursor->fetch()) {
+					$fileId = (int)$row['fileid'];
+					$result[$fileId] = new CollectiveFileInfo(
+						fileId: $fileId,
+						storage: (int)$row['storage'],
+						path: substr($row['path'], $prefixLength),
+						parent: (int)$row['parent'],
+						name: (string)$row['name'],
+						mimetype: (int)$row['mimetype'],
+						mimepart: (int)$row['mimepart'],
+						size: (int)$row['size'],
+						mtime: (int)$row['mtime'],
+						storageMtime: (int)$row['storage_mtime'],
+						encrypted: (int)$row['encrypted'],
+						etag: (string)$row['etag'],
+						permissions: (int)$row['permissions'],
+					);
+					// Descend into folders and skip hidden ones (e.g. `.attachments.*`)
+					if ((int)$row['mimetype'] === $folderMimeTypeId && !str_starts_with((string)$row['name'], '.')) {
+						$nextParentIds[] = $fileId;
+					}
+				}
+				$cursor->closeCursor();
+			}
+			$parentIds = $nextParentIds;
 		}
-		$cursor->closeCursor();
 
 		return $result;
 	}

--- a/lib/Service/PageInfoTreeBuilder.php
+++ b/lib/Service/PageInfoTreeBuilder.php
@@ -138,7 +138,7 @@ class PageInfoTreeBuilder {
 	private function fileInfos(): array {
 		if ($this->fileInfos === null) {
 			try {
-				$this->fileInfos = $this->collectiveFolderManager->getFileCacheForCollective($this->collectiveId, $this->folder->getInternalPath());
+				$this->fileInfos = $this->collectiveFolderManager->getFileCacheForCollective($this->collectiveId, $this->folder->getId());
 			} catch (DBException $e) {
 				throw new NotFoundException($e->getMessage(), 0, $e);
 			}


### PR DESCRIPTION
Changes `getFileCacheForCollectives()` to walk the filesystem tree starting from a parent fileId and using `parent` from filecache table instead of fetching all entries with a single `path LIKE 'prefix/%' query.

The reason for this change was a MariaDB bug that resulted in files whose name starts with an emoji to be skipped:
https://jira.mariadb.org/browse/MDEV-20884

Fixes: #2733

Benchmarks revealed that the parent tree walk is also faster on large collectives with many nested pages.

Additionally skips folders that start with a dot (i.e. hidden folders) as they're ignored by the page tree builder later on anyways.

---

Here's the benchmark numbers from Claude:

```
Benchmark: page tree loading, current `path LIKE` query vs. parent walk
=======================================================================

Setup: synthetic oc_filecache copy on MariaDB 10.6 (~250k rows: 60 background
collectives plus three deeply nested benchmark collectives),
DB round trip 0.085 ms, median of 21 interleaved runs (p90 in brackets).

Tree shapes (pages per nesting level 1/2/3/4/5, folders per depth):

  A: deep, 30% pages w/ attachments   10603 pages, 12616 attachment files
     pages   60 / 639 / 2328 / 4335 / 3240    folders 1/6/36/108/108
  B: deep, 100% pages w/ attachments  10374 pages, 41492 attachment files
     pages   60 / 584 / 2455 / 4094 / 3180    folders 1/6/36/108/108
  C: deep and wide, 12 sections, 30%  35058 pages, 41456 attachment files
     pages  120 / 1153 / 5240 / 13323 / 15221 folders 1/12/96/384/768

Results:

     | LIKE (current)        | walk, all folders     | walk, skip '.'-dirs
     | q   rows   ms (p90)   | q   rows   ms (p90)   | q   rows   ms (p90)
  ---+-----------------------+-----------------------+--------------------
  A  | 1  17703*  36  (39)   | 7  26631   60  (67)   | 5  14015   31  (34)
  B  | 1  62497  224 (246)   | 15 62497  148 (154)   | 5  21005   46  (51)
  C  | 1  88138  239 (248)   | 15 88138  201 (206)   | 5  46682   96  (99)

  * incomplete: the range plan on the (storage, path(64)) prefix index
     dropped 8928 rows (every first-level page with an emoji-leading title
     including its whole subtree). Actual row count is 26631.
```


Assisted-by: OpenCode:claude-fable-5

### 🏁 Checklist

- [x] Code is properly formatted (`npm run lint` / `npm run stylelint` / `composer run cs:check`)
- [x] [Sign-off message](https://probot.github.io/apps/dco/) is added to all commits
- [x] Tests (unit, integration and/or end-to-end) passing and the changes are covered with tests

### 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI tools
- [x] The AI-generated content was reviewed, comprehended and tested by a human
