### PR TITLE
[stable34] fix(pages): don't crash and don't lose fresh page state on stale page list responses

### DIFF
--- a/src/stores/pages.js
+++ b/src/stores/pages.js
@@ -17,6 +17,17 @@ import { useRootStore } from './root.js'
 
 const STORE_PREFIX = 'collectives/pinia/pages/'
 
+// Request sequences per page list index. Page list responses of superseded requests
+// must not be applied, otherwise they overwrite newer local state (e.g. a page that
+// was just created or renamed) until the next refetch.
+const getPagesSequences = {}
+
+function invalidatePagesRequests() {
+	for (const index of Object.keys(getPagesSequences)) {
+		getPagesSequences[index] = (getPagesSequences[index] ?? 0) + 1
+	}
+}
+
 export const usePagesStore = defineStore('pages', {
 	state: () => ({
 		// Uses `collectiveId` as index for internal collectives and `share_<shareToken>` for public ones
@@ -98,11 +109,11 @@ export const usePagesStore = defineStore('pages', {
 			}
 
 			return (!rootStore.pageId && !rootStore.pageParam)
-				|| rootStore.pageId === state.rootPage.id
+				|| rootStore.pageId === state.rootPage?.id
 				|| rootStore.pageParam === INDEX_PAGE
 		},
 		isIndexPage(state) {
-			return state.currentPage.fileName === INDEX_PAGE + PAGE_SUFFIX
+			return state.currentPage?.fileName === INDEX_PAGE + PAGE_SUFFIX
 		},
 
 		rootPage(state) {
@@ -117,7 +128,9 @@ export const usePagesStore = defineStore('pages', {
 			// Return root page
 			if ((!rootStore.pageId && !rootStore.pageParam)
 				|| rootStore.pageParam === INDEX_PAGE) {
-				return [state.rootPage.id]
+				return state.rootPage
+					? [state.rootPage.id]
+					: []
 			}
 
 			const pageIds = []
@@ -125,6 +138,10 @@ export const usePagesStore = defineStore('pages', {
 				let pageId = rootStore.pageId
 				do {
 					const page = state.pageById(pageId)
+					if (!page) {
+						// Page is missing, e.g. while the page list is (re)loading
+						return []
+					}
 					pageIds.unshift(page.id)
 					pageId = page.parentId
 				} while (pageId)
@@ -135,6 +152,10 @@ export const usePagesStore = defineStore('pages', {
 			const parts = rootStore.pageParam.split('/').filter(Boolean)
 			let page = state.rootPage
 			for (const i in parts) {
+				if (!page) {
+					// Page is missing, e.g. while the page list is (re)loading
+					return []
+				}
 				page = state.pages.find((p) => (p.parentId === page.id && p.title === parts[i]))
 				if (page) {
 					pageIds.push(page.id)
@@ -156,7 +177,7 @@ export const usePagesStore = defineStore('pages', {
 		},
 
 		currentPageId(state) {
-			return state.currentPage.id
+			return state.currentPage?.id
 		},
 
 		pageById(state) {
@@ -168,8 +189,13 @@ export const usePagesStore = defineStore('pages', {
 		pagePath: (state) => (page) => {
 			const collectivesStore = useCollectivesStore()
 
+			if (!page) {
+				// Page is missing, e.g. while the page list is (re)loading
+				return ''
+			}
+
 			// Landing page
-			if (page.id === state.rootPage.id) {
+			if (page.id === state.rootPage?.id) {
 				return collectivesStore.currentCollectivePath
 			}
 
@@ -198,6 +224,10 @@ export const usePagesStore = defineStore('pages', {
 		},
 
 		pageFilePath: () => (page) => {
+			if (!page) {
+				// Page is missing, e.g. while the page list is (re)loading
+				return ''
+			}
 			return [
 				page.collectivePath,
 				page.filePath,
@@ -211,6 +241,10 @@ export const usePagesStore = defineStore('pages', {
 
 		pageDavPath: (state) => (page) => {
 			const rootStore = useRootStore()
+			if (!page) {
+				// Page is missing, e.g. while the page list is (re)loading
+				return ''
+			}
 			const parts = state.pageFilePath(page).split('/')
 			if (!rootStore.isPublic) {
 				parts.unshift(getCurrentUser().uid)
@@ -436,7 +470,7 @@ export const usePagesStore = defineStore('pages', {
 			const collectivesStore = useCollectivesStore()
 			return state.isLandingPage
 				? collectivesStore.currentCollective.name
-				: state.currentPage.title
+				: state.currentPage?.title
 		},
 	},
 
@@ -547,8 +581,17 @@ export const usePagesStore = defineStore('pages', {
 				collectiveId: collective.id,
 				shareTokenParam: null,
 			}
+			const index = this.indexForCollective(collective)
+			const sequence = (getPagesSequences[index] ?? 0) + 1
+			getPagesSequences[index] = sequence
 			const response = await api.getPages(context)
-			set(this.allPages, this.indexForCollective(collective), response.data.ocs.data.pages)
+			if (sequence !== getPagesSequences[index]) {
+				// Superseded by a newer page list request or invalidated by a local
+				// mutation - drop the response to avoid overwriting newer state.
+				rootStore.done(`pagelist-${collective.id}`)
+				return
+			}
+			set(this.allPages, index, response.data.ocs.data.pages)
 			rootStore.done(`pagelist-${collective.id}`)
 		},
 
@@ -562,8 +605,17 @@ export const usePagesStore = defineStore('pages', {
 			if (setLoading && !this.pagesLoaded) {
 				rootStore.load('pagelist')
 			}
+			const index = this.collectiveIndex
+			const sequence = (getPagesSequences[index] ?? 0) + 1
+			getPagesSequences[index] = sequence
 			const response = await api.getPages(this.context)
-			set(this.allPages, this.collectiveIndex, response.data.ocs.data.pages)
+			if (sequence !== getPagesSequences[index]) {
+				// Superseded by a newer page list request or invalidated by a local
+				// mutation - drop the response to avoid overwriting newer state.
+				rootStore.done('pagelist')
+				return
+			}
+			set(this.allPages, index, response.data.ocs.data.pages)
 			rootStore.done('pagelist')
 		},
 
@@ -579,6 +631,9 @@ export const usePagesStore = defineStore('pages', {
 		},
 
 		_updatePageState(page, collectiveIndex = this.collectiveIndex) {
+			// The local page state is now newer than any page list request in flight:
+			// invalidate them to avoid overwriting this update with a stale response.
+			invalidatePagesRequests()
 			const index = this.allPages[collectiveIndex].findIndex((p) => p.id === page.id)
 			if (index > -1) {
 				this.allPages[collectiveIndex].splice(index, 1, page)
@@ -608,6 +663,8 @@ export const usePagesStore = defineStore('pages', {
 			rootStore.load('newPageContent')
 
 			const response = await api.createPage(this.context, page)
+			// The local page list is now newer than any page list request in flight
+			invalidatePagesRequests()
 			// Add new page to the beginning of pages array
 			const newPage = response.data.ocs.data.page
 			updateOrAddTo(this.allPages[this.collectiveIndex], newPage)
@@ -738,6 +795,8 @@ export const usePagesStore = defineStore('pages', {
 			const hasSubpages = this.visibleSubpages(pageId).length > 0
 
 			await api.movePageToCollective(this.context, pageId, collectiveId, newParentId, index)
+			// The local page list is now newer than any page list request in flight
+			invalidatePagesRequests()
 			removeFrom(this.allPages[this.collectiveIndex], page)
 			rootStore.done('pagelist-nodrag')
 
@@ -900,6 +959,8 @@ export const usePagesStore = defineStore('pages', {
 		 */
 		async trashPage({ pageId }) {
 			const response = await api.trashPage(this.context, pageId)
+			// The local page list is now newer than any page list request in flight
+			invalidatePagesRequests()
 			const trashPage = response.data.ocs.data.page
 			removeFrom(this.allPages[this.collectiveIndex], trashPage)
 			updateOrAddTo(this.allTrashPages[this.collectiveIndex], trashPage)
@@ -913,6 +974,8 @@ export const usePagesStore = defineStore('pages', {
 		 */
 		async restorePage({ pageId }) {
 			const response = await api.restorePage(this.context, pageId)
+			// The local page list is now newer than any page list request in flight
+			invalidatePagesRequests()
 			const trashPage = response.data.ocs.data.page
 			updateOrAddTo(this.allPages[this.collectiveIndex], trashPage)
 			removeFrom(this.allTrashPages[this.collectiveIndex], trashPage)


### PR DESCRIPTION
Backport of #2767 (fix for #2167) to the `stable34` line, so Nextcloud 30–32 users get the fix.

Same two-part fix in `src/stores/pages.js`:

1. **Per-index page-list request sequencing** — responses of superseded `GET /pages` requests are dropped instead of overwriting newer local state (the "page disappears right after creation" race: concurrent fetches from CollectiveView mount/background poller and TextEditor mount clobber `allPages[index]` wholesale). Local mutations invalidate in-flight requests; dropped responses still release the loading flag.

2. **Fail-soft current-page getter chain** — `currentPageIds`, `currentPageId`, `pagePath`, `pageFilePath`, `pageDavPath`, `isIndexPage` and `title` tolerate a transiently missing page (`return []`/`''`/`undefined`) instead of throwing `TypeError: ... currentPage is undefined` and rendering the "Page with ID xxxx not found" empty view. This also adds guards the stable34 line lacked entirely (`state.rootPage.id` / `state.currentPage.id` derefs).

**Verification:** standalone logic harness importing the real patched store (Pinia-emulated): 7/7 — #2167 crash family no longer throws; happy-path page chain/path/DAV outputs unchanged; createPage/renamePage/trashPage survive stale in-flight `GET /pages`.

**Live-verified** on a production instance (Nextcloud 30.0.17, Collectives 3.4.1): built with the project's vite pipeline, installed, and hammered with rapid create/rename/trash page sequences that previously flipped the UI to "Page with ID xxxx not found" within seconds — now stable with a clean browser console.

Fixes #2167 (for the 3.4.x line; main fix in #2767).

Signed-off-by: patches-bniemczyk <patches-bniemczyk@users.noreply.github.com>